### PR TITLE
Updated license docblocks

### DIFF
--- a/api.php
+++ b/api.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Mage
  * @package     Mage

--- a/api.php
+++ b/api.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/api.php
+++ b/api.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Mage
  * @package     Mage

--- a/app/Mage.php
+++ b/app/Mage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Mage
  * @package     Mage

--- a/app/Mage.php
+++ b/app/Mage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/Mage.php
+++ b/app/Mage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Mage
  * @package     Mage

--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Mage
  * @package     Mage

--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Mage
  * @package     Mage

--- a/app/code/core/Mage/Admin/Helper/Block.php
+++ b/app/code/core/Mage/Admin/Helper/Block.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Admin/Helper/Block.php
+++ b/app/code/core/Mage/Admin/Helper/Block.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Helper/Block.php
+++ b/app/code/core/Mage/Admin/Helper/Block.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Helper/Data.php
+++ b/app/code/core/Mage/Admin/Helper/Data.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Admin/Helper/Data.php
+++ b/app/code/core/Mage/Admin/Helper/Data.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Helper/Data.php
+++ b/app/code/core/Mage/Admin/Helper/Data.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Helper/Rules/Fallback.php
+++ b/app/code/core/Mage/Admin/Helper/Rules/Fallback.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Admin/Helper/Rules/Fallback.php
+++ b/app/code/core/Mage/Admin/Helper/Rules/Fallback.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Helper/Rules/Fallback.php
+++ b/app/code/core/Mage/Admin/Helper/Rules/Fallback.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Helper/Variable.php
+++ b/app/code/core/Mage/Admin/Helper/Variable.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Admin/Helper/Variable.php
+++ b/app/code/core/Mage/Admin/Helper/Variable.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Helper/Variable.php
+++ b/app/code/core/Mage/Admin/Helper/Variable.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Acl.php
+++ b/app/code/core/Mage/Admin/Model/Acl.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Admin/Model/Acl.php
+++ b/app/code/core/Mage/Admin/Model/Acl.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Acl.php
+++ b/app/code/core/Mage/Admin/Model/Acl.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Acl/Assert/Ip.php
+++ b/app/code/core/Mage/Admin/Model/Acl/Assert/Ip.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Admin/Model/Acl/Assert/Ip.php
+++ b/app/code/core/Mage/Admin/Model/Acl/Assert/Ip.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Acl/Assert/Ip.php
+++ b/app/code/core/Mage/Admin/Model/Acl/Assert/Ip.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Acl/Assert/Time.php
+++ b/app/code/core/Mage/Admin/Model/Acl/Assert/Time.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Admin/Model/Acl/Assert/Time.php
+++ b/app/code/core/Mage/Admin/Model/Acl/Assert/Time.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Acl/Assert/Time.php
+++ b/app/code/core/Mage/Admin/Model/Acl/Assert/Time.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Acl/Resource.php
+++ b/app/code/core/Mage/Admin/Model/Acl/Resource.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Admin/Model/Acl/Resource.php
+++ b/app/code/core/Mage/Admin/Model/Acl/Resource.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Acl/Resource.php
+++ b/app/code/core/Mage/Admin/Model/Acl/Resource.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Acl/Role.php
+++ b/app/code/core/Mage/Admin/Model/Acl/Role.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Admin/Model/Acl/Role.php
+++ b/app/code/core/Mage/Admin/Model/Acl/Role.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Acl/Role.php
+++ b/app/code/core/Mage/Admin/Model/Acl/Role.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Acl/Role/Generic.php
+++ b/app/code/core/Mage/Admin/Model/Acl/Role/Generic.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Admin/Model/Acl/Role/Generic.php
+++ b/app/code/core/Mage/Admin/Model/Acl/Role/Generic.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Acl/Role/Generic.php
+++ b/app/code/core/Mage/Admin/Model/Acl/Role/Generic.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Acl/Role/Group.php
+++ b/app/code/core/Mage/Admin/Model/Acl/Role/Group.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Admin/Model/Acl/Role/Group.php
+++ b/app/code/core/Mage/Admin/Model/Acl/Role/Group.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Acl/Role/Group.php
+++ b/app/code/core/Mage/Admin/Model/Acl/Role/Group.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Acl/Role/Registry.php
+++ b/app/code/core/Mage/Admin/Model/Acl/Role/Registry.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Admin/Model/Acl/Role/Registry.php
+++ b/app/code/core/Mage/Admin/Model/Acl/Role/Registry.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Acl/Role/Registry.php
+++ b/app/code/core/Mage/Admin/Model/Acl/Role/Registry.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Acl/Role/User.php
+++ b/app/code/core/Mage/Admin/Model/Acl/Role/User.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Admin/Model/Acl/Role/User.php
+++ b/app/code/core/Mage/Admin/Model/Acl/Role/User.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Acl/Role/User.php
+++ b/app/code/core/Mage/Admin/Model/Acl/Role/User.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Block.php
+++ b/app/code/core/Mage/Admin/Model/Block.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Admin/Model/Block.php
+++ b/app/code/core/Mage/Admin/Model/Block.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Block.php
+++ b/app/code/core/Mage/Admin/Model/Block.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Config.php
+++ b/app/code/core/Mage/Admin/Model/Config.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Admin/Model/Config.php
+++ b/app/code/core/Mage/Admin/Model/Config.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Config.php
+++ b/app/code/core/Mage/Admin/Model/Config.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Mysql4/Acl.php
+++ b/app/code/core/Mage/Admin/Model/Mysql4/Acl.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Admin/Model/Mysql4/Acl.php
+++ b/app/code/core/Mage/Admin/Model/Mysql4/Acl.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Mysql4/Acl.php
+++ b/app/code/core/Mage/Admin/Model/Mysql4/Acl.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Mysql4/Acl/Role.php
+++ b/app/code/core/Mage/Admin/Model/Mysql4/Acl/Role.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Admin/Model/Mysql4/Acl/Role.php
+++ b/app/code/core/Mage/Admin/Model/Mysql4/Acl/Role.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Mysql4/Acl/Role.php
+++ b/app/code/core/Mage/Admin/Model/Mysql4/Acl/Role.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Mysql4/Acl/Role/Collection.php
+++ b/app/code/core/Mage/Admin/Model/Mysql4/Acl/Role/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Admin/Model/Mysql4/Acl/Role/Collection.php
+++ b/app/code/core/Mage/Admin/Model/Mysql4/Acl/Role/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Mysql4/Acl/Role/Collection.php
+++ b/app/code/core/Mage/Admin/Model/Mysql4/Acl/Role/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Mysql4/Permissions/Collection.php
+++ b/app/code/core/Mage/Admin/Model/Mysql4/Permissions/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Admin/Model/Mysql4/Permissions/Collection.php
+++ b/app/code/core/Mage/Admin/Model/Mysql4/Permissions/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Mysql4/Permissions/Collection.php
+++ b/app/code/core/Mage/Admin/Model/Mysql4/Permissions/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Mysql4/Role.php
+++ b/app/code/core/Mage/Admin/Model/Mysql4/Role.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Admin/Model/Mysql4/Role.php
+++ b/app/code/core/Mage/Admin/Model/Mysql4/Role.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Mysql4/Role.php
+++ b/app/code/core/Mage/Admin/Model/Mysql4/Role.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Mysql4/Role/Collection.php
+++ b/app/code/core/Mage/Admin/Model/Mysql4/Role/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Admin/Model/Mysql4/Role/Collection.php
+++ b/app/code/core/Mage/Admin/Model/Mysql4/Role/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Mysql4/Role/Collection.php
+++ b/app/code/core/Mage/Admin/Model/Mysql4/Role/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Mysql4/Roles.php
+++ b/app/code/core/Mage/Admin/Model/Mysql4/Roles.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Admin/Model/Mysql4/Roles.php
+++ b/app/code/core/Mage/Admin/Model/Mysql4/Roles.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Mysql4/Roles.php
+++ b/app/code/core/Mage/Admin/Model/Mysql4/Roles.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Mysql4/Roles/Collection.php
+++ b/app/code/core/Mage/Admin/Model/Mysql4/Roles/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Admin/Model/Mysql4/Roles/Collection.php
+++ b/app/code/core/Mage/Admin/Model/Mysql4/Roles/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Mysql4/Roles/Collection.php
+++ b/app/code/core/Mage/Admin/Model/Mysql4/Roles/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Mysql4/Roles/User/Collection.php
+++ b/app/code/core/Mage/Admin/Model/Mysql4/Roles/User/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Admin/Model/Mysql4/Roles/User/Collection.php
+++ b/app/code/core/Mage/Admin/Model/Mysql4/Roles/User/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Mysql4/Roles/User/Collection.php
+++ b/app/code/core/Mage/Admin/Model/Mysql4/Roles/User/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Mysql4/Rules.php
+++ b/app/code/core/Mage/Admin/Model/Mysql4/Rules.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Admin/Model/Mysql4/Rules.php
+++ b/app/code/core/Mage/Admin/Model/Mysql4/Rules.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Mysql4/Rules.php
+++ b/app/code/core/Mage/Admin/Model/Mysql4/Rules.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Mysql4/Rules/Collection.php
+++ b/app/code/core/Mage/Admin/Model/Mysql4/Rules/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Admin/Model/Mysql4/Rules/Collection.php
+++ b/app/code/core/Mage/Admin/Model/Mysql4/Rules/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Mysql4/Rules/Collection.php
+++ b/app/code/core/Mage/Admin/Model/Mysql4/Rules/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Mysql4/User.php
+++ b/app/code/core/Mage/Admin/Model/Mysql4/User.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Admin/Model/Mysql4/User.php
+++ b/app/code/core/Mage/Admin/Model/Mysql4/User.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Mysql4/User.php
+++ b/app/code/core/Mage/Admin/Model/Mysql4/User.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Mysql4/User/Collection.php
+++ b/app/code/core/Mage/Admin/Model/Mysql4/User/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Admin/Model/Mysql4/User/Collection.php
+++ b/app/code/core/Mage/Admin/Model/Mysql4/User/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Mysql4/User/Collection.php
+++ b/app/code/core/Mage/Admin/Model/Mysql4/User/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Observer.php
+++ b/app/code/core/Mage/Admin/Model/Observer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Admin/Model/Observer.php
+++ b/app/code/core/Mage/Admin/Model/Observer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Observer.php
+++ b/app/code/core/Mage/Admin/Model/Observer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Redirectpolicy.php
+++ b/app/code/core/Mage/Admin/Model/Redirectpolicy.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Admin/Model/Redirectpolicy.php
+++ b/app/code/core/Mage/Admin/Model/Redirectpolicy.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Redirectpolicy.php
+++ b/app/code/core/Mage/Admin/Model/Redirectpolicy.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Resource/Acl.php
+++ b/app/code/core/Mage/Admin/Model/Resource/Acl.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Admin/Model/Resource/Acl.php
+++ b/app/code/core/Mage/Admin/Model/Resource/Acl.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Resource/Acl.php
+++ b/app/code/core/Mage/Admin/Model/Resource/Acl.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Resource/Acl/Role.php
+++ b/app/code/core/Mage/Admin/Model/Resource/Acl/Role.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Admin/Model/Resource/Acl/Role.php
+++ b/app/code/core/Mage/Admin/Model/Resource/Acl/Role.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Resource/Acl/Role.php
+++ b/app/code/core/Mage/Admin/Model/Resource/Acl/Role.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Resource/Acl/Role/Collection.php
+++ b/app/code/core/Mage/Admin/Model/Resource/Acl/Role/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Admin/Model/Resource/Acl/Role/Collection.php
+++ b/app/code/core/Mage/Admin/Model/Resource/Acl/Role/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Resource/Acl/Role/Collection.php
+++ b/app/code/core/Mage/Admin/Model/Resource/Acl/Role/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Resource/Block.php
+++ b/app/code/core/Mage/Admin/Model/Resource/Block.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Admin/Model/Resource/Block.php
+++ b/app/code/core/Mage/Admin/Model/Resource/Block.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Resource/Block.php
+++ b/app/code/core/Mage/Admin/Model/Resource/Block.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Resource/Block/Collection.php
+++ b/app/code/core/Mage/Admin/Model/Resource/Block/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Admin/Model/Resource/Block/Collection.php
+++ b/app/code/core/Mage/Admin/Model/Resource/Block/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Resource/Block/Collection.php
+++ b/app/code/core/Mage/Admin/Model/Resource/Block/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Resource/Permissions/Collection.php
+++ b/app/code/core/Mage/Admin/Model/Resource/Permissions/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Admin/Model/Resource/Permissions/Collection.php
+++ b/app/code/core/Mage/Admin/Model/Resource/Permissions/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Resource/Permissions/Collection.php
+++ b/app/code/core/Mage/Admin/Model/Resource/Permissions/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Resource/Role.php
+++ b/app/code/core/Mage/Admin/Model/Resource/Role.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Admin/Model/Resource/Role.php
+++ b/app/code/core/Mage/Admin/Model/Resource/Role.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Resource/Role.php
+++ b/app/code/core/Mage/Admin/Model/Resource/Role.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Resource/Role/Collection.php
+++ b/app/code/core/Mage/Admin/Model/Resource/Role/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Admin/Model/Resource/Role/Collection.php
+++ b/app/code/core/Mage/Admin/Model/Resource/Role/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Resource/Role/Collection.php
+++ b/app/code/core/Mage/Admin/Model/Resource/Role/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Resource/Roles.php
+++ b/app/code/core/Mage/Admin/Model/Resource/Roles.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Admin/Model/Resource/Roles.php
+++ b/app/code/core/Mage/Admin/Model/Resource/Roles.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Resource/Roles.php
+++ b/app/code/core/Mage/Admin/Model/Resource/Roles.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Resource/Roles/Collection.php
+++ b/app/code/core/Mage/Admin/Model/Resource/Roles/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Admin/Model/Resource/Roles/Collection.php
+++ b/app/code/core/Mage/Admin/Model/Resource/Roles/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Resource/Roles/Collection.php
+++ b/app/code/core/Mage/Admin/Model/Resource/Roles/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Resource/Roles/User/Collection.php
+++ b/app/code/core/Mage/Admin/Model/Resource/Roles/User/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Admin/Model/Resource/Roles/User/Collection.php
+++ b/app/code/core/Mage/Admin/Model/Resource/Roles/User/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Resource/Roles/User/Collection.php
+++ b/app/code/core/Mage/Admin/Model/Resource/Roles/User/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Resource/Rules.php
+++ b/app/code/core/Mage/Admin/Model/Resource/Rules.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Admin/Model/Resource/Rules.php
+++ b/app/code/core/Mage/Admin/Model/Resource/Rules.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Resource/Rules.php
+++ b/app/code/core/Mage/Admin/Model/Resource/Rules.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Resource/Rules/Collection.php
+++ b/app/code/core/Mage/Admin/Model/Resource/Rules/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Admin/Model/Resource/Rules/Collection.php
+++ b/app/code/core/Mage/Admin/Model/Resource/Rules/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Resource/Rules/Collection.php
+++ b/app/code/core/Mage/Admin/Model/Resource/Rules/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Resource/User.php
+++ b/app/code/core/Mage/Admin/Model/Resource/User.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Admin/Model/Resource/User.php
+++ b/app/code/core/Mage/Admin/Model/Resource/User.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Resource/User.php
+++ b/app/code/core/Mage/Admin/Model/Resource/User.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Resource/User/Collection.php
+++ b/app/code/core/Mage/Admin/Model/Resource/User/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Admin/Model/Resource/User/Collection.php
+++ b/app/code/core/Mage/Admin/Model/Resource/User/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Resource/User/Collection.php
+++ b/app/code/core/Mage/Admin/Model/Resource/User/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Resource/Variable.php
+++ b/app/code/core/Mage/Admin/Model/Resource/Variable.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Admin/Model/Resource/Variable.php
+++ b/app/code/core/Mage/Admin/Model/Resource/Variable.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Resource/Variable.php
+++ b/app/code/core/Mage/Admin/Model/Resource/Variable.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Resource/Variable/Collection.php
+++ b/app/code/core/Mage/Admin/Model/Resource/Variable/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Admin/Model/Resource/Variable/Collection.php
+++ b/app/code/core/Mage/Admin/Model/Resource/Variable/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Resource/Variable/Collection.php
+++ b/app/code/core/Mage/Admin/Model/Resource/Variable/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Role.php
+++ b/app/code/core/Mage/Admin/Model/Role.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Admin/Model/Role.php
+++ b/app/code/core/Mage/Admin/Model/Role.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Role.php
+++ b/app/code/core/Mage/Admin/Model/Role.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Roles.php
+++ b/app/code/core/Mage/Admin/Model/Roles.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Admin/Model/Roles.php
+++ b/app/code/core/Mage/Admin/Model/Roles.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Roles.php
+++ b/app/code/core/Mage/Admin/Model/Roles.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Rules.php
+++ b/app/code/core/Mage/Admin/Model/Rules.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Admin/Model/Rules.php
+++ b/app/code/core/Mage/Admin/Model/Rules.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Rules.php
+++ b/app/code/core/Mage/Admin/Model/Rules.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Session.php
+++ b/app/code/core/Mage/Admin/Model/Session.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Admin/Model/Session.php
+++ b/app/code/core/Mage/Admin/Model/Session.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Session.php
+++ b/app/code/core/Mage/Admin/Model/Session.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/User.php
+++ b/app/code/core/Mage/Admin/Model/User.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Admin/Model/User.php
+++ b/app/code/core/Mage/Admin/Model/User.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/User.php
+++ b/app/code/core/Mage/Admin/Model/User.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Variable.php
+++ b/app/code/core/Mage/Admin/Model/Variable.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Admin/Model/Variable.php
+++ b/app/code/core/Mage/Admin/Model/Variable.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/Model/Variable.php
+++ b/app/code/core/Mage/Admin/Model/Variable.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/data/admin_setup/data-install-1.6.0.0.php
+++ b/app/code/core/Mage/Admin/data/admin_setup/data-install-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Admin/data/admin_setup/data-install-1.6.0.0.php
+++ b/app/code/core/Mage/Admin/data/admin_setup/data-install-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/data/admin_setup/data-install-1.6.0.0.php
+++ b/app/code/core/Mage/Admin/data/admin_setup/data-install-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/etc/config.xml
+++ b/app/code/core/Mage/Admin/etc/config.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/etc/config.xml
+++ b/app/code/core/Mage/Admin/etc/config.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Admin/etc/config.xml
+++ b/app/code/core/Mage/Admin/etc/config.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/sql/admin_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Admin/sql/admin_setup/install-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Admin/sql/admin_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Admin/sql/admin_setup/install-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/sql/admin_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Admin/sql/admin_setup/install-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/sql/admin_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/Admin/sql/admin_setup/mysql4-install-0.7.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Admin/sql/admin_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/Admin/sql/admin_setup/mysql4-install-0.7.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/sql/admin_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/Admin/sql/admin_setup/mysql4-install-0.7.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/sql/admin_setup/mysql4-upgrade-0.7.0-0.7.1.php
+++ b/app/code/core/Mage/Admin/sql/admin_setup/mysql4-upgrade-0.7.0-0.7.1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Admin/sql/admin_setup/mysql4-upgrade-0.7.0-0.7.1.php
+++ b/app/code/core/Mage/Admin/sql/admin_setup/mysql4-upgrade-0.7.0-0.7.1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/sql/admin_setup/mysql4-upgrade-0.7.0-0.7.1.php
+++ b/app/code/core/Mage/Admin/sql/admin_setup/mysql4-upgrade-0.7.0-0.7.1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/sql/admin_setup/mysql4-upgrade-0.7.1-0.7.2.php
+++ b/app/code/core/Mage/Admin/sql/admin_setup/mysql4-upgrade-0.7.1-0.7.2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Admin/sql/admin_setup/mysql4-upgrade-0.7.1-0.7.2.php
+++ b/app/code/core/Mage/Admin/sql/admin_setup/mysql4-upgrade-0.7.1-0.7.2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/sql/admin_setup/mysql4-upgrade-0.7.1-0.7.2.php
+++ b/app/code/core/Mage/Admin/sql/admin_setup/mysql4-upgrade-0.7.1-0.7.2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/sql/admin_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/Admin/sql/admin_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Admin/sql/admin_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/Admin/sql/admin_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/sql/admin_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/Admin/sql/admin_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/sql/admin_setup/upgrade-1.6.0.0-1.6.1.0.php
+++ b/app/code/core/Mage/Admin/sql/admin_setup/upgrade-1.6.0.0-1.6.1.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Admin/sql/admin_setup/upgrade-1.6.0.0-1.6.1.0.php
+++ b/app/code/core/Mage/Admin/sql/admin_setup/upgrade-1.6.0.0-1.6.1.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/sql/admin_setup/upgrade-1.6.0.0-1.6.1.0.php
+++ b/app/code/core/Mage/Admin/sql/admin_setup/upgrade-1.6.0.0-1.6.1.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/sql/admin_setup/upgrade-1.6.1.0-1.6.1.1.php
+++ b/app/code/core/Mage/Admin/sql/admin_setup/upgrade-1.6.1.0-1.6.1.1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Admin/sql/admin_setup/upgrade-1.6.1.0-1.6.1.1.php
+++ b/app/code/core/Mage/Admin/sql/admin_setup/upgrade-1.6.1.0-1.6.1.1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/sql/admin_setup/upgrade-1.6.1.0-1.6.1.1.php
+++ b/app/code/core/Mage/Admin/sql/admin_setup/upgrade-1.6.1.0-1.6.1.1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/sql/admin_setup/upgrade-1.6.1.1-1.6.1.2.php
+++ b/app/code/core/Mage/Admin/sql/admin_setup/upgrade-1.6.1.1-1.6.1.2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Admin/sql/admin_setup/upgrade-1.6.1.1-1.6.1.2.php
+++ b/app/code/core/Mage/Admin/sql/admin_setup/upgrade-1.6.1.1-1.6.1.2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/sql/admin_setup/upgrade-1.6.1.1-1.6.1.2.php
+++ b/app/code/core/Mage/Admin/sql/admin_setup/upgrade-1.6.1.1-1.6.1.2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/sql/admin_setup/upgrade-1.6.1.2-1.6.1.3.php
+++ b/app/code/core/Mage/Admin/sql/admin_setup/upgrade-1.6.1.2-1.6.1.3.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Admin/sql/admin_setup/upgrade-1.6.1.2-1.6.1.3.php
+++ b/app/code/core/Mage/Admin/sql/admin_setup/upgrade-1.6.1.2-1.6.1.3.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/sql/admin_setup/upgrade-1.6.1.2-1.6.1.3.php
+++ b/app/code/core/Mage/Admin/sql/admin_setup/upgrade-1.6.1.2-1.6.1.3.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/sql/admin_setup/upgrade-1.6.1.3-1.6.1.4.php
+++ b/app/code/core/Mage/Admin/sql/admin_setup/upgrade-1.6.1.3-1.6.1.4.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Admin/sql/admin_setup/upgrade-1.6.1.3-1.6.1.4.php
+++ b/app/code/core/Mage/Admin/sql/admin_setup/upgrade-1.6.1.3-1.6.1.4.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/Admin/sql/admin_setup/upgrade-1.6.1.3-1.6.1.4.php
+++ b/app/code/core/Mage/Admin/sql/admin_setup/upgrade-1.6.1.3-1.6.1.4.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/code/core/Mage/AdminNotification/Helper/Data.php
+++ b/app/code/core/Mage/AdminNotification/Helper/Data.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/AdminNotification/Helper/Data.php
+++ b/app/code/core/Mage/AdminNotification/Helper/Data.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_AdminNotification

--- a/app/code/core/Mage/AdminNotification/Helper/Data.php
+++ b/app/code/core/Mage/AdminNotification/Helper/Data.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_AdminNotification

--- a/app/code/core/Mage/AdminNotification/Model/Feed.php
+++ b/app/code/core/Mage/AdminNotification/Model/Feed.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/AdminNotification/Model/Feed.php
+++ b/app/code/core/Mage/AdminNotification/Model/Feed.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_AdminNotification

--- a/app/code/core/Mage/AdminNotification/Model/Feed.php
+++ b/app/code/core/Mage/AdminNotification/Model/Feed.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_AdminNotification

--- a/app/code/core/Mage/AdminNotification/Model/Inbox.php
+++ b/app/code/core/Mage/AdminNotification/Model/Inbox.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/AdminNotification/Model/Inbox.php
+++ b/app/code/core/Mage/AdminNotification/Model/Inbox.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_AdminNotification

--- a/app/code/core/Mage/AdminNotification/Model/Inbox.php
+++ b/app/code/core/Mage/AdminNotification/Model/Inbox.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_AdminNotification

--- a/app/code/core/Mage/AdminNotification/Model/Mysql4/Inbox.php
+++ b/app/code/core/Mage/AdminNotification/Model/Mysql4/Inbox.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/AdminNotification/Model/Mysql4/Inbox.php
+++ b/app/code/core/Mage/AdminNotification/Model/Mysql4/Inbox.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_AdminNotification

--- a/app/code/core/Mage/AdminNotification/Model/Mysql4/Inbox.php
+++ b/app/code/core/Mage/AdminNotification/Model/Mysql4/Inbox.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_AdminNotification

--- a/app/code/core/Mage/AdminNotification/Model/Mysql4/Inbox/Collection.php
+++ b/app/code/core/Mage/AdminNotification/Model/Mysql4/Inbox/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/AdminNotification/Model/Mysql4/Inbox/Collection.php
+++ b/app/code/core/Mage/AdminNotification/Model/Mysql4/Inbox/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_AdminNotification

--- a/app/code/core/Mage/AdminNotification/Model/Mysql4/Inbox/Collection.php
+++ b/app/code/core/Mage/AdminNotification/Model/Mysql4/Inbox/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_AdminNotification

--- a/app/code/core/Mage/AdminNotification/Model/Observer.php
+++ b/app/code/core/Mage/AdminNotification/Model/Observer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/AdminNotification/Model/Observer.php
+++ b/app/code/core/Mage/AdminNotification/Model/Observer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_AdminNotification

--- a/app/code/core/Mage/AdminNotification/Model/Observer.php
+++ b/app/code/core/Mage/AdminNotification/Model/Observer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_AdminNotification

--- a/app/code/core/Mage/AdminNotification/Model/Resource/Inbox.php
+++ b/app/code/core/Mage/AdminNotification/Model/Resource/Inbox.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/AdminNotification/Model/Resource/Inbox.php
+++ b/app/code/core/Mage/AdminNotification/Model/Resource/Inbox.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_AdminNotification

--- a/app/code/core/Mage/AdminNotification/Model/Resource/Inbox.php
+++ b/app/code/core/Mage/AdminNotification/Model/Resource/Inbox.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_AdminNotification

--- a/app/code/core/Mage/AdminNotification/Model/Resource/Inbox/Collection.php
+++ b/app/code/core/Mage/AdminNotification/Model/Resource/Inbox/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/AdminNotification/Model/Resource/Inbox/Collection.php
+++ b/app/code/core/Mage/AdminNotification/Model/Resource/Inbox/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_AdminNotification

--- a/app/code/core/Mage/AdminNotification/Model/Resource/Inbox/Collection.php
+++ b/app/code/core/Mage/AdminNotification/Model/Resource/Inbox/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_AdminNotification

--- a/app/code/core/Mage/AdminNotification/etc/adminhtml.xml
+++ b/app/code/core/Mage/AdminNotification/etc/adminhtml.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_AdminNotification

--- a/app/code/core/Mage/AdminNotification/etc/adminhtml.xml
+++ b/app/code/core/Mage/AdminNotification/etc/adminhtml.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_AdminNotification

--- a/app/code/core/Mage/AdminNotification/etc/adminhtml.xml
+++ b/app/code/core/Mage/AdminNotification/etc/adminhtml.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/AdminNotification/etc/config.xml
+++ b/app/code/core/Mage/AdminNotification/etc/config.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_AdminNotification

--- a/app/code/core/Mage/AdminNotification/etc/config.xml
+++ b/app/code/core/Mage/AdminNotification/etc/config.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_AdminNotification

--- a/app/code/core/Mage/AdminNotification/etc/config.xml
+++ b/app/code/core/Mage/AdminNotification/etc/config.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/AdminNotification/etc/system.xml
+++ b/app/code/core/Mage/AdminNotification/etc/system.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_AdminNotification

--- a/app/code/core/Mage/AdminNotification/etc/system.xml
+++ b/app/code/core/Mage/AdminNotification/etc/system.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_AdminNotification

--- a/app/code/core/Mage/AdminNotification/etc/system.xml
+++ b/app/code/core/Mage/AdminNotification/etc/system.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/AdminNotification/sql/adminnotification_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/AdminNotification/sql/adminnotification_setup/install-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/AdminNotification/sql/adminnotification_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/AdminNotification/sql/adminnotification_setup/install-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_AdminNotification

--- a/app/code/core/Mage/AdminNotification/sql/adminnotification_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/AdminNotification/sql/adminnotification_setup/install-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_AdminNotification

--- a/app/code/core/Mage/AdminNotification/sql/adminnotification_setup/mysql4-install-1.0.0.php
+++ b/app/code/core/Mage/AdminNotification/sql/adminnotification_setup/mysql4-install-1.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/AdminNotification/sql/adminnotification_setup/mysql4-install-1.0.0.php
+++ b/app/code/core/Mage/AdminNotification/sql/adminnotification_setup/mysql4-install-1.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_AdminNotification

--- a/app/code/core/Mage/AdminNotification/sql/adminnotification_setup/mysql4-install-1.0.0.php
+++ b/app/code/core/Mage/AdminNotification/sql/adminnotification_setup/mysql4-install-1.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_AdminNotification

--- a/app/code/core/Mage/AdminNotification/sql/adminnotification_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/AdminNotification/sql/adminnotification_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/AdminNotification/sql/adminnotification_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/AdminNotification/sql/adminnotification_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_AdminNotification

--- a/app/code/core/Mage/AdminNotification/sql/adminnotification_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/AdminNotification/sql/adminnotification_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_AdminNotification

--- a/app/code/core/Mage/Adminhtml/Block/Abstract.php
+++ b/app/code/core/Mage/Adminhtml/Block/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Abstract.php
+++ b/app/code/core/Mage/Adminhtml/Block/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Abstract.php
+++ b/app/code/core/Mage/Adminhtml/Block/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Api/Buttons.php
+++ b/app/code/core/Mage/Adminhtml/Block/Api/Buttons.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Api/Buttons.php
+++ b/app/code/core/Mage/Adminhtml/Block/Api/Buttons.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Api/Buttons.php
+++ b/app/code/core/Mage/Adminhtml/Block/Api/Buttons.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Api/Editroles.php
+++ b/app/code/core/Mage/Adminhtml/Block/Api/Editroles.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Api/Editroles.php
+++ b/app/code/core/Mage/Adminhtml/Block/Api/Editroles.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Api/Editroles.php
+++ b/app/code/core/Mage/Adminhtml/Block/Api/Editroles.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Api/Edituser.php
+++ b/app/code/core/Mage/Adminhtml/Block/Api/Edituser.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Api/Edituser.php
+++ b/app/code/core/Mage/Adminhtml/Block/Api/Edituser.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Api/Edituser.php
+++ b/app/code/core/Mage/Adminhtml/Block/Api/Edituser.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Api/Grid/Role.php
+++ b/app/code/core/Mage/Adminhtml/Block/Api/Grid/Role.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Api/Grid/Role.php
+++ b/app/code/core/Mage/Adminhtml/Block/Api/Grid/Role.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Api/Grid/Role.php
+++ b/app/code/core/Mage/Adminhtml/Block/Api/Grid/Role.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Api/Role.php
+++ b/app/code/core/Mage/Adminhtml/Block/Api/Role.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Api/Role.php
+++ b/app/code/core/Mage/Adminhtml/Block/Api/Role.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Api/Role.php
+++ b/app/code/core/Mage/Adminhtml/Block/Api/Role.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Api/Role/Grid/User.php
+++ b/app/code/core/Mage/Adminhtml/Block/Api/Role/Grid/User.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Api/Role/Grid/User.php
+++ b/app/code/core/Mage/Adminhtml/Block/Api/Role/Grid/User.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Api/Role/Grid/User.php
+++ b/app/code/core/Mage/Adminhtml/Block/Api/Role/Grid/User.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Api/Roles.php
+++ b/app/code/core/Mage/Adminhtml/Block/Api/Roles.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Api/Roles.php
+++ b/app/code/core/Mage/Adminhtml/Block/Api/Roles.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Api/Roles.php
+++ b/app/code/core/Mage/Adminhtml/Block/Api/Roles.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Api/Tab/Roleinfo.php
+++ b/app/code/core/Mage/Adminhtml/Block/Api/Tab/Roleinfo.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Api/Tab/Roleinfo.php
+++ b/app/code/core/Mage/Adminhtml/Block/Api/Tab/Roleinfo.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Api/Tab/Roleinfo.php
+++ b/app/code/core/Mage/Adminhtml/Block/Api/Tab/Roleinfo.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Api/Tab/Rolesedit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Api/Tab/Rolesedit.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Api/Tab/Rolesedit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Api/Tab/Rolesedit.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Api/Tab/Rolesedit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Api/Tab/Rolesedit.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Api/Tab/Rolesusers.php
+++ b/app/code/core/Mage/Adminhtml/Block/Api/Tab/Rolesusers.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Api/Tab/Rolesusers.php
+++ b/app/code/core/Mage/Adminhtml/Block/Api/Tab/Rolesusers.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Api/Tab/Rolesusers.php
+++ b/app/code/core/Mage/Adminhtml/Block/Api/Tab/Rolesusers.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Api/Tab/Userroles.php
+++ b/app/code/core/Mage/Adminhtml/Block/Api/Tab/Userroles.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Api/Tab/Userroles.php
+++ b/app/code/core/Mage/Adminhtml/Block/Api/Tab/Userroles.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Api/Tab/Userroles.php
+++ b/app/code/core/Mage/Adminhtml/Block/Api/Tab/Userroles.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Api/User.php
+++ b/app/code/core/Mage/Adminhtml/Block/Api/User.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Api/User.php
+++ b/app/code/core/Mage/Adminhtml/Block/Api/User.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Api/User.php
+++ b/app/code/core/Mage/Adminhtml/Block/Api/User.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Api/User/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Api/User/Edit.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Api/User/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Api/User/Edit.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Api/User/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Api/User/Edit.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Api/User/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Api/User/Edit/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Api/User/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Api/User/Edit/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Api/User/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Api/User/Edit/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Api/User/Edit/Tab/Main.php
+++ b/app/code/core/Mage/Adminhtml/Block/Api/User/Edit/Tab/Main.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Api/User/Edit/Tab/Main.php
+++ b/app/code/core/Mage/Adminhtml/Block/Api/User/Edit/Tab/Main.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Api/User/Edit/Tab/Main.php
+++ b/app/code/core/Mage/Adminhtml/Block/Api/User/Edit/Tab/Main.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Api/User/Edit/Tab/Roles.php
+++ b/app/code/core/Mage/Adminhtml/Block/Api/User/Edit/Tab/Roles.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Api/User/Edit/Tab/Roles.php
+++ b/app/code/core/Mage/Adminhtml/Block/Api/User/Edit/Tab/Roles.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Api/User/Edit/Tab/Roles.php
+++ b/app/code/core/Mage/Adminhtml/Block/Api/User/Edit/Tab/Roles.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Api/User/Edit/Tabs.php
+++ b/app/code/core/Mage/Adminhtml/Block/Api/User/Edit/Tabs.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Api/User/Edit/Tabs.php
+++ b/app/code/core/Mage/Adminhtml/Block/Api/User/Edit/Tabs.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Api/User/Edit/Tabs.php
+++ b/app/code/core/Mage/Adminhtml/Block/Api/User/Edit/Tabs.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Api/User/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Api/User/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Api/User/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Api/User/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Api/User/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Api/User/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Api/Users.php
+++ b/app/code/core/Mage/Adminhtml/Block/Api/Users.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Api/Users.php
+++ b/app/code/core/Mage/Adminhtml/Block/Api/Users.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Api/Users.php
+++ b/app/code/core/Mage/Adminhtml/Block/Api/Users.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Cache.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cache.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Cache.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cache.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Cache.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cache.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Cache/Additional.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cache/Additional.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Cache/Additional.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cache/Additional.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Cache/Additional.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cache/Additional.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Cache/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cache/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Cache/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cache/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Cache/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cache/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Cache/Notifications.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cache/Notifications.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Cache/Notifications.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cache/Notifications.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Cache/Notifications.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cache/Notifications.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Abstract.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Abstract.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Abstract.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Checkboxes/Tree.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Checkboxes/Tree.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Checkboxes/Tree.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Checkboxes/Tree.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Checkboxes/Tree.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Checkboxes/Tree.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Edit.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Edit.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Edit.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Edit/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Edit/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Edit/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Helper/Image.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Helper/Image.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Helper/Image.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Helper/Image.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Helper/Image.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Helper/Image.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Helper/Pricestep.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Helper/Pricestep.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Helper/Pricestep.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Helper/Pricestep.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Helper/Pricestep.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Helper/Pricestep.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Helper/Sortby/Available.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Helper/Sortby/Available.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Helper/Sortby/Available.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Helper/Sortby/Available.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Helper/Sortby/Available.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Helper/Sortby/Available.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Helper/Sortby/Default.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Helper/Sortby/Default.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Helper/Sortby/Default.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Helper/Sortby/Default.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Helper/Sortby/Default.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Helper/Sortby/Default.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Tab/Attributes.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Tab/Attributes.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Tab/Attributes.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Tab/Attributes.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Tab/Attributes.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Tab/Attributes.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Tab/Design.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Tab/Design.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Tab/Design.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Tab/Design.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Tab/Design.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Tab/Design.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Tab/General.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Tab/General.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Tab/General.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Tab/General.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Tab/General.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Tab/General.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Tab/Product.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Tab/Product.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Tab/Product.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Tab/Product.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Tab/Product.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Tab/Product.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Tabs.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Tabs.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Tabs.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Tabs.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Tabs.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Tabs.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Tree.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Tree.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Tree.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Tree.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Tree.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Tree.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Widget/Chooser.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Widget/Chooser.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Widget/Chooser.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Widget/Chooser.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Widget/Chooser.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Widget/Chooser.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Form/Renderer/Attribute/Urlkey.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Form/Renderer/Attribute/Urlkey.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Form/Renderer/Attribute/Urlkey.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Form/Renderer/Attribute/Urlkey.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Form/Renderer/Attribute/Urlkey.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Form/Renderer/Attribute/Urlkey.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Form/Renderer/Config/DateFieldsOrder.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Form/Renderer/Config/DateFieldsOrder.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Form/Renderer/Config/DateFieldsOrder.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Form/Renderer/Config/DateFieldsOrder.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Form/Renderer/Config/DateFieldsOrder.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Form/Renderer/Config/DateFieldsOrder.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Form/Renderer/Config/YearRange.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Form/Renderer/Config/YearRange.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Form/Renderer/Config/YearRange.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Form/Renderer/Config/YearRange.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Form/Renderer/Config/YearRange.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Form/Renderer/Config/YearRange.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Form/Renderer/Fieldset/Element.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Form/Renderer/Fieldset/Element.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Form/Renderer/Fieldset/Element.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Form/Renderer/Fieldset/Element.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Form/Renderer/Fieldset/Element.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Form/Renderer/Fieldset/Element.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Helper/Form/Wysiwyg.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Helper/Form/Wysiwyg.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Helper/Form/Wysiwyg.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Helper/Form/Wysiwyg.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Helper/Form/Wysiwyg.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Helper/Form/Wysiwyg.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Helper/Form/Wysiwyg/Content.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Helper/Form/Wysiwyg/Content.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Helper/Form/Wysiwyg/Content.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Helper/Form/Wysiwyg/Content.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Helper/Form/Wysiwyg/Content.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Helper/Form/Wysiwyg/Content.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Edit.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Edit.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Edit.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Edit/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Edit/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Edit/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Edit/Tab/Front.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Edit/Tab/Front.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Edit/Tab/Front.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Edit/Tab/Front.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Edit/Tab/Front.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Edit/Tab/Front.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Edit/Tab/Main.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Edit/Tab/Main.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Edit/Tab/Main.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Edit/Tab/Main.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Edit/Tab/Main.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Edit/Tab/Main.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Edit/Tab/Options.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Edit/Tab/Options.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Edit/Tab/Options.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Edit/Tab/Options.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Edit/Tab/Options.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Edit/Tab/Options.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Edit/Tab/System.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Edit/Tab/System.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Edit/Tab/System.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Edit/Tab/System.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Edit/Tab/System.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Edit/Tab/System.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Edit/Tabs.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Edit/Tabs.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Edit/Tabs.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Edit/Tabs.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Edit/Tabs.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Edit/Tabs.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/New/Product/Attributes.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/New/Product/Attributes.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/New/Product/Attributes.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/New/Product/Attributes.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/New/Product/Attributes.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/New/Product/Attributes.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/New/Product/Created.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/New/Product/Created.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/New/Product/Created.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/New/Product/Created.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/New/Product/Created.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/New/Product/Created.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Set/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Set/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Set/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Set/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Set/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Set/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Set/Main.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Set/Main.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Set/Main.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Set/Main.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Set/Main.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Set/Main.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Set/Main/Formattribute.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Set/Main/Formattribute.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Set/Main/Formattribute.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Set/Main/Formattribute.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Set/Main/Formattribute.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Set/Main/Formattribute.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Set/Main/Formgroup.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Set/Main/Formgroup.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Set/Main/Formgroup.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Set/Main/Formgroup.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Set/Main/Formgroup.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Set/Main/Formgroup.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Set/Main/Formset.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Set/Main/Formset.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Set/Main/Formset.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Set/Main/Formset.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Set/Main/Formset.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Set/Main/Formset.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Set/Main/Tree/Attribute.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Set/Main/Tree/Attribute.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Set/Main/Tree/Attribute.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Set/Main/Tree/Attribute.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Set/Main/Tree/Attribute.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Set/Main/Tree/Attribute.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Set/Main/Tree/Group.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Set/Main/Tree/Group.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Set/Main/Tree/Group.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Set/Main/Tree/Group.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Set/Main/Tree/Group.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Set/Main/Tree/Group.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Set/Toolbar/Add.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Set/Toolbar/Add.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Set/Toolbar/Add.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Set/Toolbar/Add.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Set/Toolbar/Add.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Set/Toolbar/Add.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Set/Toolbar/Main.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Set/Toolbar/Main.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Set/Toolbar/Main.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Set/Toolbar/Main.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Set/Toolbar/Main.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Set/Toolbar/Main.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Set/Toolbar/Main/Filter.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Set/Toolbar/Main/Filter.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Set/Toolbar/Main/Filter.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Set/Toolbar/Main/Filter.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Set/Toolbar/Main/Filter.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Set/Toolbar/Main/Filter.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Composite/Configure.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Composite/Configure.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Composite/Configure.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Composite/Configure.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Composite/Configure.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Composite/Configure.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Composite/Error.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Composite/Error.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Composite/Error.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Composite/Error.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Composite/Error.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Composite/Error.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Composite/Fieldset.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Composite/Fieldset.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Composite/Fieldset.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Composite/Fieldset.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Composite/Fieldset.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Composite/Fieldset.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Composite/Fieldset/Configurable.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Composite/Fieldset/Configurable.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Composite/Fieldset/Configurable.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Composite/Fieldset/Configurable.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Composite/Fieldset/Configurable.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Composite/Fieldset/Configurable.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Composite/Fieldset/Grouped.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Composite/Fieldset/Grouped.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Composite/Fieldset/Grouped.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Composite/Fieldset/Grouped.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Composite/Fieldset/Grouped.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Composite/Fieldset/Grouped.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Composite/Fieldset/Options.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Composite/Fieldset/Options.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Composite/Fieldset/Options.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Composite/Fieldset/Options.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Composite/Fieldset/Options.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Composite/Fieldset/Options.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Composite/Fieldset/Qty.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Composite/Fieldset/Qty.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Composite/Fieldset/Qty.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Composite/Fieldset/Qty.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Composite/Fieldset/Qty.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Composite/Fieldset/Qty.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Composite/Update/Result.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Composite/Update/Result.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Composite/Update/Result.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Composite/Update/Result.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Composite/Update/Result.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Composite/Update/Result.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Created.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Created.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Created.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Created.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Created.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Created.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Action/Attribute.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Action/Attribute.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Action/Attribute.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Action/Attribute.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Action/Attribute.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Action/Attribute.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Action/Attribute/Tab/Attributes.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Action/Attribute/Tab/Attributes.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Action/Attribute/Tab/Attributes.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Action/Attribute/Tab/Attributes.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Action/Attribute/Tab/Attributes.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Action/Attribute/Tab/Attributes.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Action/Attribute/Tab/Inventory.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Action/Attribute/Tab/Inventory.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Action/Attribute/Tab/Inventory.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Action/Attribute/Tab/Inventory.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Action/Attribute/Tab/Inventory.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Action/Attribute/Tab/Inventory.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Action/Attribute/Tab/Websites.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Action/Attribute/Tab/Websites.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Action/Attribute/Tab/Websites.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Action/Attribute/Tab/Websites.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Action/Attribute/Tab/Websites.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Action/Attribute/Tab/Websites.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Action/Attribute/Tabs.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Action/Attribute/Tabs.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Action/Attribute/Tabs.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Action/Attribute/Tabs.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Action/Attribute/Tabs.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Action/Attribute/Tabs.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Js.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Js.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Js.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Js.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Js.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Js.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Ajax/Serializer.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Ajax/Serializer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Ajax/Serializer.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Ajax/Serializer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Ajax/Serializer.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Ajax/Serializer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Alerts.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Alerts.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Alerts.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Alerts.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Alerts.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Alerts.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Alerts/Price.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Alerts/Price.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Alerts/Price.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Alerts/Price.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Alerts/Price.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Alerts/Price.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Alerts/Stock.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Alerts/Stock.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Alerts/Stock.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Alerts/Stock.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Alerts/Stock.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Alerts/Stock.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Attributes.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Attributes.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Attributes.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Attributes.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Attributes.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Attributes.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Attributes/Create.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Attributes/Create.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Attributes/Create.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Attributes/Create.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Attributes/Create.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Attributes/Create.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Categories.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Categories.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Categories.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Categories.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Categories.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Categories.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Crosssell.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Crosssell.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Crosssell.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Crosssell.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Crosssell.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Crosssell.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Inventory.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Inventory.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Inventory.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Inventory.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Inventory.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Inventory.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Options.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Options.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Options.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Options.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Options.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Options.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Options/Option.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Options/Option.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Options/Option.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Options/Option.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Options/Option.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Options/Option.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Options/Type/Abstract.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Options/Type/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Options/Type/Abstract.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Options/Type/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Options/Type/Abstract.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Options/Type/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Options/Type/Date.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Options/Type/Date.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Options/Type/Date.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Options/Type/Date.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Options/Type/Date.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Options/Type/Date.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Options/Type/File.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Options/Type/File.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Options/Type/File.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Options/Type/File.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Options/Type/File.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Options/Type/File.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Options/Type/Select.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Options/Type/Select.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Options/Type/Select.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Options/Type/Select.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Options/Type/Select.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Options/Type/Select.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Options/Type/Text.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Options/Type/Text.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Options/Type/Text.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Options/Type/Text.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Options/Type/Text.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Options/Type/Text.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Price.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Price.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Price.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Price.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Price.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Price.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Price/Group.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Price/Group.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Price/Group.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Price/Group.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Price/Group.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Price/Group.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Price/Group/Abstract.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Price/Group/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Price/Group/Abstract.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Price/Group/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Price/Group/Abstract.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Price/Group/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Price/Recurring.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Price/Recurring.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Price/Recurring.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Price/Recurring.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Price/Recurring.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Price/Recurring.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Price/Tier.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Price/Tier.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Price/Tier.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Price/Tier.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Price/Tier.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Price/Tier.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Related.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Related.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Related.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Related.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Related.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Related.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Reviews.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Reviews.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Reviews.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Reviews.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Reviews.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Reviews.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Settings.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Settings.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Settings.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Settings.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Settings.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Settings.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Super/Config.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Super/Config.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Super/Config.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Super/Config.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Super/Config.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Super/Config.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Super/Config/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Super/Config/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Super/Config/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Super/Config/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Super/Config/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Super/Config/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Super/Config/Grid/Filter/Inventory.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Super/Config/Grid/Filter/Inventory.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Super/Config/Grid/Filter/Inventory.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Super/Config/Grid/Filter/Inventory.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Super/Config/Grid/Filter/Inventory.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Super/Config/Grid/Filter/Inventory.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Super/Config/Grid/Renderer/Checkbox.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Super/Config/Grid/Renderer/Checkbox.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Super/Config/Grid/Renderer/Checkbox.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Super/Config/Grid/Renderer/Checkbox.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Super/Config/Grid/Renderer/Checkbox.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Super/Config/Grid/Renderer/Checkbox.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Super/Config/Grid/Renderer/Inventory.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Super/Config/Grid/Renderer/Inventory.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Super/Config/Grid/Renderer/Inventory.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Super/Config/Grid/Renderer/Inventory.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Super/Config/Grid/Renderer/Inventory.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Super/Config/Grid/Renderer/Inventory.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Super/Config/Simple.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Super/Config/Simple.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Super/Config/Simple.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Super/Config/Simple.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Super/Config/Simple.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Super/Config/Simple.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Super/Group.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Super/Group.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Super/Group.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Super/Group.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Super/Group.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Super/Group.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Super/Settings.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Super/Settings.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Super/Settings.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Super/Settings.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Super/Settings.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Super/Settings.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Tag.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Tag.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Tag.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Tag.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Tag.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Tag.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Tag/Customer.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Tag/Customer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Tag/Customer.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Tag/Customer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Tag/Customer.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Tag/Customer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Upsell.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Upsell.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Upsell.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Upsell.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Upsell.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Upsell.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Websites.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Websites.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Websites.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Websites.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Websites.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Websites.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tabs.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tabs.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tabs.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tabs.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tabs.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tabs.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tabs/Configurable.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tabs/Configurable.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tabs/Configurable.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tabs/Configurable.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tabs/Configurable.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tabs/Configurable.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tabs/Grouped.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tabs/Grouped.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tabs/Grouped.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tabs/Grouped.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tabs/Grouped.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tabs/Grouped.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Frontend/Product/Watermark.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Frontend/Product/Watermark.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Frontend/Product/Watermark.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Frontend/Product/Watermark.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Frontend/Product/Watermark.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Frontend/Product/Watermark.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Helper/Form/Apply.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Helper/Form/Apply.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Helper/Form/Apply.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Helper/Form/Apply.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Helper/Form/Apply.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Helper/Form/Apply.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Helper/Form/Boolean.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Helper/Form/Boolean.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Helper/Form/Boolean.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Helper/Form/Boolean.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Helper/Form/Boolean.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Helper/Form/Boolean.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Helper/Form/Config.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Helper/Form/Config.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Helper/Form/Config.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Helper/Form/Config.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Helper/Form/Config.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Helper/Form/Config.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Helper/Form/Gallery.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Helper/Form/Gallery.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Helper/Form/Gallery.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Helper/Form/Gallery.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Helper/Form/Gallery.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Helper/Form/Gallery.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Helper/Form/Gallery/Content.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Helper/Form/Gallery/Content.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Helper/Form/Gallery/Content.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Helper/Form/Gallery/Content.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Helper/Form/Gallery/Content.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Helper/Form/Gallery/Content.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Helper/Form/Image.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Helper/Form/Image.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Helper/Form/Image.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Helper/Form/Image.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Helper/Form/Image.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Helper/Form/Image.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Helper/Form/Msrp/Enabled.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Helper/Form/Msrp/Enabled.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Helper/Form/Msrp/Enabled.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Helper/Form/Msrp/Enabled.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Helper/Form/Msrp/Enabled.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Helper/Form/Msrp/Enabled.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Helper/Form/Msrp/Price.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Helper/Form/Msrp/Price.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Helper/Form/Msrp/Price.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Helper/Form/Msrp/Price.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Helper/Form/Msrp/Price.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Helper/Form/Msrp/Price.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Helper/Form/Price.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Helper/Form/Price.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Helper/Form/Price.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Helper/Form/Price.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Helper/Form/Price.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Helper/Form/Price.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Helper/Form/Weight.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Helper/Form/Weight.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Helper/Form/Weight.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Helper/Form/Weight.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Helper/Form/Weight.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Helper/Form/Weight.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Price.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Price.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Price.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Price.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Price.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Price.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Widget/Chooser.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Widget/Chooser.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Widget/Chooser.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Widget/Chooser.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Widget/Chooser.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Widget/Chooser.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Widget/Chooser/Container.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Widget/Chooser/Container.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Widget/Chooser/Container.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Widget/Chooser/Container.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Widget/Chooser/Container.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Widget/Chooser/Container.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Search.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Search.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Search.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Search.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Search.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Search.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Search/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Search/Edit.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Search/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Search/Edit.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Search/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Search/Edit.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Search/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Search/Edit/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Search/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Search/Edit/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Search/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Search/Edit/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Search/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Search/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Search/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Search/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Search/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Search/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Checkout/Agreement.php
+++ b/app/code/core/Mage/Adminhtml/Block/Checkout/Agreement.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Checkout/Agreement.php
+++ b/app/code/core/Mage/Adminhtml/Block/Checkout/Agreement.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Checkout/Agreement.php
+++ b/app/code/core/Mage/Adminhtml/Block/Checkout/Agreement.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Checkout/Agreement/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Checkout/Agreement/Edit.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Checkout/Agreement/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Checkout/Agreement/Edit.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Checkout/Agreement/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Checkout/Agreement/Edit.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Checkout/Agreement/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Checkout/Agreement/Edit/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Checkout/Agreement/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Checkout/Agreement/Edit/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Checkout/Agreement/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Checkout/Agreement/Edit/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Checkout/Agreement/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Checkout/Agreement/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Checkout/Agreement/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Checkout/Agreement/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Checkout/Agreement/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Checkout/Agreement/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Checkout/Formkey.php
+++ b/app/code/core/Mage/Adminhtml/Block/Checkout/Formkey.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Checkout/Formkey.php
+++ b/app/code/core/Mage/Adminhtml/Block/Checkout/Formkey.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Checkout/Formkey.php
+++ b/app/code/core/Mage/Adminhtml/Block/Checkout/Formkey.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Cms/Block.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cms/Block.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Cms/Block.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cms/Block.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Cms/Block.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cms/Block.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Cms/Block/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cms/Block/Edit.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Cms/Block/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cms/Block/Edit.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Cms/Block/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cms/Block/Edit.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Cms/Block/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cms/Block/Edit/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Cms/Block/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cms/Block/Edit/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Cms/Block/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cms/Block/Edit/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Cms/Block/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cms/Block/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Cms/Block/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cms/Block/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Cms/Block/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cms/Block/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Cms/Block/Widget/Chooser.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cms/Block/Widget/Chooser.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Cms/Block/Widget/Chooser.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cms/Block/Widget/Chooser.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Cms/Block/Widget/Chooser.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cms/Block/Widget/Chooser.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Cms/Page.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cms/Page.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Cms/Page.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cms/Page.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Cms/Page.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cms/Page.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Cms/Page/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cms/Page/Edit.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Cms/Page/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cms/Page/Edit.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Cms/Page/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cms/Page/Edit.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Cms/Page/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cms/Page/Edit/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Cms/Page/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cms/Page/Edit/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Cms/Page/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cms/Page/Edit/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Cms/Page/Edit/Tab/Content.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cms/Page/Edit/Tab/Content.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Cms/Page/Edit/Tab/Content.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cms/Page/Edit/Tab/Content.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Cms/Page/Edit/Tab/Content.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cms/Page/Edit/Tab/Content.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Cms/Page/Edit/Tab/Design.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cms/Page/Edit/Tab/Design.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Cms/Page/Edit/Tab/Design.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cms/Page/Edit/Tab/Design.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Cms/Page/Edit/Tab/Design.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cms/Page/Edit/Tab/Design.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Cms/Page/Edit/Tab/Main.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cms/Page/Edit/Tab/Main.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Cms/Page/Edit/Tab/Main.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cms/Page/Edit/Tab/Main.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Cms/Page/Edit/Tab/Main.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cms/Page/Edit/Tab/Main.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Cms/Page/Edit/Tab/Meta.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cms/Page/Edit/Tab/Meta.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Cms/Page/Edit/Tab/Meta.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cms/Page/Edit/Tab/Meta.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Cms/Page/Edit/Tab/Meta.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cms/Page/Edit/Tab/Meta.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Cms/Page/Edit/Tabs.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cms/Page/Edit/Tabs.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Cms/Page/Edit/Tabs.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cms/Page/Edit/Tabs.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Cms/Page/Edit/Tabs.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cms/Page/Edit/Tabs.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Cms/Page/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cms/Page/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Cms/Page/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cms/Page/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Cms/Page/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cms/Page/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Cms/Page/Grid/Renderer/Action.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cms/Page/Grid/Renderer/Action.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Cms/Page/Grid/Renderer/Action.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cms/Page/Grid/Renderer/Action.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Cms/Page/Grid/Renderer/Action.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cms/Page/Grid/Renderer/Action.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Cms/Page/Widget/Chooser.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cms/Page/Widget/Chooser.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Cms/Page/Widget/Chooser.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cms/Page/Widget/Chooser.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Cms/Page/Widget/Chooser.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cms/Page/Widget/Chooser.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Cms/Wysiwyg/Images/Content.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cms/Wysiwyg/Images/Content.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Cms/Wysiwyg/Images/Content.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cms/Wysiwyg/Images/Content.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Cms/Wysiwyg/Images/Content.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cms/Wysiwyg/Images/Content.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Cms/Wysiwyg/Images/Content/Files.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cms/Wysiwyg/Images/Content/Files.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Cms/Wysiwyg/Images/Content/Files.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cms/Wysiwyg/Images/Content/Files.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Cms/Wysiwyg/Images/Content/Files.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cms/Wysiwyg/Images/Content/Files.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Cms/Wysiwyg/Images/Content/Newfolder.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cms/Wysiwyg/Images/Content/Newfolder.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Cms/Wysiwyg/Images/Content/Newfolder.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cms/Wysiwyg/Images/Content/Newfolder.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Cms/Wysiwyg/Images/Content/Newfolder.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cms/Wysiwyg/Images/Content/Newfolder.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Cms/Wysiwyg/Images/Content/Uploader.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cms/Wysiwyg/Images/Content/Uploader.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Cms/Wysiwyg/Images/Content/Uploader.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cms/Wysiwyg/Images/Content/Uploader.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Cms/Wysiwyg/Images/Content/Uploader.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cms/Wysiwyg/Images/Content/Uploader.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Cms/Wysiwyg/Images/Tree.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cms/Wysiwyg/Images/Tree.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Cms/Wysiwyg/Images/Tree.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cms/Wysiwyg/Images/Tree.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Cms/Wysiwyg/Images/Tree.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cms/Wysiwyg/Images/Tree.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Customer.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Renderer/Adminpass.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Renderer/Adminpass.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Renderer/Adminpass.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Renderer/Adminpass.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Renderer/Adminpass.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Renderer/Adminpass.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Renderer/Attribute/Group.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Renderer/Attribute/Group.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Renderer/Attribute/Group.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Renderer/Attribute/Group.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Renderer/Attribute/Group.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Renderer/Attribute/Group.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Renderer/Newpass.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Renderer/Newpass.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Renderer/Newpass.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Renderer/Newpass.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Renderer/Newpass.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Renderer/Newpass.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Renderer/Region.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Renderer/Region.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Renderer/Region.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Renderer/Region.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Renderer/Region.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Renderer/Region.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Account.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Account.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Account.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Account.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Account.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Account.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Addresses.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Addresses.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Addresses.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Addresses.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Addresses.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Addresses.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Cart.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Cart.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Cart.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Cart.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Cart.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Cart.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Carts.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Carts.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Carts.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Carts.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Carts.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Carts.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Newsletter.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Newsletter.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Newsletter.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Newsletter.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Newsletter.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Newsletter.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Newsletter/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Newsletter/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Newsletter/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Newsletter/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Newsletter/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Newsletter/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Newsletter/Grid/Filter/Status.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Newsletter/Grid/Filter/Status.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Newsletter/Grid/Filter/Status.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Newsletter/Grid/Filter/Status.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Newsletter/Grid/Filter/Status.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Newsletter/Grid/Filter/Status.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Newsletter/Grid/Renderer/Action.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Newsletter/Grid/Renderer/Action.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Newsletter/Grid/Renderer/Action.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Newsletter/Grid/Renderer/Action.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Newsletter/Grid/Renderer/Action.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Newsletter/Grid/Renderer/Action.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Newsletter/Grid/Renderer/Status.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Newsletter/Grid/Renderer/Status.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Newsletter/Grid/Renderer/Status.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Newsletter/Grid/Renderer/Status.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Newsletter/Grid/Renderer/Status.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Newsletter/Grid/Renderer/Status.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Orders.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Orders.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Orders.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Orders.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Orders.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Orders.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Reviews.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Reviews.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Reviews.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Reviews.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Reviews.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Reviews.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Tag.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Tag.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Tag.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Tag.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Tag.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Tag.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Tags.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Tags.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Tags.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Tags.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Tags.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Tags.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/View.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/View.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/View.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/View.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/View.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/View.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/View/Accordion.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/View/Accordion.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/View/Accordion.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/View/Accordion.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/View/Accordion.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/View/Accordion.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/View/Cart.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/View/Cart.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/View/Cart.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/View/Cart.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/View/Cart.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/View/Cart.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/View/Grid/Renderer/Item.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/View/Grid/Renderer/Item.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/View/Grid/Renderer/Item.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/View/Grid/Renderer/Item.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/View/Grid/Renderer/Item.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/View/Grid/Renderer/Item.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/View/Orders.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/View/Orders.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/View/Orders.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/View/Orders.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/View/Orders.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/View/Orders.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/View/Sales.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/View/Sales.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/View/Sales.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/View/Sales.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/View/Sales.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/View/Sales.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/View/Wishlist.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/View/Wishlist.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/View/Wishlist.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/View/Wishlist.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/View/Wishlist.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/View/Wishlist.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Wishlist.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Wishlist.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Wishlist.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Wishlist.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Wishlist.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Wishlist.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Wishlist/Grid/Renderer/Description.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Wishlist/Grid/Renderer/Description.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Wishlist/Grid/Renderer/Description.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Wishlist/Grid/Renderer/Description.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Wishlist/Grid/Renderer/Description.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Wishlist/Grid/Renderer/Description.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tabs.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tabs.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tabs.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tabs.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tabs.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tabs.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Form/Element/Boolean.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Form/Element/Boolean.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Form/Element/Boolean.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Form/Element/Boolean.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Form/Element/Boolean.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Form/Element/Boolean.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Form/Element/File.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Form/Element/File.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Form/Element/File.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Form/Element/File.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Form/Element/File.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Form/Element/File.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Form/Element/Image.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Form/Element/Image.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Form/Element/Image.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Form/Element/Image.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Form/Element/Image.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Form/Element/Image.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Grid/Filter/Country.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Grid/Filter/Country.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Grid/Filter/Country.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Grid/Filter/Country.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Grid/Filter/Country.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Grid/Filter/Country.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Grid/Renderer/Multiaction.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Grid/Renderer/Multiaction.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Grid/Renderer/Multiaction.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Grid/Renderer/Multiaction.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Grid/Renderer/Multiaction.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Grid/Renderer/Multiaction.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Group.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Group.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Group.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Group.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Group.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Group.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Group/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Group/Edit.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Group/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Group/Edit.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Group/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Group/Edit.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Group/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Group/Edit/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Group/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Group/Edit/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Group/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Group/Edit/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Group/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Group/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Group/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Group/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Group/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Group/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Online.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Online.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Online.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Online.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Online.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Online.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Online/Filter.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Online/Filter.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Online/Filter.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Online/Filter.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Online/Filter.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Online/Filter.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Online/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Online/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Online/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Online/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Online/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Online/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Online/Grid/Renderer/Ip.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Online/Grid/Renderer/Ip.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Online/Grid/Renderer/Ip.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Online/Grid/Renderer/Ip.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Online/Grid/Renderer/Ip.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Online/Grid/Renderer/Ip.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Online/Grid/Renderer/Type.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Online/Grid/Renderer/Type.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Online/Grid/Renderer/Type.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Online/Grid/Renderer/Type.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Online/Grid/Renderer/Type.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Online/Grid/Renderer/Type.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Online/Grid/Renderer/Url.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Online/Grid/Renderer/Url.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Online/Grid/Renderer/Url.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Online/Grid/Renderer/Url.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Online/Grid/Renderer/Url.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Online/Grid/Renderer/Url.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Sales/Order/Address/Form/Renderer/Vat.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Sales/Order/Address/Form/Renderer/Vat.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Sales/Order/Address/Form/Renderer/Vat.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Sales/Order/Address/Form/Renderer/Vat.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Sales/Order/Address/Form/Renderer/Vat.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Sales/Order/Address/Form/Renderer/Vat.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer/System/Config/Validatevat.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/System/Config/Validatevat.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Customer/System/Config/Validatevat.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/System/Config/Validatevat.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Customer/System/Config/Validatevat.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/System/Config/Validatevat.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Dashboard.php
+++ b/app/code/core/Mage/Adminhtml/Block/Dashboard.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Dashboard.php
+++ b/app/code/core/Mage/Adminhtml/Block/Dashboard.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Dashboard.php
+++ b/app/code/core/Mage/Adminhtml/Block/Dashboard.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Dashboard/Abstract.php
+++ b/app/code/core/Mage/Adminhtml/Block/Dashboard/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Dashboard/Abstract.php
+++ b/app/code/core/Mage/Adminhtml/Block/Dashboard/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Dashboard/Abstract.php
+++ b/app/code/core/Mage/Adminhtml/Block/Dashboard/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Dashboard/Bar.php
+++ b/app/code/core/Mage/Adminhtml/Block/Dashboard/Bar.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Dashboard/Bar.php
+++ b/app/code/core/Mage/Adminhtml/Block/Dashboard/Bar.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Dashboard/Bar.php
+++ b/app/code/core/Mage/Adminhtml/Block/Dashboard/Bar.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Dashboard/Diagrams.php
+++ b/app/code/core/Mage/Adminhtml/Block/Dashboard/Diagrams.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Dashboard/Diagrams.php
+++ b/app/code/core/Mage/Adminhtml/Block/Dashboard/Diagrams.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Dashboard/Diagrams.php
+++ b/app/code/core/Mage/Adminhtml/Block/Dashboard/Diagrams.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Dashboard/Graph.php
+++ b/app/code/core/Mage/Adminhtml/Block/Dashboard/Graph.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Dashboard/Graph.php
+++ b/app/code/core/Mage/Adminhtml/Block/Dashboard/Graph.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Dashboard/Graph.php
+++ b/app/code/core/Mage/Adminhtml/Block/Dashboard/Graph.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Dashboard/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Dashboard/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Dashboard/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Dashboard/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Dashboard/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Dashboard/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Dashboard/Grids.php
+++ b/app/code/core/Mage/Adminhtml/Block/Dashboard/Grids.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Dashboard/Grids.php
+++ b/app/code/core/Mage/Adminhtml/Block/Dashboard/Grids.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Dashboard/Grids.php
+++ b/app/code/core/Mage/Adminhtml/Block/Dashboard/Grids.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Dashboard/Orders/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Dashboard/Orders/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Dashboard/Orders/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Dashboard/Orders/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Dashboard/Orders/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Dashboard/Orders/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Dashboard/Sales.php
+++ b/app/code/core/Mage/Adminhtml/Block/Dashboard/Sales.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Dashboard/Sales.php
+++ b/app/code/core/Mage/Adminhtml/Block/Dashboard/Sales.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Dashboard/Sales.php
+++ b/app/code/core/Mage/Adminhtml/Block/Dashboard/Sales.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Dashboard/Searches/Last.php
+++ b/app/code/core/Mage/Adminhtml/Block/Dashboard/Searches/Last.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Dashboard/Searches/Last.php
+++ b/app/code/core/Mage/Adminhtml/Block/Dashboard/Searches/Last.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Dashboard/Searches/Last.php
+++ b/app/code/core/Mage/Adminhtml/Block/Dashboard/Searches/Last.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Dashboard/Searches/Renderer/Searchquery.php
+++ b/app/code/core/Mage/Adminhtml/Block/Dashboard/Searches/Renderer/Searchquery.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Dashboard/Searches/Renderer/Searchquery.php
+++ b/app/code/core/Mage/Adminhtml/Block/Dashboard/Searches/Renderer/Searchquery.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Dashboard/Searches/Renderer/Searchquery.php
+++ b/app/code/core/Mage/Adminhtml/Block/Dashboard/Searches/Renderer/Searchquery.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Dashboard/Searches/Top.php
+++ b/app/code/core/Mage/Adminhtml/Block/Dashboard/Searches/Top.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Dashboard/Searches/Top.php
+++ b/app/code/core/Mage/Adminhtml/Block/Dashboard/Searches/Top.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Dashboard/Searches/Top.php
+++ b/app/code/core/Mage/Adminhtml/Block/Dashboard/Searches/Top.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Dashboard/Tab/Amounts.php
+++ b/app/code/core/Mage/Adminhtml/Block/Dashboard/Tab/Amounts.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Dashboard/Tab/Amounts.php
+++ b/app/code/core/Mage/Adminhtml/Block/Dashboard/Tab/Amounts.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Dashboard/Tab/Amounts.php
+++ b/app/code/core/Mage/Adminhtml/Block/Dashboard/Tab/Amounts.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Dashboard/Tab/Customers/Most.php
+++ b/app/code/core/Mage/Adminhtml/Block/Dashboard/Tab/Customers/Most.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Dashboard/Tab/Customers/Most.php
+++ b/app/code/core/Mage/Adminhtml/Block/Dashboard/Tab/Customers/Most.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Dashboard/Tab/Customers/Most.php
+++ b/app/code/core/Mage/Adminhtml/Block/Dashboard/Tab/Customers/Most.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Dashboard/Tab/Customers/Newest.php
+++ b/app/code/core/Mage/Adminhtml/Block/Dashboard/Tab/Customers/Newest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Dashboard/Tab/Customers/Newest.php
+++ b/app/code/core/Mage/Adminhtml/Block/Dashboard/Tab/Customers/Newest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Dashboard/Tab/Customers/Newest.php
+++ b/app/code/core/Mage/Adminhtml/Block/Dashboard/Tab/Customers/Newest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Dashboard/Tab/Orders.php
+++ b/app/code/core/Mage/Adminhtml/Block/Dashboard/Tab/Orders.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Dashboard/Tab/Orders.php
+++ b/app/code/core/Mage/Adminhtml/Block/Dashboard/Tab/Orders.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Dashboard/Tab/Orders.php
+++ b/app/code/core/Mage/Adminhtml/Block/Dashboard/Tab/Orders.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Dashboard/Tab/Products/Ordered.php
+++ b/app/code/core/Mage/Adminhtml/Block/Dashboard/Tab/Products/Ordered.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Dashboard/Tab/Products/Ordered.php
+++ b/app/code/core/Mage/Adminhtml/Block/Dashboard/Tab/Products/Ordered.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Dashboard/Tab/Products/Ordered.php
+++ b/app/code/core/Mage/Adminhtml/Block/Dashboard/Tab/Products/Ordered.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Dashboard/Tab/Products/Viewed.php
+++ b/app/code/core/Mage/Adminhtml/Block/Dashboard/Tab/Products/Viewed.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Dashboard/Tab/Products/Viewed.php
+++ b/app/code/core/Mage/Adminhtml/Block/Dashboard/Tab/Products/Viewed.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Dashboard/Tab/Products/Viewed.php
+++ b/app/code/core/Mage/Adminhtml/Block/Dashboard/Tab/Products/Viewed.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Dashboard/Totals.php
+++ b/app/code/core/Mage/Adminhtml/Block/Dashboard/Totals.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Dashboard/Totals.php
+++ b/app/code/core/Mage/Adminhtml/Block/Dashboard/Totals.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Dashboard/Totals.php
+++ b/app/code/core/Mage/Adminhtml/Block/Dashboard/Totals.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Denied.php
+++ b/app/code/core/Mage/Adminhtml/Block/Denied.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Denied.php
+++ b/app/code/core/Mage/Adminhtml/Block/Denied.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Denied.php
+++ b/app/code/core/Mage/Adminhtml/Block/Denied.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Html/Date.php
+++ b/app/code/core/Mage/Adminhtml/Block/Html/Date.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Html/Date.php
+++ b/app/code/core/Mage/Adminhtml/Block/Html/Date.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Html/Date.php
+++ b/app/code/core/Mage/Adminhtml/Block/Html/Date.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Html/Select.php
+++ b/app/code/core/Mage/Adminhtml/Block/Html/Select.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Html/Select.php
+++ b/app/code/core/Mage/Adminhtml/Block/Html/Select.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Html/Select.php
+++ b/app/code/core/Mage/Adminhtml/Block/Html/Select.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Media/Editor.php
+++ b/app/code/core/Mage/Adminhtml/Block/Media/Editor.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Media/Editor.php
+++ b/app/code/core/Mage/Adminhtml/Block/Media/Editor.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Media/Editor.php
+++ b/app/code/core/Mage/Adminhtml/Block/Media/Editor.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Media/Uploader.php
+++ b/app/code/core/Mage/Adminhtml/Block/Media/Uploader.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Media/Uploader.php
+++ b/app/code/core/Mage/Adminhtml/Block/Media/Uploader.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Media/Uploader.php
+++ b/app/code/core/Mage/Adminhtml/Block/Media/Uploader.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Messages.php
+++ b/app/code/core/Mage/Adminhtml/Block/Messages.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Messages.php
+++ b/app/code/core/Mage/Adminhtml/Block/Messages.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Messages.php
+++ b/app/code/core/Mage/Adminhtml/Block/Messages.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Newsletter/Problem.php
+++ b/app/code/core/Mage/Adminhtml/Block/Newsletter/Problem.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Newsletter/Problem.php
+++ b/app/code/core/Mage/Adminhtml/Block/Newsletter/Problem.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Newsletter/Problem.php
+++ b/app/code/core/Mage/Adminhtml/Block/Newsletter/Problem.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Newsletter/Problem/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Newsletter/Problem/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Newsletter/Problem/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Newsletter/Problem/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Newsletter/Problem/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Newsletter/Problem/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Newsletter/Problem/Grid/Filter/Checkbox.php
+++ b/app/code/core/Mage/Adminhtml/Block/Newsletter/Problem/Grid/Filter/Checkbox.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Newsletter/Problem/Grid/Filter/Checkbox.php
+++ b/app/code/core/Mage/Adminhtml/Block/Newsletter/Problem/Grid/Filter/Checkbox.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Newsletter/Problem/Grid/Filter/Checkbox.php
+++ b/app/code/core/Mage/Adminhtml/Block/Newsletter/Problem/Grid/Filter/Checkbox.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Newsletter/Problem/Grid/Renderer/Checkbox.php
+++ b/app/code/core/Mage/Adminhtml/Block/Newsletter/Problem/Grid/Renderer/Checkbox.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Newsletter/Problem/Grid/Renderer/Checkbox.php
+++ b/app/code/core/Mage/Adminhtml/Block/Newsletter/Problem/Grid/Renderer/Checkbox.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Newsletter/Problem/Grid/Renderer/Checkbox.php
+++ b/app/code/core/Mage/Adminhtml/Block/Newsletter/Problem/Grid/Renderer/Checkbox.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Newsletter/Queue.php
+++ b/app/code/core/Mage/Adminhtml/Block/Newsletter/Queue.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Newsletter/Queue.php
+++ b/app/code/core/Mage/Adminhtml/Block/Newsletter/Queue.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Newsletter/Queue.php
+++ b/app/code/core/Mage/Adminhtml/Block/Newsletter/Queue.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Newsletter/Queue/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Newsletter/Queue/Edit.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Newsletter/Queue/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Newsletter/Queue/Edit.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Newsletter/Queue/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Newsletter/Queue/Edit.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Newsletter/Queue/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Newsletter/Queue/Edit/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Newsletter/Queue/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Newsletter/Queue/Edit/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Newsletter/Queue/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Newsletter/Queue/Edit/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Newsletter/Queue/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Newsletter/Queue/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Newsletter/Queue/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Newsletter/Queue/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Newsletter/Queue/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Newsletter/Queue/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Newsletter/Queue/Grid/Renderer/Action.php
+++ b/app/code/core/Mage/Adminhtml/Block/Newsletter/Queue/Grid/Renderer/Action.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Newsletter/Queue/Grid/Renderer/Action.php
+++ b/app/code/core/Mage/Adminhtml/Block/Newsletter/Queue/Grid/Renderer/Action.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Newsletter/Queue/Grid/Renderer/Action.php
+++ b/app/code/core/Mage/Adminhtml/Block/Newsletter/Queue/Grid/Renderer/Action.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Newsletter/Queue/Preview.php
+++ b/app/code/core/Mage/Adminhtml/Block/Newsletter/Queue/Preview.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Newsletter/Queue/Preview.php
+++ b/app/code/core/Mage/Adminhtml/Block/Newsletter/Queue/Preview.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Newsletter/Queue/Preview.php
+++ b/app/code/core/Mage/Adminhtml/Block/Newsletter/Queue/Preview.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Newsletter/Queue/Preview/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Newsletter/Queue/Preview/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Newsletter/Queue/Preview/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Newsletter/Queue/Preview/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Newsletter/Queue/Preview/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Newsletter/Queue/Preview/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Newsletter/Subscriber.php
+++ b/app/code/core/Mage/Adminhtml/Block/Newsletter/Subscriber.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Newsletter/Subscriber.php
+++ b/app/code/core/Mage/Adminhtml/Block/Newsletter/Subscriber.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Newsletter/Subscriber.php
+++ b/app/code/core/Mage/Adminhtml/Block/Newsletter/Subscriber.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Newsletter/Subscriber/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Newsletter/Subscriber/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Newsletter/Subscriber/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Newsletter/Subscriber/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Newsletter/Subscriber/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Newsletter/Subscriber/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Newsletter/Subscriber/Grid/Filter/Checkbox.php
+++ b/app/code/core/Mage/Adminhtml/Block/Newsletter/Subscriber/Grid/Filter/Checkbox.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Newsletter/Subscriber/Grid/Filter/Checkbox.php
+++ b/app/code/core/Mage/Adminhtml/Block/Newsletter/Subscriber/Grid/Filter/Checkbox.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Newsletter/Subscriber/Grid/Filter/Checkbox.php
+++ b/app/code/core/Mage/Adminhtml/Block/Newsletter/Subscriber/Grid/Filter/Checkbox.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Newsletter/Subscriber/Grid/Filter/Website.php
+++ b/app/code/core/Mage/Adminhtml/Block/Newsletter/Subscriber/Grid/Filter/Website.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Newsletter/Subscriber/Grid/Filter/Website.php
+++ b/app/code/core/Mage/Adminhtml/Block/Newsletter/Subscriber/Grid/Filter/Website.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Newsletter/Subscriber/Grid/Filter/Website.php
+++ b/app/code/core/Mage/Adminhtml/Block/Newsletter/Subscriber/Grid/Filter/Website.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Newsletter/Subscriber/Grid/Renderer/Checkbox.php
+++ b/app/code/core/Mage/Adminhtml/Block/Newsletter/Subscriber/Grid/Renderer/Checkbox.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Newsletter/Subscriber/Grid/Renderer/Checkbox.php
+++ b/app/code/core/Mage/Adminhtml/Block/Newsletter/Subscriber/Grid/Renderer/Checkbox.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Newsletter/Subscriber/Grid/Renderer/Checkbox.php
+++ b/app/code/core/Mage/Adminhtml/Block/Newsletter/Subscriber/Grid/Renderer/Checkbox.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Newsletter/Template.php
+++ b/app/code/core/Mage/Adminhtml/Block/Newsletter/Template.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Newsletter/Template.php
+++ b/app/code/core/Mage/Adminhtml/Block/Newsletter/Template.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Newsletter/Template.php
+++ b/app/code/core/Mage/Adminhtml/Block/Newsletter/Template.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Newsletter/Template/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Newsletter/Template/Edit.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Newsletter/Template/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Newsletter/Template/Edit.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Newsletter/Template/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Newsletter/Template/Edit.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Newsletter/Template/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Newsletter/Template/Edit/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Newsletter/Template/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Newsletter/Template/Edit/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Newsletter/Template/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Newsletter/Template/Edit/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Newsletter/Template/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Newsletter/Template/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Newsletter/Template/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Newsletter/Template/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Newsletter/Template/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Newsletter/Template/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Newsletter/Template/Grid/Renderer/Action.php
+++ b/app/code/core/Mage/Adminhtml/Block/Newsletter/Template/Grid/Renderer/Action.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Newsletter/Template/Grid/Renderer/Action.php
+++ b/app/code/core/Mage/Adminhtml/Block/Newsletter/Template/Grid/Renderer/Action.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Newsletter/Template/Grid/Renderer/Action.php
+++ b/app/code/core/Mage/Adminhtml/Block/Newsletter/Template/Grid/Renderer/Action.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Newsletter/Template/Grid/Renderer/Sender.php
+++ b/app/code/core/Mage/Adminhtml/Block/Newsletter/Template/Grid/Renderer/Sender.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Newsletter/Template/Grid/Renderer/Sender.php
+++ b/app/code/core/Mage/Adminhtml/Block/Newsletter/Template/Grid/Renderer/Sender.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Newsletter/Template/Grid/Renderer/Sender.php
+++ b/app/code/core/Mage/Adminhtml/Block/Newsletter/Template/Grid/Renderer/Sender.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Newsletter/Template/Preview.php
+++ b/app/code/core/Mage/Adminhtml/Block/Newsletter/Template/Preview.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Newsletter/Template/Preview.php
+++ b/app/code/core/Mage/Adminhtml/Block/Newsletter/Template/Preview.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Newsletter/Template/Preview.php
+++ b/app/code/core/Mage/Adminhtml/Block/Newsletter/Template/Preview.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Newsletter/Template/Preview/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Newsletter/Template/Preview/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Newsletter/Template/Preview/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Newsletter/Template/Preview/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Newsletter/Template/Preview/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Newsletter/Template/Preview/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Notification/Baseurl.php
+++ b/app/code/core/Mage/Adminhtml/Block/Notification/Baseurl.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Notification/Baseurl.php
+++ b/app/code/core/Mage/Adminhtml/Block/Notification/Baseurl.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Notification/Baseurl.php
+++ b/app/code/core/Mage/Adminhtml/Block/Notification/Baseurl.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Notification/Curl.php
+++ b/app/code/core/Mage/Adminhtml/Block/Notification/Curl.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Notification/Curl.php
+++ b/app/code/core/Mage/Adminhtml/Block/Notification/Curl.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Notification/Curl.php
+++ b/app/code/core/Mage/Adminhtml/Block/Notification/Curl.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Notification/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Notification/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Notification/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Notification/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Notification/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Notification/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Notification/Grid/Renderer/Actions.php
+++ b/app/code/core/Mage/Adminhtml/Block/Notification/Grid/Renderer/Actions.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Notification/Grid/Renderer/Actions.php
+++ b/app/code/core/Mage/Adminhtml/Block/Notification/Grid/Renderer/Actions.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Notification/Grid/Renderer/Actions.php
+++ b/app/code/core/Mage/Adminhtml/Block/Notification/Grid/Renderer/Actions.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Notification/Grid/Renderer/Notice.php
+++ b/app/code/core/Mage/Adminhtml/Block/Notification/Grid/Renderer/Notice.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Notification/Grid/Renderer/Notice.php
+++ b/app/code/core/Mage/Adminhtml/Block/Notification/Grid/Renderer/Notice.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Notification/Grid/Renderer/Notice.php
+++ b/app/code/core/Mage/Adminhtml/Block/Notification/Grid/Renderer/Notice.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Notification/Grid/Renderer/Severity.php
+++ b/app/code/core/Mage/Adminhtml/Block/Notification/Grid/Renderer/Severity.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Notification/Grid/Renderer/Severity.php
+++ b/app/code/core/Mage/Adminhtml/Block/Notification/Grid/Renderer/Severity.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Notification/Grid/Renderer/Severity.php
+++ b/app/code/core/Mage/Adminhtml/Block/Notification/Grid/Renderer/Severity.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Notification/Inbox.php
+++ b/app/code/core/Mage/Adminhtml/Block/Notification/Inbox.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Notification/Inbox.php
+++ b/app/code/core/Mage/Adminhtml/Block/Notification/Inbox.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Notification/Inbox.php
+++ b/app/code/core/Mage/Adminhtml/Block/Notification/Inbox.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Notification/Security.php
+++ b/app/code/core/Mage/Adminhtml/Block/Notification/Security.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Notification/Security.php
+++ b/app/code/core/Mage/Adminhtml/Block/Notification/Security.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Notification/Security.php
+++ b/app/code/core/Mage/Adminhtml/Block/Notification/Security.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Notification/Toolbar.php
+++ b/app/code/core/Mage/Adminhtml/Block/Notification/Toolbar.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Notification/Toolbar.php
+++ b/app/code/core/Mage/Adminhtml/Block/Notification/Toolbar.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Notification/Toolbar.php
+++ b/app/code/core/Mage/Adminhtml/Block/Notification/Toolbar.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Notification/Window.php
+++ b/app/code/core/Mage/Adminhtml/Block/Notification/Window.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Notification/Window.php
+++ b/app/code/core/Mage/Adminhtml/Block/Notification/Window.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Notification/Window.php
+++ b/app/code/core/Mage/Adminhtml/Block/Notification/Window.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Page.php
+++ b/app/code/core/Mage/Adminhtml/Block/Page.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Page.php
+++ b/app/code/core/Mage/Adminhtml/Block/Page.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Page.php
+++ b/app/code/core/Mage/Adminhtml/Block/Page.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Page/Footer.php
+++ b/app/code/core/Mage/Adminhtml/Block/Page/Footer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Page/Footer.php
+++ b/app/code/core/Mage/Adminhtml/Block/Page/Footer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Page/Footer.php
+++ b/app/code/core/Mage/Adminhtml/Block/Page/Footer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Page/Head.php
+++ b/app/code/core/Mage/Adminhtml/Block/Page/Head.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Page/Head.php
+++ b/app/code/core/Mage/Adminhtml/Block/Page/Head.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Page/Head.php
+++ b/app/code/core/Mage/Adminhtml/Block/Page/Head.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Page/Header.php
+++ b/app/code/core/Mage/Adminhtml/Block/Page/Header.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Page/Header.php
+++ b/app/code/core/Mage/Adminhtml/Block/Page/Header.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Page/Header.php
+++ b/app/code/core/Mage/Adminhtml/Block/Page/Header.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Page/Menu.php
+++ b/app/code/core/Mage/Adminhtml/Block/Page/Menu.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Page/Menu.php
+++ b/app/code/core/Mage/Adminhtml/Block/Page/Menu.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Page/Menu.php
+++ b/app/code/core/Mage/Adminhtml/Block/Page/Menu.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Page/Notices.php
+++ b/app/code/core/Mage/Adminhtml/Block/Page/Notices.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Page/Notices.php
+++ b/app/code/core/Mage/Adminhtml/Block/Page/Notices.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Page/Notices.php
+++ b/app/code/core/Mage/Adminhtml/Block/Page/Notices.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/Block.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/Block.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/Block.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/Block.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/Block.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/Block.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/Block/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/Block/Edit.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/Block/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/Block/Edit.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/Block/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/Block/Edit.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/Block/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/Block/Edit/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/Block/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/Block/Edit/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/Block/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/Block/Edit/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/Block/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/Block/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/Block/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/Block/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/Block/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/Block/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/Buttons.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/Buttons.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/Buttons.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/Buttons.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/Buttons.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/Buttons.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/Editroles.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/Editroles.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/Editroles.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/Editroles.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/Editroles.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/Editroles.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/Edituser.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/Edituser.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/Edituser.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/Edituser.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/Edituser.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/Edituser.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/Grid/Role.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/Grid/Role.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/Grid/Role.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/Grid/Role.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/Grid/Role.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/Grid/Role.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/Grid/User.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/Grid/User.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/Grid/User.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/Grid/User.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/Grid/User.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/Grid/User.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/Role.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/Role.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/Role.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/Role.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/Role.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/Role.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/Role/Grid/User.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/Role/Grid/User.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/Role/Grid/User.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/Role/Grid/User.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/Role/Grid/User.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/Role/Grid/User.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/Roles.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/Roles.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/Roles.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/Roles.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/Roles.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/Roles.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/Tab/Roleinfo.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/Tab/Roleinfo.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/Tab/Roleinfo.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/Tab/Roleinfo.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/Tab/Roleinfo.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/Tab/Roleinfo.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/Tab/Rolesedit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/Tab/Rolesedit.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/Tab/Rolesedit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/Tab/Rolesedit.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/Tab/Rolesedit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/Tab/Rolesedit.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/Tab/Rolesusers.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/Tab/Rolesusers.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/Tab/Rolesusers.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/Tab/Rolesusers.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/Tab/Rolesusers.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/Tab/Rolesusers.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/Tab/Useredit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/Tab/Useredit.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/Tab/Useredit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/Tab/Useredit.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/Tab/Useredit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/Tab/Useredit.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/Tab/Userroles.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/Tab/Userroles.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/Tab/Userroles.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/Tab/Userroles.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/Tab/Userroles.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/Tab/Userroles.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/User.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/User.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/User.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/User.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/User.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/User.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/User/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/User/Edit.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/User/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/User/Edit.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/User/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/User/Edit.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/User/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/User/Edit/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/User/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/User/Edit/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/User/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/User/Edit/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/User/Edit/Tab/Main.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/User/Edit/Tab/Main.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/User/Edit/Tab/Main.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/User/Edit/Tab/Main.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/User/Edit/Tab/Main.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/User/Edit/Tab/Main.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/User/Edit/Tab/Roles.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/User/Edit/Tab/Roles.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/User/Edit/Tab/Roles.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/User/Edit/Tab/Roles.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/User/Edit/Tab/Roles.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/User/Edit/Tab/Roles.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/User/Edit/Tabs.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/User/Edit/Tabs.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/User/Edit/Tabs.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/User/Edit/Tabs.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/User/Edit/Tabs.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/User/Edit/Tabs.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/User/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/User/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/User/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/User/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/User/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/User/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/Usernroles.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/Usernroles.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/Usernroles.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/Usernroles.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/Usernroles.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/Usernroles.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/Users.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/Users.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/Users.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/Users.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/Users.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/Users.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/Variable.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/Variable.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/Variable.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/Variable.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/Variable.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/Variable.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/Variable/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/Variable/Edit.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/Variable/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/Variable/Edit.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/Variable/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/Variable/Edit.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/Variable/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/Variable/Edit/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/Variable/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/Variable/Edit/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/Variable/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/Variable/Edit/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/Variable/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/Variable/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/Variable/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/Variable/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/Variable/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/Variable/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Poll/Answer/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Poll/Answer/Edit.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Poll/Answer/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Poll/Answer/Edit.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Poll/Answer/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Poll/Answer/Edit.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Poll/Answer/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Poll/Answer/Edit/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Poll/Answer/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Poll/Answer/Edit/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Poll/Answer/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Poll/Answer/Edit/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Poll/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Poll/Edit.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Poll/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Poll/Edit.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Poll/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Poll/Edit.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Poll/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Poll/Edit/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Poll/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Poll/Edit/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Poll/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Poll/Edit/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Poll/Edit/Tab/Answers.php
+++ b/app/code/core/Mage/Adminhtml/Block/Poll/Edit/Tab/Answers.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Poll/Edit/Tab/Answers.php
+++ b/app/code/core/Mage/Adminhtml/Block/Poll/Edit/Tab/Answers.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Poll/Edit/Tab/Answers.php
+++ b/app/code/core/Mage/Adminhtml/Block/Poll/Edit/Tab/Answers.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Poll/Edit/Tab/Answers/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Poll/Edit/Tab/Answers/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Poll/Edit/Tab/Answers/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Poll/Edit/Tab/Answers/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Poll/Edit/Tab/Answers/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Poll/Edit/Tab/Answers/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Poll/Edit/Tab/Answers/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Poll/Edit/Tab/Answers/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Poll/Edit/Tab/Answers/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Poll/Edit/Tab/Answers/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Poll/Edit/Tab/Answers/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Poll/Edit/Tab/Answers/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Poll/Edit/Tab/Answers/List.php
+++ b/app/code/core/Mage/Adminhtml/Block/Poll/Edit/Tab/Answers/List.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Poll/Edit/Tab/Answers/List.php
+++ b/app/code/core/Mage/Adminhtml/Block/Poll/Edit/Tab/Answers/List.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Poll/Edit/Tab/Answers/List.php
+++ b/app/code/core/Mage/Adminhtml/Block/Poll/Edit/Tab/Answers/List.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Poll/Edit/Tab/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Poll/Edit/Tab/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Poll/Edit/Tab/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Poll/Edit/Tab/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Poll/Edit/Tab/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Poll/Edit/Tab/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Poll/Edit/Tabs.php
+++ b/app/code/core/Mage/Adminhtml/Block/Poll/Edit/Tabs.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Poll/Edit/Tabs.php
+++ b/app/code/core/Mage/Adminhtml/Block/Poll/Edit/Tabs.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Poll/Edit/Tabs.php
+++ b/app/code/core/Mage/Adminhtml/Block/Poll/Edit/Tabs.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Poll/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Poll/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Poll/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Poll/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Poll/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Poll/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Poll/Poll.php
+++ b/app/code/core/Mage/Adminhtml/Block/Poll/Poll.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Poll/Poll.php
+++ b/app/code/core/Mage/Adminhtml/Block/Poll/Poll.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Poll/Poll.php
+++ b/app/code/core/Mage/Adminhtml/Block/Poll/Poll.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Promo/Catalog.php
+++ b/app/code/core/Mage/Adminhtml/Block/Promo/Catalog.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Promo/Catalog.php
+++ b/app/code/core/Mage/Adminhtml/Block/Promo/Catalog.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Promo/Catalog.php
+++ b/app/code/core/Mage/Adminhtml/Block/Promo/Catalog.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Promo/Catalog/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Promo/Catalog/Edit.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Promo/Catalog/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Promo/Catalog/Edit.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Promo/Catalog/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Promo/Catalog/Edit.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Promo/Catalog/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Promo/Catalog/Edit/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Promo/Catalog/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Promo/Catalog/Edit/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Promo/Catalog/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Promo/Catalog/Edit/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Promo/Catalog/Edit/Js.php
+++ b/app/code/core/Mage/Adminhtml/Block/Promo/Catalog/Edit/Js.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Promo/Catalog/Edit/Js.php
+++ b/app/code/core/Mage/Adminhtml/Block/Promo/Catalog/Edit/Js.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Promo/Catalog/Edit/Js.php
+++ b/app/code/core/Mage/Adminhtml/Block/Promo/Catalog/Edit/Js.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Promo/Catalog/Edit/Tab/Actions.php
+++ b/app/code/core/Mage/Adminhtml/Block/Promo/Catalog/Edit/Tab/Actions.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Promo/Catalog/Edit/Tab/Actions.php
+++ b/app/code/core/Mage/Adminhtml/Block/Promo/Catalog/Edit/Tab/Actions.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Promo/Catalog/Edit/Tab/Actions.php
+++ b/app/code/core/Mage/Adminhtml/Block/Promo/Catalog/Edit/Tab/Actions.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Promo/Catalog/Edit/Tab/Conditions.php
+++ b/app/code/core/Mage/Adminhtml/Block/Promo/Catalog/Edit/Tab/Conditions.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Promo/Catalog/Edit/Tab/Conditions.php
+++ b/app/code/core/Mage/Adminhtml/Block/Promo/Catalog/Edit/Tab/Conditions.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Promo/Catalog/Edit/Tab/Conditions.php
+++ b/app/code/core/Mage/Adminhtml/Block/Promo/Catalog/Edit/Tab/Conditions.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Promo/Catalog/Edit/Tab/Main.php
+++ b/app/code/core/Mage/Adminhtml/Block/Promo/Catalog/Edit/Tab/Main.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Promo/Catalog/Edit/Tab/Main.php
+++ b/app/code/core/Mage/Adminhtml/Block/Promo/Catalog/Edit/Tab/Main.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Promo/Catalog/Edit/Tab/Main.php
+++ b/app/code/core/Mage/Adminhtml/Block/Promo/Catalog/Edit/Tab/Main.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Promo/Catalog/Edit/Tabs.php
+++ b/app/code/core/Mage/Adminhtml/Block/Promo/Catalog/Edit/Tabs.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Promo/Catalog/Edit/Tabs.php
+++ b/app/code/core/Mage/Adminhtml/Block/Promo/Catalog/Edit/Tabs.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Promo/Catalog/Edit/Tabs.php
+++ b/app/code/core/Mage/Adminhtml/Block/Promo/Catalog/Edit/Tabs.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Promo/Catalog/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Promo/Catalog/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Promo/Catalog/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Promo/Catalog/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Promo/Catalog/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Promo/Catalog/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Promo/Quote.php
+++ b/app/code/core/Mage/Adminhtml/Block/Promo/Quote.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Promo/Quote.php
+++ b/app/code/core/Mage/Adminhtml/Block/Promo/Quote.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Promo/Quote.php
+++ b/app/code/core/Mage/Adminhtml/Block/Promo/Quote.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Edit.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Edit.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Edit.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Edit/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Edit/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Edit/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Edit/Tab/Actions.php
+++ b/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Edit/Tab/Actions.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Edit/Tab/Actions.php
+++ b/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Edit/Tab/Actions.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Edit/Tab/Actions.php
+++ b/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Edit/Tab/Actions.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Edit/Tab/Conditions.php
+++ b/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Edit/Tab/Conditions.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Edit/Tab/Conditions.php
+++ b/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Edit/Tab/Conditions.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Edit/Tab/Conditions.php
+++ b/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Edit/Tab/Conditions.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Edit/Tab/Coupons.php
+++ b/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Edit/Tab/Coupons.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Edit/Tab/Coupons.php
+++ b/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Edit/Tab/Coupons.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Edit/Tab/Coupons.php
+++ b/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Edit/Tab/Coupons.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Edit/Tab/Coupons/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Edit/Tab/Coupons/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Edit/Tab/Coupons/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Edit/Tab/Coupons/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Edit/Tab/Coupons/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Edit/Tab/Coupons/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Edit/Tab/Coupons/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Edit/Tab/Coupons/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Edit/Tab/Coupons/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Edit/Tab/Coupons/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Edit/Tab/Coupons/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Edit/Tab/Coupons/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Edit/Tab/Coupons/Grid/Column/Renderer/Used.php
+++ b/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Edit/Tab/Coupons/Grid/Column/Renderer/Used.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Edit/Tab/Coupons/Grid/Column/Renderer/Used.php
+++ b/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Edit/Tab/Coupons/Grid/Column/Renderer/Used.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Edit/Tab/Coupons/Grid/Column/Renderer/Used.php
+++ b/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Edit/Tab/Coupons/Grid/Column/Renderer/Used.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Edit/Tab/Labels.php
+++ b/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Edit/Tab/Labels.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Edit/Tab/Labels.php
+++ b/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Edit/Tab/Labels.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Edit/Tab/Labels.php
+++ b/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Edit/Tab/Labels.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Edit/Tab/Main.php
+++ b/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Edit/Tab/Main.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Edit/Tab/Main.php
+++ b/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Edit/Tab/Main.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Edit/Tab/Main.php
+++ b/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Edit/Tab/Main.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Edit/Tab/Main/Renderer/Checkbox.php
+++ b/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Edit/Tab/Main/Renderer/Checkbox.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Edit/Tab/Main/Renderer/Checkbox.php
+++ b/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Edit/Tab/Main/Renderer/Checkbox.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Edit/Tab/Main/Renderer/Checkbox.php
+++ b/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Edit/Tab/Main/Renderer/Checkbox.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Edit/Tabs.php
+++ b/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Edit/Tabs.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Edit/Tabs.php
+++ b/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Edit/Tabs.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Edit/Tabs.php
+++ b/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Edit/Tabs.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Promo/Widget/Chooser.php
+++ b/app/code/core/Mage/Adminhtml/Block/Promo/Widget/Chooser.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Promo/Widget/Chooser.php
+++ b/app/code/core/Mage/Adminhtml/Block/Promo/Widget/Chooser.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Promo/Widget/Chooser.php
+++ b/app/code/core/Mage/Adminhtml/Block/Promo/Widget/Chooser.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Promo/Widget/Chooser/Daterange.php
+++ b/app/code/core/Mage/Adminhtml/Block/Promo/Widget/Chooser/Daterange.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Promo/Widget/Chooser/Daterange.php
+++ b/app/code/core/Mage/Adminhtml/Block/Promo/Widget/Chooser/Daterange.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Promo/Widget/Chooser/Daterange.php
+++ b/app/code/core/Mage/Adminhtml/Block/Promo/Widget/Chooser/Daterange.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Promo/Widget/Chooser/Sku.php
+++ b/app/code/core/Mage/Adminhtml/Block/Promo/Widget/Chooser/Sku.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Promo/Widget/Chooser/Sku.php
+++ b/app/code/core/Mage/Adminhtml/Block/Promo/Widget/Chooser/Sku.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Promo/Widget/Chooser/Sku.php
+++ b/app/code/core/Mage/Adminhtml/Block/Promo/Widget/Chooser/Sku.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Rating/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Rating/Edit.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Rating/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Rating/Edit.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Rating/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Rating/Edit.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Rating/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Rating/Edit/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Rating/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Rating/Edit/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Rating/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Rating/Edit/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Rating/Edit/Tab/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Rating/Edit/Tab/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Rating/Edit/Tab/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Rating/Edit/Tab/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Rating/Edit/Tab/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Rating/Edit/Tab/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Rating/Edit/Tab/Options.php
+++ b/app/code/core/Mage/Adminhtml/Block/Rating/Edit/Tab/Options.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Rating/Edit/Tab/Options.php
+++ b/app/code/core/Mage/Adminhtml/Block/Rating/Edit/Tab/Options.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Rating/Edit/Tab/Options.php
+++ b/app/code/core/Mage/Adminhtml/Block/Rating/Edit/Tab/Options.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Rating/Edit/Tabs.php
+++ b/app/code/core/Mage/Adminhtml/Block/Rating/Edit/Tabs.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Rating/Edit/Tabs.php
+++ b/app/code/core/Mage/Adminhtml/Block/Rating/Edit/Tabs.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Rating/Edit/Tabs.php
+++ b/app/code/core/Mage/Adminhtml/Block/Rating/Edit/Tabs.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Rating/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Rating/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Rating/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Rating/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Rating/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Rating/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Rating/Rating.php
+++ b/app/code/core/Mage/Adminhtml/Block/Rating/Rating.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Rating/Rating.php
+++ b/app/code/core/Mage/Adminhtml/Block/Rating/Rating.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Rating/Rating.php
+++ b/app/code/core/Mage/Adminhtml/Block/Rating/Rating.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Config/Form/Field/MtdStart.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Config/Form/Field/MtdStart.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Report/Config/Form/Field/MtdStart.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Config/Form/Field/MtdStart.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Config/Form/Field/MtdStart.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Config/Form/Field/MtdStart.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Config/Form/Field/YtdStart.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Config/Form/Field/YtdStart.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Report/Config/Form/Field/YtdStart.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Config/Form/Field/YtdStart.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Config/Form/Field/YtdStart.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Config/Form/Field/YtdStart.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Customer/Accounts.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Customer/Accounts.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Report/Customer/Accounts.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Customer/Accounts.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Customer/Accounts.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Customer/Accounts.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Customer/Accounts/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Customer/Accounts/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Report/Customer/Accounts/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Customer/Accounts/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Customer/Accounts/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Customer/Accounts/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Customer/Orders.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Customer/Orders.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Report/Customer/Orders.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Customer/Orders.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Customer/Orders.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Customer/Orders.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Customer/Orders/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Customer/Orders/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Report/Customer/Orders/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Customer/Orders/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Customer/Orders/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Customer/Orders/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Customer/Totals.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Customer/Totals.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Report/Customer/Totals.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Customer/Totals.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Customer/Totals.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Customer/Totals.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Customer/Totals/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Customer/Totals/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Report/Customer/Totals/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Customer/Totals/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Customer/Totals/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Customer/Totals/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Filter/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Filter/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Report/Filter/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Filter/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Filter/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Filter/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Report/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Grid/Abstract.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Grid/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Report/Grid/Abstract.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Grid/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Grid/Abstract.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Grid/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Grid/Column/Renderer/Blanknumber.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Grid/Column/Renderer/Blanknumber.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Report/Grid/Column/Renderer/Blanknumber.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Grid/Column/Renderer/Blanknumber.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Grid/Column/Renderer/Blanknumber.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Grid/Column/Renderer/Blanknumber.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Grid/Column/Renderer/Currency.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Grid/Column/Renderer/Currency.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Report/Grid/Column/Renderer/Currency.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Grid/Column/Renderer/Currency.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Grid/Column/Renderer/Currency.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Grid/Column/Renderer/Currency.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Grid/Column/Renderer/Customer.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Grid/Column/Renderer/Customer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Report/Grid/Column/Renderer/Customer.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Grid/Column/Renderer/Customer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Grid/Column/Renderer/Customer.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Grid/Column/Renderer/Customer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Grid/Column/Renderer/Product.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Grid/Column/Renderer/Product.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Report/Grid/Column/Renderer/Product.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Grid/Column/Renderer/Product.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Grid/Column/Renderer/Product.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Grid/Column/Renderer/Product.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Grid/Shopcart.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Grid/Shopcart.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Report/Grid/Shopcart.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Grid/Shopcart.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Grid/Shopcart.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Grid/Shopcart.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Product.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Product.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Report/Product.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Product.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Product.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Product.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Product/Downloads.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Product/Downloads.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Report/Product/Downloads.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Product/Downloads.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Product/Downloads.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Product/Downloads.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Product/Downloads/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Product/Downloads/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Report/Product/Downloads/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Product/Downloads/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Product/Downloads/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Product/Downloads/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Product/Downloads/Renderer/Purchases.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Product/Downloads/Renderer/Purchases.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Report/Product/Downloads/Renderer/Purchases.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Product/Downloads/Renderer/Purchases.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Product/Downloads/Renderer/Purchases.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Product/Downloads/Renderer/Purchases.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Product/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Product/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Report/Product/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Product/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Product/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Product/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Product/Lowstock.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Product/Lowstock.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Report/Product/Lowstock.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Product/Lowstock.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Product/Lowstock.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Product/Lowstock.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Product/Lowstock/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Product/Lowstock/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Report/Product/Lowstock/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Product/Lowstock/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Product/Lowstock/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Product/Lowstock/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Product/Ordered.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Product/Ordered.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Report/Product/Ordered.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Product/Ordered.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Product/Ordered.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Product/Ordered.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Product/Ordered/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Product/Ordered/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Report/Product/Ordered/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Product/Ordered/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Product/Ordered/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Product/Ordered/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Product/Sold.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Product/Sold.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Report/Product/Sold.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Product/Sold.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Product/Sold.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Product/Sold.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Product/Sold/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Product/Sold/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Report/Product/Sold/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Product/Sold/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Product/Sold/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Product/Sold/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Product/Viewed.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Product/Viewed.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Report/Product/Viewed.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Product/Viewed.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Product/Viewed.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Product/Viewed.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Product/Viewed/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Product/Viewed/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Report/Product/Viewed/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Product/Viewed/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Product/Viewed/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Product/Viewed/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Refresh/Statistics.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Refresh/Statistics.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Report/Refresh/Statistics.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Refresh/Statistics.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Refresh/Statistics.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Refresh/Statistics.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Refresh/Statistics/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Refresh/Statistics/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Report/Refresh/Statistics/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Refresh/Statistics/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Refresh/Statistics/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Refresh/Statistics/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Review/Customer.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Review/Customer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Report/Review/Customer.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Review/Customer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Review/Customer.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Review/Customer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Review/Customer/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Review/Customer/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Report/Review/Customer/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Review/Customer/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Review/Customer/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Review/Customer/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Review/Detail.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Review/Detail.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Report/Review/Detail.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Review/Detail.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Review/Detail.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Review/Detail.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Review/Detail/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Review/Detail/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Report/Review/Detail/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Review/Detail/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Review/Detail/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Review/Detail/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Review/Product.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Review/Product.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Report/Review/Product.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Review/Product.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Review/Product.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Review/Product.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Review/Product/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Review/Product/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Report/Review/Product/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Review/Product/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Review/Product/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Review/Product/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Sales/Bestsellers.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Sales/Bestsellers.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Report/Sales/Bestsellers.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Sales/Bestsellers.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Sales/Bestsellers.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Sales/Bestsellers.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Sales/Bestsellers/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Sales/Bestsellers/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Report/Sales/Bestsellers/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Sales/Bestsellers/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Sales/Bestsellers/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Sales/Bestsellers/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Sales/Coupons.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Sales/Coupons.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Report/Sales/Coupons.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Sales/Coupons.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Sales/Coupons.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Sales/Coupons.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Sales/Coupons/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Sales/Coupons/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Report/Sales/Coupons/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Sales/Coupons/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Sales/Coupons/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Sales/Coupons/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Sales/Grid/Column/Renderer/Date.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Sales/Grid/Column/Renderer/Date.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Report/Sales/Grid/Column/Renderer/Date.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Sales/Grid/Column/Renderer/Date.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Sales/Grid/Column/Renderer/Date.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Sales/Grid/Column/Renderer/Date.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Sales/Invoiced.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Sales/Invoiced.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Report/Sales/Invoiced.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Sales/Invoiced.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Sales/Invoiced.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Sales/Invoiced.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Sales/Invoiced/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Sales/Invoiced/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Report/Sales/Invoiced/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Sales/Invoiced/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Sales/Invoiced/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Sales/Invoiced/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Sales/Refunded.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Sales/Refunded.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Report/Sales/Refunded.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Sales/Refunded.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Sales/Refunded.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Sales/Refunded.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Sales/Refunded/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Sales/Refunded/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Report/Sales/Refunded/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Sales/Refunded/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Sales/Refunded/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Sales/Refunded/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Sales/Sales.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Sales/Sales.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Report/Sales/Sales.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Sales/Sales.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Sales/Sales.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Sales/Sales.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Sales/Sales/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Sales/Sales/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Report/Sales/Sales/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Sales/Sales/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Sales/Sales/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Sales/Sales/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Sales/Shipping.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Sales/Shipping.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Report/Sales/Shipping.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Sales/Shipping.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Sales/Shipping.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Sales/Shipping.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Sales/Shipping/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Sales/Shipping/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Report/Sales/Shipping/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Sales/Shipping/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Sales/Shipping/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Sales/Shipping/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Sales/Tax.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Sales/Tax.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Report/Sales/Tax.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Sales/Tax.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Sales/Tax.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Sales/Tax.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Sales/Tax/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Sales/Tax/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Report/Sales/Tax/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Sales/Tax/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Sales/Tax/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Sales/Tax/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Search.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Search.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Report/Search.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Search.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Search.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Search.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Search/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Search/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Report/Search/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Search/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Search/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Search/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Shopcart/Abandoned.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Shopcart/Abandoned.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Report/Shopcart/Abandoned.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Shopcart/Abandoned.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Shopcart/Abandoned.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Shopcart/Abandoned.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Shopcart/Abandoned/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Shopcart/Abandoned/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Report/Shopcart/Abandoned/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Shopcart/Abandoned/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Shopcart/Abandoned/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Shopcart/Abandoned/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Shopcart/Customer.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Shopcart/Customer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Report/Shopcart/Customer.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Shopcart/Customer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Shopcart/Customer.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Shopcart/Customer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Shopcart/Customer/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Shopcart/Customer/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Report/Shopcart/Customer/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Shopcart/Customer/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Shopcart/Customer/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Shopcart/Customer/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Shopcart/Product.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Shopcart/Product.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Report/Shopcart/Product.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Shopcart/Product.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Shopcart/Product.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Shopcart/Product.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Shopcart/Product/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Shopcart/Product/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Report/Shopcart/Product/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Shopcart/Product/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Shopcart/Product/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Shopcart/Product/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Tag/Customer.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Tag/Customer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Report/Tag/Customer.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Tag/Customer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Tag/Customer.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Tag/Customer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Tag/Customer/Detail.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Tag/Customer/Detail.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Report/Tag/Customer/Detail.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Tag/Customer/Detail.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Tag/Customer/Detail.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Tag/Customer/Detail.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Tag/Customer/Detail/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Tag/Customer/Detail/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Report/Tag/Customer/Detail/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Tag/Customer/Detail/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Tag/Customer/Detail/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Tag/Customer/Detail/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Tag/Customer/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Tag/Customer/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Report/Tag/Customer/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Tag/Customer/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Tag/Customer/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Tag/Customer/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Tag/Popular.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Tag/Popular.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Report/Tag/Popular.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Tag/Popular.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Tag/Popular.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Tag/Popular.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Tag/Popular/Detail.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Tag/Popular/Detail.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Report/Tag/Popular/Detail.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Tag/Popular/Detail.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Tag/Popular/Detail.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Tag/Popular/Detail.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Tag/Popular/Detail/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Tag/Popular/Detail/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Report/Tag/Popular/Detail/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Tag/Popular/Detail/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Tag/Popular/Detail/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Tag/Popular/Detail/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Tag/Popular/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Tag/Popular/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Report/Tag/Popular/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Tag/Popular/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Tag/Popular/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Tag/Popular/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Tag/Product.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Tag/Product.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Report/Tag/Product.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Tag/Product.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Tag/Product.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Tag/Product.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Tag/Product/Detail.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Tag/Product/Detail.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Report/Tag/Product/Detail.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Tag/Product/Detail.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Tag/Product/Detail.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Tag/Product/Detail.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Tag/Product/Detail/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Tag/Product/Detail/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Report/Tag/Product/Detail/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Tag/Product/Detail/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Tag/Product/Detail/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Tag/Product/Detail/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Tag/Product/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Tag/Product/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Report/Tag/Product/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Tag/Product/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Tag/Product/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Tag/Product/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Wishlist.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Wishlist.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Report/Wishlist.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Wishlist.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Wishlist.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Wishlist.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Wishlist/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Wishlist/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Report/Wishlist/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Wishlist/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Report/Wishlist/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Wishlist/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Review/Add.php
+++ b/app/code/core/Mage/Adminhtml/Block/Review/Add.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Review/Add.php
+++ b/app/code/core/Mage/Adminhtml/Block/Review/Add.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Review/Add.php
+++ b/app/code/core/Mage/Adminhtml/Block/Review/Add.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Review/Add/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Review/Add/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Review/Add/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Review/Add/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Review/Add/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Review/Add/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Review/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Review/Edit.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Review/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Review/Edit.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Review/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Review/Edit.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Review/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Review/Edit/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Review/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Review/Edit/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Review/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Review/Edit/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Review/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Review/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Review/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Review/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Review/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Review/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Review/Grid/Filter/Type.php
+++ b/app/code/core/Mage/Adminhtml/Block/Review/Grid/Filter/Type.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Review/Grid/Filter/Type.php
+++ b/app/code/core/Mage/Adminhtml/Block/Review/Grid/Filter/Type.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Review/Grid/Filter/Type.php
+++ b/app/code/core/Mage/Adminhtml/Block/Review/Grid/Filter/Type.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Review/Grid/Renderer/Type.php
+++ b/app/code/core/Mage/Adminhtml/Block/Review/Grid/Renderer/Type.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Review/Grid/Renderer/Type.php
+++ b/app/code/core/Mage/Adminhtml/Block/Review/Grid/Renderer/Type.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Review/Grid/Renderer/Type.php
+++ b/app/code/core/Mage/Adminhtml/Block/Review/Grid/Renderer/Type.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Review/Main.php
+++ b/app/code/core/Mage/Adminhtml/Block/Review/Main.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Review/Main.php
+++ b/app/code/core/Mage/Adminhtml/Block/Review/Main.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Review/Main.php
+++ b/app/code/core/Mage/Adminhtml/Block/Review/Main.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Review/Product/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Review/Product/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Review/Product/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Review/Product/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Review/Product/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Review/Product/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Review/Rating/Detailed.php
+++ b/app/code/core/Mage/Adminhtml/Block/Review/Rating/Detailed.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Review/Rating/Detailed.php
+++ b/app/code/core/Mage/Adminhtml/Block/Review/Rating/Detailed.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Review/Rating/Detailed.php
+++ b/app/code/core/Mage/Adminhtml/Block/Review/Rating/Detailed.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Review/Rating/Summary.php
+++ b/app/code/core/Mage/Adminhtml/Block/Review/Rating/Summary.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Review/Rating/Summary.php
+++ b/app/code/core/Mage/Adminhtml/Block/Review/Rating/Summary.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Review/Rating/Summary.php
+++ b/app/code/core/Mage/Adminhtml/Block/Review/Rating/Summary.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Creditmemo.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Creditmemo.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Creditmemo.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Creditmemo.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Creditmemo.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Creditmemo.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Creditmemo/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Creditmemo/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Creditmemo/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Creditmemo/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Creditmemo/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Creditmemo/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Invoice.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Invoice.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Invoice.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Invoice.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Invoice.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Invoice.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Invoice/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Invoice/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Invoice/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Invoice/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Invoice/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Invoice/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Items/Abstract.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Items/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Items/Abstract.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Items/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Items/Abstract.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Items/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Items/Column/Default.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Items/Column/Default.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Items/Column/Default.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Items/Column/Default.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Items/Column/Default.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Items/Column/Default.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Items/Column/Name.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Items/Column/Name.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Items/Column/Name.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Items/Column/Name.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Items/Column/Name.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Items/Column/Name.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Items/Column/Name/Grouped.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Items/Column/Name/Grouped.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Items/Column/Name/Grouped.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Items/Column/Name/Grouped.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Items/Column/Name/Grouped.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Items/Column/Name/Grouped.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Items/Column/Qty.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Items/Column/Qty.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Items/Column/Qty.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Items/Column/Qty.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Items/Column/Qty.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Items/Column/Qty.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Items/Renderer/Configurable.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Items/Renderer/Configurable.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Items/Renderer/Configurable.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Items/Renderer/Configurable.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Items/Renderer/Configurable.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Items/Renderer/Configurable.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Items/Renderer/Default.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Items/Renderer/Default.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Items/Renderer/Default.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Items/Renderer/Default.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Items/Renderer/Default.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Items/Renderer/Default.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Abstract.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Abstract.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Abstract.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Address.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Address.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Address.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Address.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Address.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Address.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Address/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Address/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Address/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Address/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Address/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Address/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Comments/View.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Comments/View.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Comments/View.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Comments/View.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Comments/View.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Comments/View.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Abstract.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Abstract.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Abstract.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Billing/Address.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Billing/Address.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Billing/Address.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Billing/Address.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Billing/Address.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Billing/Address.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Billing/Method.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Billing/Method.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Billing/Method.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Billing/Method.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Billing/Method.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Billing/Method.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Billing/Method/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Billing/Method/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Billing/Method/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Billing/Method/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Billing/Method/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Billing/Method/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Comment.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Comment.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Comment.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Comment.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Comment.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Comment.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Coupons.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Coupons.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Coupons.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Coupons.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Coupons.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Coupons.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Coupons/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Coupons/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Coupons/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Coupons/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Coupons/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Coupons/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Customer.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Customer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Customer.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Customer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Customer.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Customer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Customer/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Customer/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Customer/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Customer/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Customer/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Customer/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Data.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Data.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Data.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Data.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Data.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Data.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Form/Abstract.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Form/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Form/Abstract.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Form/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Form/Abstract.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Form/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Form/Account.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Form/Account.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Form/Account.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Form/Account.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Form/Account.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Form/Account.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Form/Address.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Form/Address.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Form/Address.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Form/Address.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Form/Address.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Form/Address.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Giftmessage.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Giftmessage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Giftmessage.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Giftmessage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Giftmessage.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Giftmessage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Giftmessage/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Giftmessage/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Giftmessage/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Giftmessage/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Giftmessage/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Giftmessage/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Header.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Header.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Header.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Header.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Header.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Header.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Items.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Items.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Items.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Items.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Items.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Items.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Items/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Items/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Items/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Items/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Items/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Items/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Load.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Load.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Load.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Load.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Load.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Load.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Messages.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Messages.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Messages.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Messages.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Messages.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Messages.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Newsletter.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Newsletter.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Newsletter.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Newsletter.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Newsletter.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Newsletter.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Newsletter/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Newsletter/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Newsletter/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Newsletter/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Newsletter/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Newsletter/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Search.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Search.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Search.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Search.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Search.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Search.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Search/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Search/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Search/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Search/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Search/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Search/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Search/Grid/Renderer/Giftmessage.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Search/Grid/Renderer/Giftmessage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Search/Grid/Renderer/Giftmessage.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Search/Grid/Renderer/Giftmessage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Search/Grid/Renderer/Giftmessage.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Search/Grid/Renderer/Giftmessage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Search/Grid/Renderer/Price.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Search/Grid/Renderer/Price.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Search/Grid/Renderer/Price.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Search/Grid/Renderer/Price.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Search/Grid/Renderer/Price.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Search/Grid/Renderer/Price.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Search/Grid/Renderer/Product.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Search/Grid/Renderer/Product.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Search/Grid/Renderer/Product.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Search/Grid/Renderer/Product.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Search/Grid/Renderer/Product.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Search/Grid/Renderer/Product.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Search/Grid/Renderer/Qty.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Search/Grid/Renderer/Qty.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Search/Grid/Renderer/Qty.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Search/Grid/Renderer/Qty.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Search/Grid/Renderer/Qty.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Search/Grid/Renderer/Qty.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Shipping/Address.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Shipping/Address.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Shipping/Address.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Shipping/Address.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Shipping/Address.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Shipping/Address.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Shipping/Method.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Shipping/Method.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Shipping/Method.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Shipping/Method.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Shipping/Method.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Shipping/Method.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Shipping/Method/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Shipping/Method/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Shipping/Method/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Shipping/Method/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Shipping/Method/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Shipping/Method/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Sidebar.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Sidebar.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Sidebar.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Sidebar.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Sidebar.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Sidebar.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Sidebar/Abstract.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Sidebar/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Sidebar/Abstract.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Sidebar/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Sidebar/Abstract.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Sidebar/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Sidebar/Cart.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Sidebar/Cart.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Sidebar/Cart.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Sidebar/Cart.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Sidebar/Cart.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Sidebar/Cart.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Sidebar/Compared.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Sidebar/Compared.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Sidebar/Compared.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Sidebar/Compared.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Sidebar/Compared.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Sidebar/Compared.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Sidebar/Pcompared.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Sidebar/Pcompared.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Sidebar/Pcompared.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Sidebar/Pcompared.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Sidebar/Pcompared.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Sidebar/Pcompared.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Sidebar/Pviewed.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Sidebar/Pviewed.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Sidebar/Pviewed.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Sidebar/Pviewed.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Sidebar/Pviewed.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Sidebar/Pviewed.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Sidebar/Reorder.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Sidebar/Reorder.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Sidebar/Reorder.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Sidebar/Reorder.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Sidebar/Reorder.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Sidebar/Reorder.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Sidebar/Viewed.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Sidebar/Viewed.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Sidebar/Viewed.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Sidebar/Viewed.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Sidebar/Viewed.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Sidebar/Viewed.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Sidebar/Wishlist.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Sidebar/Wishlist.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Sidebar/Wishlist.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Sidebar/Wishlist.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Sidebar/Wishlist.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Sidebar/Wishlist.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Store.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Store.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Store.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Store.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Store.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Store.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Store/Select.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Store/Select.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Store/Select.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Store/Select.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Store/Select.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Store/Select.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Totals.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Totals.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Totals.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Totals.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Totals.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Totals.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Totals/Default.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Totals/Default.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Totals/Default.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Totals/Default.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Totals/Default.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Totals/Default.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Totals/Discount.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Totals/Discount.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Totals/Discount.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Totals/Discount.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Totals/Discount.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Totals/Discount.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Totals/Grandtotal.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Totals/Grandtotal.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Totals/Grandtotal.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Totals/Grandtotal.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Totals/Grandtotal.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Totals/Grandtotal.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Totals/Shipping.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Totals/Shipping.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Totals/Shipping.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Totals/Shipping.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Totals/Shipping.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Totals/Shipping.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Totals/Subtotal.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Totals/Subtotal.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Totals/Subtotal.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Totals/Subtotal.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Totals/Subtotal.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Totals/Subtotal.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Totals/Table.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Totals/Table.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Totals/Table.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Totals/Table.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Totals/Table.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Totals/Table.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Totals/Tax.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Totals/Tax.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Totals/Tax.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Totals/Tax.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Totals/Tax.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Totals/Tax.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Creditmemo/Create.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Creditmemo/Create.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Creditmemo/Create.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Creditmemo/Create.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Creditmemo/Create.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Creditmemo/Create.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Creditmemo/Create/Adjustments.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Creditmemo/Create/Adjustments.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Creditmemo/Create/Adjustments.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Creditmemo/Create/Adjustments.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Creditmemo/Create/Adjustments.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Creditmemo/Create/Adjustments.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Creditmemo/Create/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Creditmemo/Create/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Creditmemo/Create/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Creditmemo/Create/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Creditmemo/Create/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Creditmemo/Create/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Creditmemo/Create/Items.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Creditmemo/Create/Items.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Creditmemo/Create/Items.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Creditmemo/Create/Items.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Creditmemo/Create/Items.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Creditmemo/Create/Items.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Creditmemo/Totals.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Creditmemo/Totals.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Creditmemo/Totals.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Creditmemo/Totals.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Creditmemo/Totals.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Creditmemo/Totals.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Creditmemo/View.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Creditmemo/View.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Creditmemo/View.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Creditmemo/View.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Creditmemo/View.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Creditmemo/View.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Creditmemo/View/Comments.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Creditmemo/View/Comments.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Creditmemo/View/Comments.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Creditmemo/View/Comments.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Creditmemo/View/Comments.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Creditmemo/View/Comments.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Creditmemo/View/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Creditmemo/View/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Creditmemo/View/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Creditmemo/View/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Creditmemo/View/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Creditmemo/View/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Creditmemo/View/Items.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Creditmemo/View/Items.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Creditmemo/View/Items.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Creditmemo/View/Items.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Creditmemo/View/Items.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Creditmemo/View/Items.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Invoice/Create.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Invoice/Create.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Invoice/Create.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Invoice/Create.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Invoice/Create.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Invoice/Create.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Invoice/Create/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Invoice/Create/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Invoice/Create/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Invoice/Create/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Invoice/Create/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Invoice/Create/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Invoice/Create/Items.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Invoice/Create/Items.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Invoice/Create/Items.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Invoice/Create/Items.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Invoice/Create/Items.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Invoice/Create/Items.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Invoice/Create/Tracking.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Invoice/Create/Tracking.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Invoice/Create/Tracking.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Invoice/Create/Tracking.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Invoice/Create/Tracking.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Invoice/Create/Tracking.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Invoice/Totals.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Invoice/Totals.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Invoice/Totals.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Invoice/Totals.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Invoice/Totals.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Invoice/Totals.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Invoice/View.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Invoice/View.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Invoice/View.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Invoice/View.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Invoice/View.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Invoice/View.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Invoice/View/Comments.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Invoice/View/Comments.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Invoice/View/Comments.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Invoice/View/Comments.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Invoice/View/Comments.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Invoice/View/Comments.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Invoice/View/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Invoice/View/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Invoice/View/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Invoice/View/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Invoice/View/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Invoice/View/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Invoice/View/Items.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Invoice/View/Items.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Invoice/View/Items.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Invoice/View/Items.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Invoice/View/Items.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Invoice/View/Items.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Payment.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Payment.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Payment.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Payment.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Payment.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Payment.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Shipment/Create.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Shipment/Create.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Shipment/Create.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Shipment/Create.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Shipment/Create.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Shipment/Create.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Shipment/Create/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Shipment/Create/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Shipment/Create/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Shipment/Create/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Shipment/Create/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Shipment/Create/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Shipment/Create/Items.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Shipment/Create/Items.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Shipment/Create/Items.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Shipment/Create/Items.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Shipment/Create/Items.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Shipment/Create/Items.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Shipment/Create/Tracking.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Shipment/Create/Tracking.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Shipment/Create/Tracking.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Shipment/Create/Tracking.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Shipment/Create/Tracking.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Shipment/Create/Tracking.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Shipment/Packaging.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Shipment/Packaging.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Shipment/Packaging.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Shipment/Packaging.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Shipment/Packaging.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Shipment/Packaging.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Shipment/Packaging/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Shipment/Packaging/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Shipment/Packaging/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Shipment/Packaging/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Shipment/Packaging/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Shipment/Packaging/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Shipment/Tracking/Info.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Shipment/Tracking/Info.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Shipment/Tracking/Info.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Shipment/Tracking/Info.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Shipment/Tracking/Info.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Shipment/Tracking/Info.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Shipment/View.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Shipment/View.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Shipment/View.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Shipment/View.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Shipment/View.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Shipment/View.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Shipment/View/Comments.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Shipment/View/Comments.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Shipment/View/Comments.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Shipment/View/Comments.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Shipment/View/Comments.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Shipment/View/Comments.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Shipment/View/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Shipment/View/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Shipment/View/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Shipment/View/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Shipment/View/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Shipment/View/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Shipment/View/Items.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Shipment/View/Items.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Shipment/View/Items.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Shipment/View/Items.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Shipment/View/Items.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Shipment/View/Items.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Shipment/View/Tracking.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Shipment/View/Tracking.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Shipment/View/Tracking.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Shipment/View/Tracking.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Shipment/View/Tracking.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Shipment/View/Tracking.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Status.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Status.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Status.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Status.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Status.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Status.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Status/Assign.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Status/Assign.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Status/Assign.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Status/Assign.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Status/Assign.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Status/Assign.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Status/Assign/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Status/Assign/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Status/Assign/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Status/Assign/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Status/Assign/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Status/Assign/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Status/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Status/Edit.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Status/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Status/Edit.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Status/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Status/Edit.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Status/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Status/Edit/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Status/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Status/Edit/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Status/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Status/Edit/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Status/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Status/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Status/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Status/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Status/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Status/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Status/New.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Status/New.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Status/New.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Status/New.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Status/New.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Status/New.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Status/New/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Status/New/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Status/New/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Status/New/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Status/New/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Status/New/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Totalbar.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Totalbar.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Totalbar.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Totalbar.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Totalbar.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Totalbar.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Totals.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Totals.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Totals.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Totals.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Totals.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Totals.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Totals/Item.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Totals/Item.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Totals/Item.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Totals/Item.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Totals/Item.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Totals/Item.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Totals/Tax.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Totals/Tax.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Totals/Tax.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Totals/Tax.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Totals/Tax.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Totals/Tax.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/View.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/View.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/View.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/View.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/View.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/View.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/View/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/View/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/View/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/View/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/View/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/View/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/View/Giftmessage.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/View/Giftmessage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/View/Giftmessage.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/View/Giftmessage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/View/Giftmessage.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/View/Giftmessage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/View/History.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/View/History.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/View/History.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/View/History.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/View/History.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/View/History.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/View/Info.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/View/Info.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/View/Info.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/View/Info.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/View/Info.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/View/Info.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/View/Items.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/View/Items.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/View/Items.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/View/Items.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/View/Items.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/View/Items.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/View/Items/Renderer/Default.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/View/Items/Renderer/Default.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/View/Items/Renderer/Default.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/View/Items/Renderer/Default.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/View/Items/Renderer/Default.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/View/Items/Renderer/Default.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/View/Messages.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/View/Messages.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/View/Messages.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/View/Messages.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/View/Messages.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/View/Messages.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/View/Tab/Creditmemos.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/View/Tab/Creditmemos.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/View/Tab/Creditmemos.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/View/Tab/Creditmemos.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/View/Tab/Creditmemos.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/View/Tab/Creditmemos.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/View/Tab/History.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/View/Tab/History.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/View/Tab/History.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/View/Tab/History.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/View/Tab/History.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/View/Tab/History.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/View/Tab/Info.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/View/Tab/Info.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/View/Tab/Info.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/View/Tab/Info.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/View/Tab/Info.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/View/Tab/Info.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/View/Tab/Invoices.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/View/Tab/Invoices.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/View/Tab/Invoices.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/View/Tab/Invoices.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/View/Tab/Invoices.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/View/Tab/Invoices.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/View/Tab/Shipments.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/View/Tab/Shipments.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/View/Tab/Shipments.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/View/Tab/Shipments.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/View/Tab/Shipments.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/View/Tab/Shipments.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/View/Tab/Transactions.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/View/Tab/Transactions.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/View/Tab/Transactions.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/View/Tab/Transactions.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/View/Tab/Transactions.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/View/Tab/Transactions.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/View/Tabs.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/View/Tabs.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/View/Tabs.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/View/Tabs.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/View/Tabs.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/View/Tabs.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Reorder/Renderer/Action.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Reorder/Renderer/Action.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Reorder/Renderer/Action.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Reorder/Renderer/Action.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Reorder/Renderer/Action.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Reorder/Renderer/Action.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Shipment.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Shipment.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Shipment.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Shipment.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Shipment.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Shipment.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Shipment/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Shipment/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Shipment/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Shipment/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Shipment/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Shipment/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Totals.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Totals.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Totals.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Totals.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Totals.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Totals.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Transactions.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Transactions.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Transactions.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Transactions.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Transactions.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Transactions.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Transactions/Child/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Transactions/Child/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Transactions/Child/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Transactions/Child/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Transactions/Child/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Transactions/Child/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Transactions/Detail.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Transactions/Detail.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Transactions/Detail.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Transactions/Detail.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Transactions/Detail.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Transactions/Detail.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Transactions/Detail/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Transactions/Detail/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Transactions/Detail/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Transactions/Detail/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Transactions/Detail/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Transactions/Detail/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Transactions/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Transactions/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Transactions/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Transactions/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Transactions/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Transactions/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Shipping/Carrier/Tablerate/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Shipping/Carrier/Tablerate/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Shipping/Carrier/Tablerate/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Shipping/Carrier/Tablerate/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Shipping/Carrier/Tablerate/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Shipping/Carrier/Tablerate/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sitemap.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sitemap.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sitemap.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sitemap.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sitemap.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sitemap.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sitemap/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sitemap/Edit.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sitemap/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sitemap/Edit.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sitemap/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sitemap/Edit.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sitemap/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sitemap/Edit/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sitemap/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sitemap/Edit/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sitemap/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sitemap/Edit/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sitemap/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sitemap/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sitemap/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sitemap/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sitemap/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sitemap/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sitemap/Grid/Renderer/Action.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sitemap/Grid/Renderer/Action.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sitemap/Grid/Renderer/Action.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sitemap/Grid/Renderer/Action.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sitemap/Grid/Renderer/Action.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sitemap/Grid/Renderer/Action.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sitemap/Grid/Renderer/Link.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sitemap/Grid/Renderer/Link.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sitemap/Grid/Renderer/Link.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sitemap/Grid/Renderer/Link.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sitemap/Grid/Renderer/Link.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sitemap/Grid/Renderer/Link.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sitemap/Grid/Renderer/Time.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sitemap/Grid/Renderer/Time.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Sitemap/Grid/Renderer/Time.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sitemap/Grid/Renderer/Time.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Sitemap/Grid/Renderer/Time.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sitemap/Grid/Renderer/Time.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Store/Switcher.php
+++ b/app/code/core/Mage/Adminhtml/Block/Store/Switcher.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Store/Switcher.php
+++ b/app/code/core/Mage/Adminhtml/Block/Store/Switcher.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Store/Switcher.php
+++ b/app/code/core/Mage/Adminhtml/Block/Store/Switcher.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Store/Switcher/Form/Renderer/Fieldset.php
+++ b/app/code/core/Mage/Adminhtml/Block/Store/Switcher/Form/Renderer/Fieldset.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Store/Switcher/Form/Renderer/Fieldset.php
+++ b/app/code/core/Mage/Adminhtml/Block/Store/Switcher/Form/Renderer/Fieldset.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Store/Switcher/Form/Renderer/Fieldset.php
+++ b/app/code/core/Mage/Adminhtml/Block/Store/Switcher/Form/Renderer/Fieldset.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Store/Switcher/Form/Renderer/Fieldset/Element.php
+++ b/app/code/core/Mage/Adminhtml/Block/Store/Switcher/Form/Renderer/Fieldset/Element.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Store/Switcher/Form/Renderer/Fieldset/Element.php
+++ b/app/code/core/Mage/Adminhtml/Block/Store/Switcher/Form/Renderer/Fieldset/Element.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Store/Switcher/Form/Renderer/Fieldset/Element.php
+++ b/app/code/core/Mage/Adminhtml/Block/Store/Switcher/Form/Renderer/Fieldset/Element.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Account/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Account/Edit.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/System/Account/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Account/Edit.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Account/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Account/Edit.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Account/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Account/Edit/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/System/Account/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Account/Edit/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Account/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Account/Edit/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Cache/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Cache/Edit.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/System/Cache/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Cache/Edit.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Cache/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Cache/Edit.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Cache/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Cache/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/System/Cache/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Cache/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Cache/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Cache/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Dwstree.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Dwstree.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Dwstree.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Dwstree.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Dwstree.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Dwstree.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Edit.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Edit.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Edit.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/Array/Abstract.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/Array/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/Array/Abstract.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/Array/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/Array/Abstract.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/Array/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/Datetime.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/Datetime.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/Datetime.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/Datetime.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/Datetime.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/Datetime.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/Export.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/Export.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/Export.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/Export.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/Export.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/Export.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/File.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/File.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/File.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/File.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/File.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/File.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/Heading.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/Heading.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/Heading.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/Heading.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/Heading.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/Heading.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/Image.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/Image.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/Image.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/Image.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/Image.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/Image.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/Import.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/Import.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/Import.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/Import.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/Import.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/Import.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/Notification.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/Notification.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/Notification.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/Notification.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/Notification.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/Notification.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/Regexceptions.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/Regexceptions.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/Regexceptions.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/Regexceptions.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/Regexceptions.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/Regexceptions.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/Select/Allowspecific.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/Select/Allowspecific.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/Select/Allowspecific.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/Select/Allowspecific.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/Select/Allowspecific.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/Select/Allowspecific.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/Select/Flatcatalog.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/Select/Flatcatalog.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/Select/Flatcatalog.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/Select/Flatcatalog.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/Select/Flatcatalog.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/Select/Flatcatalog.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/Select/Flatproduct.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/Select/Flatproduct.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/Select/Flatproduct.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/Select/Flatproduct.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/Select/Flatproduct.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/Select/Flatproduct.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Fieldset.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Fieldset.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Fieldset.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Fieldset.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Fieldset.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Fieldset.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Fieldset/Modules/DisableOutput.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Fieldset/Modules/DisableOutput.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Fieldset/Modules/DisableOutput.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Fieldset/Modules/DisableOutput.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Fieldset/Modules/DisableOutput.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Fieldset/Modules/DisableOutput.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Fieldset/Order/Statuses.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Fieldset/Order/Statuses.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Fieldset/Order/Statuses.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Fieldset/Order/Statuses.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Fieldset/Order/Statuses.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Fieldset/Order/Statuses.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Switcher.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Switcher.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Switcher.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Switcher.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Switcher.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Switcher.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Config/System/Storage/Media/Synchronize.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/System/Storage/Media/Synchronize.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/System/Config/System/Storage/Media/Synchronize.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/System/Storage/Media/Synchronize.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Config/System/Storage/Media/Synchronize.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/System/Storage/Media/Synchronize.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Tabs.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Tabs.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Tabs.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Tabs.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Tabs.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Tabs.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Convert/Gui.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Convert/Gui.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/System/Convert/Gui.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Convert/Gui.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Convert/Gui.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Convert/Gui.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Convert/Gui/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Convert/Gui/Edit.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/System/Convert/Gui/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Convert/Gui/Edit.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Convert/Gui/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Convert/Gui/Edit.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Convert/Gui/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Convert/Gui/Edit/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/System/Convert/Gui/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Convert/Gui/Edit/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Convert/Gui/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Convert/Gui/Edit/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Convert/Gui/Edit/Tab/Upload.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Convert/Gui/Edit/Tab/Upload.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/System/Convert/Gui/Edit/Tab/Upload.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Convert/Gui/Edit/Tab/Upload.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Convert/Gui/Edit/Tab/Upload.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Convert/Gui/Edit/Tab/Upload.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Convert/Gui/Edit/Tab/View.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Convert/Gui/Edit/Tab/View.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/System/Convert/Gui/Edit/Tab/View.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Convert/Gui/Edit/Tab/View.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Convert/Gui/Edit/Tab/View.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Convert/Gui/Edit/Tab/View.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Convert/Gui/Edit/Tab/Wizard.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Convert/Gui/Edit/Tab/Wizard.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/System/Convert/Gui/Edit/Tab/Wizard.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Convert/Gui/Edit/Tab/Wizard.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Convert/Gui/Edit/Tab/Wizard.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Convert/Gui/Edit/Tab/Wizard.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Convert/Gui/Edit/Tabs.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Convert/Gui/Edit/Tabs.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/System/Convert/Gui/Edit/Tabs.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Convert/Gui/Edit/Tabs.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Convert/Gui/Edit/Tabs.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Convert/Gui/Edit/Tabs.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Convert/Gui/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Convert/Gui/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/System/Convert/Gui/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Convert/Gui/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Convert/Gui/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Convert/Gui/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Convert/Profile.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Convert/Profile.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/System/Convert/Profile.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Convert/Profile.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Convert/Profile.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Convert/Profile.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Convert/Profile/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Convert/Profile/Edit.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/System/Convert/Profile/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Convert/Profile/Edit.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Convert/Profile/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Convert/Profile/Edit.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Convert/Profile/Edit/Filter/Action.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Convert/Profile/Edit/Filter/Action.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/System/Convert/Profile/Edit/Filter/Action.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Convert/Profile/Edit/Filter/Action.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Convert/Profile/Edit/Filter/Action.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Convert/Profile/Edit/Filter/Action.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Convert/Profile/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Convert/Profile/Edit/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/System/Convert/Profile/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Convert/Profile/Edit/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Convert/Profile/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Convert/Profile/Edit/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Convert/Profile/Edit/Renderer/Action.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Convert/Profile/Edit/Renderer/Action.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/System/Convert/Profile/Edit/Renderer/Action.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Convert/Profile/Edit/Renderer/Action.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Convert/Profile/Edit/Renderer/Action.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Convert/Profile/Edit/Renderer/Action.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Convert/Profile/Edit/Tab/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Convert/Profile/Edit/Tab/Edit.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/System/Convert/Profile/Edit/Tab/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Convert/Profile/Edit/Tab/Edit.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Convert/Profile/Edit/Tab/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Convert/Profile/Edit/Tab/Edit.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Convert/Profile/Edit/Tab/History.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Convert/Profile/Edit/Tab/History.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/System/Convert/Profile/Edit/Tab/History.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Convert/Profile/Edit/Tab/History.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Convert/Profile/Edit/Tab/History.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Convert/Profile/Edit/Tab/History.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Convert/Profile/Edit/Tab/Run.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Convert/Profile/Edit/Tab/Run.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/System/Convert/Profile/Edit/Tab/Run.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Convert/Profile/Edit/Tab/Run.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Convert/Profile/Edit/Tab/Run.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Convert/Profile/Edit/Tab/Run.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Convert/Profile/Edit/Tabs.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Convert/Profile/Edit/Tabs.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/System/Convert/Profile/Edit/Tabs.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Convert/Profile/Edit/Tabs.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Convert/Profile/Edit/Tabs.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Convert/Profile/Edit/Tabs.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Convert/Profile/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Convert/Profile/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/System/Convert/Profile/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Convert/Profile/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Convert/Profile/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Convert/Profile/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Convert/Profile/Run.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Convert/Profile/Run.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/System/Convert/Profile/Run.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Convert/Profile/Run.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Convert/Profile/Run.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Convert/Profile/Run.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Currency.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Currency.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/System/Currency.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Currency.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Currency.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Currency.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Currency/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Currency/Edit/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/System/Currency/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Currency/Edit/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Currency/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Currency/Edit/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Currency/Edit/Tab/Main.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Currency/Edit/Tab/Main.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/System/Currency/Edit/Tab/Main.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Currency/Edit/Tab/Main.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Currency/Edit/Tab/Main.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Currency/Edit/Tab/Main.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Currency/Edit/Tab/Rates.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Currency/Edit/Tab/Rates.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/System/Currency/Edit/Tab/Rates.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Currency/Edit/Tab/Rates.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Currency/Edit/Tab/Rates.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Currency/Edit/Tab/Rates.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Currency/Edit/Tabs.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Currency/Edit/Tabs.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/System/Currency/Edit/Tabs.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Currency/Edit/Tabs.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Currency/Edit/Tabs.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Currency/Edit/Tabs.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Currency/Rate/Matrix.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Currency/Rate/Matrix.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/System/Currency/Rate/Matrix.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Currency/Rate/Matrix.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Currency/Rate/Matrix.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Currency/Rate/Matrix.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Currency/Rate/Services.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Currency/Rate/Services.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/System/Currency/Rate/Services.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Currency/Rate/Services.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Currency/Rate/Services.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Currency/Rate/Services.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Design.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Design.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/System/Design.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Design.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Design.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Design.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Design/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Design/Edit.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/System/Design/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Design/Edit.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Design/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Design/Edit.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Design/Edit/Tab/General.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Design/Edit/Tab/General.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/System/Design/Edit/Tab/General.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Design/Edit/Tab/General.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Design/Edit/Tab/General.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Design/Edit/Tab/General.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Design/Edit/Tabs.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Design/Edit/Tabs.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/System/Design/Edit/Tabs.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Design/Edit/Tabs.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Design/Edit/Tabs.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Design/Edit/Tabs.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Design/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Design/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/System/Design/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Design/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Design/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Design/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Email/Template.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Email/Template.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/System/Email/Template.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Email/Template.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Email/Template.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Email/Template.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Email/Template/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Email/Template/Edit.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/System/Email/Template/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Email/Template/Edit.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Email/Template/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Email/Template/Edit.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Email/Template/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Email/Template/Edit/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/System/Email/Template/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Email/Template/Edit/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Email/Template/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Email/Template/Edit/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Email/Template/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Email/Template/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/System/Email/Template/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Email/Template/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Email/Template/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Email/Template/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Email/Template/Grid/Filter/Type.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Email/Template/Grid/Filter/Type.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/System/Email/Template/Grid/Filter/Type.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Email/Template/Grid/Filter/Type.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Email/Template/Grid/Filter/Type.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Email/Template/Grid/Filter/Type.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Email/Template/Grid/Renderer/Action.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Email/Template/Grid/Renderer/Action.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/System/Email/Template/Grid/Renderer/Action.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Email/Template/Grid/Renderer/Action.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Email/Template/Grid/Renderer/Action.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Email/Template/Grid/Renderer/Action.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Email/Template/Grid/Renderer/Sender.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Email/Template/Grid/Renderer/Sender.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/System/Email/Template/Grid/Renderer/Sender.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Email/Template/Grid/Renderer/Sender.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Email/Template/Grid/Renderer/Sender.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Email/Template/Grid/Renderer/Sender.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Email/Template/Grid/Renderer/Type.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Email/Template/Grid/Renderer/Type.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/System/Email/Template/Grid/Renderer/Type.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Email/Template/Grid/Renderer/Type.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Email/Template/Grid/Renderer/Type.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Email/Template/Grid/Renderer/Type.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Email/Template/Preview.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Email/Template/Preview.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/System/Email/Template/Preview.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Email/Template/Preview.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Email/Template/Preview.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Email/Template/Preview.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Store/Delete.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Store/Delete.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/System/Store/Delete.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Store/Delete.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Store/Delete.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Store/Delete.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Store/Delete/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Store/Delete/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/System/Store/Delete/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Store/Delete/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Store/Delete/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Store/Delete/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Store/Delete/Group.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Store/Delete/Group.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/System/Store/Delete/Group.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Store/Delete/Group.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Store/Delete/Group.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Store/Delete/Group.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Store/Delete/Website.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Store/Delete/Website.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/System/Store/Delete/Website.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Store/Delete/Website.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Store/Delete/Website.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Store/Delete/Website.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Store/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Store/Edit.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/System/Store/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Store/Edit.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Store/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Store/Edit.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Store/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Store/Edit/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/System/Store/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Store/Edit/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Store/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Store/Edit/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Store/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Store/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/System/Store/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Store/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Store/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Store/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Store/Grid/Render/Group.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Store/Grid/Render/Group.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/System/Store/Grid/Render/Group.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Store/Grid/Render/Group.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Store/Grid/Render/Group.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Store/Grid/Render/Group.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Store/Grid/Render/Store.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Store/Grid/Render/Store.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/System/Store/Grid/Render/Store.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Store/Grid/Render/Store.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Store/Grid/Render/Store.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Store/Grid/Render/Store.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Store/Grid/Render/Website.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Store/Grid/Render/Website.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/System/Store/Grid/Render/Website.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Store/Grid/Render/Website.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Store/Grid/Render/Website.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Store/Grid/Render/Website.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Store/Store.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Store/Store.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/System/Store/Store.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Store/Store.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Store/Store.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Store/Store.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Store/Tree.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Store/Tree.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/System/Store/Tree.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Store/Tree.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Store/Tree.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Store/Tree.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Variable.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Variable.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/System/Variable.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Variable.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Variable.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Variable.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Variable/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Variable/Edit.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/System/Variable/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Variable/Edit.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Variable/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Variable/Edit.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Variable/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Variable/Edit/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/System/Variable/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Variable/Edit/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Variable/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Variable/Edit/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Variable/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Variable/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/System/Variable/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Variable/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/System/Variable/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Variable/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Tag.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tag.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Tag.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tag.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Tag.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tag.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Tag/Assigned/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tag/Assigned/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Tag/Assigned/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tag/Assigned/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Tag/Assigned/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tag/Assigned/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Tag/Customer.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tag/Customer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Tag/Customer.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tag/Customer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Tag/Customer.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tag/Customer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Tag/Customer/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tag/Customer/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Tag/Customer/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tag/Customer/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Tag/Customer/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tag/Customer/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Tag/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tag/Edit.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Tag/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tag/Edit.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Tag/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tag/Edit.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Tag/Edit/Accordion.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tag/Edit/Accordion.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Tag/Edit/Accordion.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tag/Edit/Accordion.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Tag/Edit/Accordion.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tag/Edit/Accordion.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Tag/Edit/Assigned.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tag/Edit/Assigned.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Tag/Edit/Assigned.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tag/Edit/Assigned.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Tag/Edit/Assigned.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tag/Edit/Assigned.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Tag/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tag/Edit/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Tag/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tag/Edit/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Tag/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tag/Edit/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Tag/Grid/All.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tag/Grid/All.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Tag/Grid/All.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tag/Grid/All.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Tag/Grid/All.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tag/Grid/All.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Tag/Grid/Customers.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tag/Grid/Customers.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Tag/Grid/Customers.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tag/Grid/Customers.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Tag/Grid/Customers.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tag/Grid/Customers.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Tag/Grid/Pending.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tag/Grid/Pending.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Tag/Grid/Pending.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tag/Grid/Pending.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Tag/Grid/Pending.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tag/Grid/Pending.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Tag/Grid/Products.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tag/Grid/Products.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Tag/Grid/Products.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tag/Grid/Products.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Tag/Grid/Products.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tag/Grid/Products.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Tag/Pending.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tag/Pending.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Tag/Pending.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tag/Pending.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Tag/Pending.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tag/Pending.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Tag/Product.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tag/Product.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Tag/Product.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tag/Product.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Tag/Product.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tag/Product.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Tag/Product/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tag/Product/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Tag/Product/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tag/Product/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Tag/Product/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tag/Product/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Tag/Store/Switcher.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tag/Store/Switcher.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Tag/Store/Switcher.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tag/Store/Switcher.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Tag/Store/Switcher.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tag/Store/Switcher.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Tag/Tag.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tag/Tag.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Tag/Tag.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tag/Tag.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Tag/Tag.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tag/Tag.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Tag/Tag/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tag/Tag/Edit.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Tag/Tag/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tag/Tag/Edit.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Tag/Tag/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tag/Tag/Edit.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Tag/Tag/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tag/Tag/Edit/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Tag/Tag/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tag/Tag/Edit/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Tag/Tag/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tag/Tag/Edit/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Tag/Tag/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tag/Tag/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Tag/Tag/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tag/Tag/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Tag/Tag/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tag/Tag/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Tax/Class.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tax/Class.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Tax/Class.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tax/Class.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Tax/Class.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tax/Class.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Tax/Class/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tax/Class/Edit.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Tax/Class/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tax/Class/Edit.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Tax/Class/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tax/Class/Edit.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Tax/Class/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tax/Class/Edit/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Tax/Class/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tax/Class/Edit/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Tax/Class/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tax/Class/Edit/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Tax/Class/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tax/Class/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Tax/Class/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tax/Class/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Tax/Class/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tax/Class/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Tax/Rate/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tax/Rate/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Tax/Rate/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tax/Rate/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Tax/Rate/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tax/Rate/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Tax/Rate/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tax/Rate/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Tax/Rate/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tax/Rate/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Tax/Rate/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tax/Rate/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Tax/Rate/Grid/Renderer/Country.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tax/Rate/Grid/Renderer/Country.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Tax/Rate/Grid/Renderer/Country.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tax/Rate/Grid/Renderer/Country.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Tax/Rate/Grid/Renderer/Country.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tax/Rate/Grid/Renderer/Country.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Tax/Rate/Grid/Renderer/Data.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tax/Rate/Grid/Renderer/Data.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Tax/Rate/Grid/Renderer/Data.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tax/Rate/Grid/Renderer/Data.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Tax/Rate/Grid/Renderer/Data.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tax/Rate/Grid/Renderer/Data.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Tax/Rate/ImportExport.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tax/Rate/ImportExport.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Tax/Rate/ImportExport.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tax/Rate/ImportExport.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Tax/Rate/ImportExport.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tax/Rate/ImportExport.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Tax/Rate/Title.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tax/Rate/Title.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Tax/Rate/Title.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tax/Rate/Title.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Tax/Rate/Title.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tax/Rate/Title.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Tax/Rate/Title/Fieldset.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tax/Rate/Title/Fieldset.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Tax/Rate/Title/Fieldset.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tax/Rate/Title/Fieldset.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Tax/Rate/Title/Fieldset.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tax/Rate/Title/Fieldset.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Tax/Rate/Toolbar/Add.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tax/Rate/Toolbar/Add.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Tax/Rate/Toolbar/Add.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tax/Rate/Toolbar/Add.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Tax/Rate/Toolbar/Add.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tax/Rate/Toolbar/Add.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Tax/Rate/Toolbar/Save.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tax/Rate/Toolbar/Save.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Tax/Rate/Toolbar/Save.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tax/Rate/Toolbar/Save.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Tax/Rate/Toolbar/Save.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tax/Rate/Toolbar/Save.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Tax/Rule.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tax/Rule.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Tax/Rule.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tax/Rule.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Tax/Rule.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tax/Rule.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Tax/Rule/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tax/Rule/Edit.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Tax/Rule/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tax/Rule/Edit.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Tax/Rule/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tax/Rule/Edit.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Tax/Rule/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tax/Rule/Edit/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Tax/Rule/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tax/Rule/Edit/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Tax/Rule/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tax/Rule/Edit/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Tax/Rule/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tax/Rule/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Tax/Rule/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tax/Rule/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Tax/Rule/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tax/Rule/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Template.php
+++ b/app/code/core/Mage/Adminhtml/Block/Template.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Template.php
+++ b/app/code/core/Mage/Adminhtml/Block/Template.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Template.php
+++ b/app/code/core/Mage/Adminhtml/Block/Template.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Text/List.php
+++ b/app/code/core/Mage/Adminhtml/Block/Text/List.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Text/List.php
+++ b/app/code/core/Mage/Adminhtml/Block/Text/List.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Text/List.php
+++ b/app/code/core/Mage/Adminhtml/Block/Text/List.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Urlrewrite.php
+++ b/app/code/core/Mage/Adminhtml/Block/Urlrewrite.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Urlrewrite.php
+++ b/app/code/core/Mage/Adminhtml/Block/Urlrewrite.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Urlrewrite.php
+++ b/app/code/core/Mage/Adminhtml/Block/Urlrewrite.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Urlrewrite/Category/Tree.php
+++ b/app/code/core/Mage/Adminhtml/Block/Urlrewrite/Category/Tree.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Urlrewrite/Category/Tree.php
+++ b/app/code/core/Mage/Adminhtml/Block/Urlrewrite/Category/Tree.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Urlrewrite/Category/Tree.php
+++ b/app/code/core/Mage/Adminhtml/Block/Urlrewrite/Category/Tree.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Urlrewrite/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Urlrewrite/Edit.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Urlrewrite/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Urlrewrite/Edit.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Urlrewrite/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Urlrewrite/Edit.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Urlrewrite/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Urlrewrite/Edit/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Urlrewrite/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Urlrewrite/Edit/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Urlrewrite/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Urlrewrite/Edit/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Urlrewrite/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Urlrewrite/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Urlrewrite/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Urlrewrite/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Urlrewrite/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Urlrewrite/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Urlrewrite/Link.php
+++ b/app/code/core/Mage/Adminhtml/Block/Urlrewrite/Link.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Urlrewrite/Link.php
+++ b/app/code/core/Mage/Adminhtml/Block/Urlrewrite/Link.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Urlrewrite/Link.php
+++ b/app/code/core/Mage/Adminhtml/Block/Urlrewrite/Link.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Urlrewrite/Product/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Urlrewrite/Product/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Urlrewrite/Product/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Urlrewrite/Product/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Urlrewrite/Product/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Urlrewrite/Product/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Urlrewrite/Selector.php
+++ b/app/code/core/Mage/Adminhtml/Block/Urlrewrite/Selector.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Urlrewrite/Selector.php
+++ b/app/code/core/Mage/Adminhtml/Block/Urlrewrite/Selector.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Urlrewrite/Selector.php
+++ b/app/code/core/Mage/Adminhtml/Block/Urlrewrite/Selector.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Widget.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Accordion.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Accordion.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Accordion.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Accordion.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Accordion.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Accordion.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Accordion/Item.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Accordion/Item.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Accordion/Item.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Accordion/Item.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Accordion/Item.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Accordion/Item.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Breadcrumbs.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Breadcrumbs.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Breadcrumbs.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Breadcrumbs.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Breadcrumbs.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Breadcrumbs.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Button.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Button.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Button.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Button.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Button.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Button.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Container.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Container.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Container.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Container.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Container.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Container.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Form/Container.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Form/Container.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Form/Container.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Form/Container.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Form/Container.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Form/Container.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Form/Element.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Form/Element.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Form/Element.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Form/Element.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Form/Element.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Form/Element.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Form/Element/Dependence.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Form/Element/Dependence.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Form/Element/Dependence.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Form/Element/Dependence.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Form/Element/Dependence.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Form/Element/Dependence.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Form/Element/Gallery.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Form/Element/Gallery.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Form/Element/Gallery.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Form/Element/Gallery.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Form/Element/Gallery.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Form/Element/Gallery.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Form/Renderer/Element.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Form/Renderer/Element.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Form/Renderer/Element.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Form/Renderer/Element.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Form/Renderer/Element.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Form/Renderer/Element.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Form/Renderer/Fieldset.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Form/Renderer/Fieldset.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Form/Renderer/Fieldset.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Form/Renderer/Fieldset.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Form/Renderer/Fieldset.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Form/Renderer/Fieldset.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Form/Renderer/Fieldset/Element.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Form/Renderer/Fieldset/Element.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Form/Renderer/Fieldset/Element.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Form/Renderer/Fieldset/Element.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Form/Renderer/Fieldset/Element.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Form/Renderer/Fieldset/Element.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Block.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Block.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Block.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Block.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Block.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Block.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Abstract.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Abstract.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Abstract.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Checkbox.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Checkbox.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Checkbox.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Checkbox.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Checkbox.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Checkbox.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Country.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Country.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Country.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Country.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Country.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Country.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Date.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Date.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Date.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Date.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Date.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Date.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Datetime.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Datetime.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Datetime.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Datetime.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Datetime.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Datetime.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Interface.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Interface.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Interface.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Interface.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Interface.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Interface.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Massaction.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Massaction.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Massaction.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Massaction.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Massaction.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Massaction.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Price.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Price.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Price.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Price.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Price.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Price.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Radio.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Radio.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Radio.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Radio.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Radio.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Radio.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Range.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Range.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Range.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Range.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Range.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Range.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Select.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Select.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Select.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Select.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Select.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Select.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Store.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Store.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Store.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Store.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Store.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Store.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Text.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Text.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Text.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Text.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Text.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Text.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Theme.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Theme.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Theme.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Theme.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Theme.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Theme.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Abstract.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Abstract.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Abstract.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Action.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Action.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Action.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Action.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Action.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Action.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Checkbox.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Checkbox.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Checkbox.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Checkbox.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Checkbox.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Checkbox.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Concat.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Concat.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Concat.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Concat.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Concat.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Concat.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Country.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Country.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Country.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Country.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Country.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Country.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Currency.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Currency.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Currency.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Currency.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Currency.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Currency.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Date.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Date.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Date.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Date.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Date.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Date.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Datetime.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Datetime.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Datetime.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Datetime.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Datetime.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Datetime.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Input.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Input.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Input.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Input.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Input.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Input.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Interface.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Interface.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Interface.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Interface.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Interface.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Interface.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Ip.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Ip.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Ip.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Ip.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Ip.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Ip.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Longtext.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Longtext.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Longtext.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Longtext.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Longtext.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Longtext.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Massaction.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Massaction.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Massaction.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Massaction.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Massaction.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Massaction.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Number.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Number.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Number.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Number.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Number.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Number.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Options.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Options.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Options.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Options.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Options.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Options.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Price.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Price.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Price.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Price.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Price.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Price.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Radio.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Radio.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Radio.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Radio.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Radio.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Radio.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Select.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Select.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Select.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Select.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Select.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Select.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Store.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Store.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Store.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Store.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Store.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Store.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Text.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Text.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Text.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Text.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Text.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Text.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Theme.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Theme.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Theme.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Theme.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Theme.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Theme.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Wrapline.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Wrapline.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Wrapline.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Wrapline.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Wrapline.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Wrapline.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Container.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Container.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Container.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Container.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Container.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Container.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Massaction.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Massaction.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Massaction.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Massaction.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Massaction.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Massaction.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Massaction/Abstract.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Massaction/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Massaction/Abstract.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Massaction/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Massaction/Abstract.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Massaction/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Massaction/Item.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Massaction/Item.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Massaction/Item.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Massaction/Item.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Massaction/Item.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Massaction/Item.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Massaction/Item/Additional/Default.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Massaction/Item/Additional/Default.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Massaction/Item/Additional/Default.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Massaction/Item/Additional/Default.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Massaction/Item/Additional/Default.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Massaction/Item/Additional/Default.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Massaction/Item/Additional/Interface.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Massaction/Item/Additional/Interface.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Massaction/Item/Additional/Interface.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Massaction/Item/Additional/Interface.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Massaction/Item/Additional/Interface.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Massaction/Item/Additional/Interface.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Serializer.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Serializer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Serializer.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Serializer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Serializer.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Serializer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Tab/Interface.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Tab/Interface.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Tab/Interface.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Tab/Interface.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Tab/Interface.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Tab/Interface.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Tabs.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Tabs.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Tabs.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Tabs.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Tabs.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Tabs.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Tree.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Tree.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Tree.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Tree.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Tree.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Tree.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/View/Container.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/View/Container.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Block/Widget/View/Container.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/View/Container.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Block/Widget/View/Container.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/View/Container.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Controller/Action.php
+++ b/app/code/core/Mage/Adminhtml/Controller/Action.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Controller/Action.php
+++ b/app/code/core/Mage/Adminhtml/Controller/Action.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Controller/Action.php
+++ b/app/code/core/Mage/Adminhtml/Controller/Action.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Controller/Report/Abstract.php
+++ b/app/code/core/Mage/Adminhtml/Controller/Report/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Controller/Report/Abstract.php
+++ b/app/code/core/Mage/Adminhtml/Controller/Report/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Controller/Report/Abstract.php
+++ b/app/code/core/Mage/Adminhtml/Controller/Report/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Controller/Rss/Abstract.php
+++ b/app/code/core/Mage/Adminhtml/Controller/Rss/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Controller/Rss/Abstract.php
+++ b/app/code/core/Mage/Adminhtml/Controller/Rss/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Controller/Rss/Abstract.php
+++ b/app/code/core/Mage/Adminhtml/Controller/Rss/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Controller/Sales/Creditmemo.php
+++ b/app/code/core/Mage/Adminhtml/Controller/Sales/Creditmemo.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Controller/Sales/Creditmemo.php
+++ b/app/code/core/Mage/Adminhtml/Controller/Sales/Creditmemo.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Controller/Sales/Creditmemo.php
+++ b/app/code/core/Mage/Adminhtml/Controller/Sales/Creditmemo.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Controller/Sales/Invoice.php
+++ b/app/code/core/Mage/Adminhtml/Controller/Sales/Invoice.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Controller/Sales/Invoice.php
+++ b/app/code/core/Mage/Adminhtml/Controller/Sales/Invoice.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Controller/Sales/Invoice.php
+++ b/app/code/core/Mage/Adminhtml/Controller/Sales/Invoice.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Controller/Sales/Shipment.php
+++ b/app/code/core/Mage/Adminhtml/Controller/Sales/Shipment.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Controller/Sales/Shipment.php
+++ b/app/code/core/Mage/Adminhtml/Controller/Sales/Shipment.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Controller/Sales/Shipment.php
+++ b/app/code/core/Mage/Adminhtml/Controller/Sales/Shipment.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Exception.php
+++ b/app/code/core/Mage/Adminhtml/Exception.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Exception.php
+++ b/app/code/core/Mage/Adminhtml/Exception.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Exception.php
+++ b/app/code/core/Mage/Adminhtml/Exception.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Helper/Addresses.php
+++ b/app/code/core/Mage/Adminhtml/Helper/Addresses.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Helper/Addresses.php
+++ b/app/code/core/Mage/Adminhtml/Helper/Addresses.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Helper/Addresses.php
+++ b/app/code/core/Mage/Adminhtml/Helper/Addresses.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Helper/Catalog.php
+++ b/app/code/core/Mage/Adminhtml/Helper/Catalog.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Helper/Catalog.php
+++ b/app/code/core/Mage/Adminhtml/Helper/Catalog.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Helper/Catalog.php
+++ b/app/code/core/Mage/Adminhtml/Helper/Catalog.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Helper/Catalog/Product/Composite.php
+++ b/app/code/core/Mage/Adminhtml/Helper/Catalog/Product/Composite.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Helper/Catalog/Product/Composite.php
+++ b/app/code/core/Mage/Adminhtml/Helper/Catalog/Product/Composite.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Helper/Catalog/Product/Composite.php
+++ b/app/code/core/Mage/Adminhtml/Helper/Catalog/Product/Composite.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Helper/Catalog/Product/Edit/Action/Attribute.php
+++ b/app/code/core/Mage/Adminhtml/Helper/Catalog/Product/Edit/Action/Attribute.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Helper/Catalog/Product/Edit/Action/Attribute.php
+++ b/app/code/core/Mage/Adminhtml/Helper/Catalog/Product/Edit/Action/Attribute.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Helper/Catalog/Product/Edit/Action/Attribute.php
+++ b/app/code/core/Mage/Adminhtml/Helper/Catalog/Product/Edit/Action/Attribute.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Helper/Config.php
+++ b/app/code/core/Mage/Adminhtml/Helper/Config.php
@@ -7,8 +7,7 @@ declare(strict_types=1);
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Helper/Config.php
+++ b/app/code/core/Mage/Adminhtml/Helper/Config.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Helper/Config.php
+++ b/app/code/core/Mage/Adminhtml/Helper/Config.php
@@ -9,9 +9,6 @@ declare(strict_types=1);
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Helper/Dashboard/Abstract.php
+++ b/app/code/core/Mage/Adminhtml/Helper/Dashboard/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Helper/Dashboard/Abstract.php
+++ b/app/code/core/Mage/Adminhtml/Helper/Dashboard/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Helper/Dashboard/Abstract.php
+++ b/app/code/core/Mage/Adminhtml/Helper/Dashboard/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Helper/Dashboard/Data.php
+++ b/app/code/core/Mage/Adminhtml/Helper/Dashboard/Data.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Helper/Dashboard/Data.php
+++ b/app/code/core/Mage/Adminhtml/Helper/Dashboard/Data.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Helper/Dashboard/Data.php
+++ b/app/code/core/Mage/Adminhtml/Helper/Dashboard/Data.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Helper/Dashboard/Order.php
+++ b/app/code/core/Mage/Adminhtml/Helper/Dashboard/Order.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Helper/Dashboard/Order.php
+++ b/app/code/core/Mage/Adminhtml/Helper/Dashboard/Order.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Helper/Dashboard/Order.php
+++ b/app/code/core/Mage/Adminhtml/Helper/Dashboard/Order.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Helper/Data.php
+++ b/app/code/core/Mage/Adminhtml/Helper/Data.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Helper/Data.php
+++ b/app/code/core/Mage/Adminhtml/Helper/Data.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Helper/Data.php
+++ b/app/code/core/Mage/Adminhtml/Helper/Data.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Helper/Help/Mapping.php
+++ b/app/code/core/Mage/Adminhtml/Helper/Help/Mapping.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Helper/Help/Mapping.php
+++ b/app/code/core/Mage/Adminhtml/Helper/Help/Mapping.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Helper/Help/Mapping.php
+++ b/app/code/core/Mage/Adminhtml/Helper/Help/Mapping.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Helper/Js.php
+++ b/app/code/core/Mage/Adminhtml/Helper/Js.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Helper/Js.php
+++ b/app/code/core/Mage/Adminhtml/Helper/Js.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Helper/Js.php
+++ b/app/code/core/Mage/Adminhtml/Helper/Js.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Helper/Media/Js.php
+++ b/app/code/core/Mage/Adminhtml/Helper/Media/Js.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Helper/Media/Js.php
+++ b/app/code/core/Mage/Adminhtml/Helper/Media/Js.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Helper/Media/Js.php
+++ b/app/code/core/Mage/Adminhtml/Helper/Media/Js.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Helper/Rss.php
+++ b/app/code/core/Mage/Adminhtml/Helper/Rss.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Helper/Rss.php
+++ b/app/code/core/Mage/Adminhtml/Helper/Rss.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Helper/Rss.php
+++ b/app/code/core/Mage/Adminhtml/Helper/Rss.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Helper/Sales.php
+++ b/app/code/core/Mage/Adminhtml/Helper/Sales.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Helper/Sales.php
+++ b/app/code/core/Mage/Adminhtml/Helper/Sales.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Helper/Sales.php
+++ b/app/code/core/Mage/Adminhtml/Helper/Sales.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/Config.php
+++ b/app/code/core/Mage/Adminhtml/Model/Config.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/Config.php
+++ b/app/code/core/Mage/Adminhtml/Model/Config.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/Config.php
+++ b/app/code/core/Mage/Adminhtml/Model/Config.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/Config/Data.php
+++ b/app/code/core/Mage/Adminhtml/Model/Config/Data.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/Config/Data.php
+++ b/app/code/core/Mage/Adminhtml/Model/Config/Data.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/Config/Data.php
+++ b/app/code/core/Mage/Adminhtml/Model/Config/Data.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/Customer/Renderer/Region.php
+++ b/app/code/core/Mage/Adminhtml/Model/Customer/Renderer/Region.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/Customer/Renderer/Region.php
+++ b/app/code/core/Mage/Adminhtml/Model/Customer/Renderer/Region.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/Customer/Renderer/Region.php
+++ b/app/code/core/Mage/Adminhtml/Model/Customer/Renderer/Region.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/Email/PathValidator.php
+++ b/app/code/core/Mage/Adminhtml/Model/Email/PathValidator.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/Email/PathValidator.php
+++ b/app/code/core/Mage/Adminhtml/Model/Email/PathValidator.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/Email/PathValidator.php
+++ b/app/code/core/Mage/Adminhtml/Model/Email/PathValidator.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/Email/Template.php
+++ b/app/code/core/Mage/Adminhtml/Model/Email/Template.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/Email/Template.php
+++ b/app/code/core/Mage/Adminhtml/Model/Email/Template.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/Email/Template.php
+++ b/app/code/core/Mage/Adminhtml/Model/Email/Template.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/Giftmessage/Save.php
+++ b/app/code/core/Mage/Adminhtml/Model/Giftmessage/Save.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/Giftmessage/Save.php
+++ b/app/code/core/Mage/Adminhtml/Model/Giftmessage/Save.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/Giftmessage/Save.php
+++ b/app/code/core/Mage/Adminhtml/Model/Giftmessage/Save.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/LayoutUpdate/Validator.php
+++ b/app/code/core/Mage/Adminhtml/Model/LayoutUpdate/Validator.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/LayoutUpdate/Validator.php
+++ b/app/code/core/Mage/Adminhtml/Model/LayoutUpdate/Validator.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/LayoutUpdate/Validator.php
+++ b/app/code/core/Mage/Adminhtml/Model/LayoutUpdate/Validator.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/Newsletter/Renderer/Text.php
+++ b/app/code/core/Mage/Adminhtml/Model/Newsletter/Renderer/Text.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/Newsletter/Renderer/Text.php
+++ b/app/code/core/Mage/Adminhtml/Model/Newsletter/Renderer/Text.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/Newsletter/Renderer/Text.php
+++ b/app/code/core/Mage/Adminhtml/Model/Newsletter/Renderer/Text.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/Observer.php
+++ b/app/code/core/Mage/Adminhtml/Model/Observer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/Observer.php
+++ b/app/code/core/Mage/Adminhtml/Model/Observer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/Observer.php
+++ b/app/code/core/Mage/Adminhtml/Model/Observer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/Report/Item.php
+++ b/app/code/core/Mage/Adminhtml/Model/Report/Item.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/Report/Item.php
+++ b/app/code/core/Mage/Adminhtml/Model/Report/Item.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/Report/Item.php
+++ b/app/code/core/Mage/Adminhtml/Model/Report/Item.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/Sales/Order.php
+++ b/app/code/core/Mage/Adminhtml/Model/Sales/Order.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/Sales/Order.php
+++ b/app/code/core/Mage/Adminhtml/Model/Sales/Order.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/Sales/Order.php
+++ b/app/code/core/Mage/Adminhtml/Model/Sales/Order.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/Sales/Order/Create.php
+++ b/app/code/core/Mage/Adminhtml/Model/Sales/Order/Create.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/Sales/Order/Create.php
+++ b/app/code/core/Mage/Adminhtml/Model/Sales/Order/Create.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/Sales/Order/Create.php
+++ b/app/code/core/Mage/Adminhtml/Model/Sales/Order/Create.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/Sales/Order/Random.php
+++ b/app/code/core/Mage/Adminhtml/Model/Sales/Order/Random.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/Sales/Order/Random.php
+++ b/app/code/core/Mage/Adminhtml/Model/Sales/Order/Random.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/Sales/Order/Random.php
+++ b/app/code/core/Mage/Adminhtml/Model/Sales/Order/Random.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/Search/Catalog.php
+++ b/app/code/core/Mage/Adminhtml/Model/Search/Catalog.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/Search/Catalog.php
+++ b/app/code/core/Mage/Adminhtml/Model/Search/Catalog.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/Search/Catalog.php
+++ b/app/code/core/Mage/Adminhtml/Model/Search/Catalog.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/Search/Customer.php
+++ b/app/code/core/Mage/Adminhtml/Model/Search/Customer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/Search/Customer.php
+++ b/app/code/core/Mage/Adminhtml/Model/Search/Customer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/Search/Customer.php
+++ b/app/code/core/Mage/Adminhtml/Model/Search/Customer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/Search/Order.php
+++ b/app/code/core/Mage/Adminhtml/Model/Search/Order.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/Search/Order.php
+++ b/app/code/core/Mage/Adminhtml/Model/Search/Order.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/Search/Order.php
+++ b/app/code/core/Mage/Adminhtml/Model/Search/Order.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/Session.php
+++ b/app/code/core/Mage/Adminhtml/Model/Session.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/Session.php
+++ b/app/code/core/Mage/Adminhtml/Model/Session.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/Session.php
+++ b/app/code/core/Mage/Adminhtml/Model/Session.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/Session/Quote.php
+++ b/app/code/core/Mage/Adminhtml/Model/Session/Quote.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/Session/Quote.php
+++ b/app/code/core/Mage/Adminhtml/Model/Session/Quote.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/Session/Quote.php
+++ b/app/code/core/Mage/Adminhtml/Model/Session/Quote.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Admin/Custom.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Admin/Custom.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Admin/Custom.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Admin/Custom.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Admin/Custom.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Admin/Custom.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Admin/Custompath.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Admin/Custompath.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Admin/Custompath.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Admin/Custompath.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Admin/Custompath.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Admin/Custompath.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Admin/Observer.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Admin/Observer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Admin/Observer.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Admin/Observer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Admin/Observer.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Admin/Observer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Admin/Password/Link/Expirationperiod.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Admin/Password/Link/Expirationperiod.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Admin/Password/Link/Expirationperiod.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Admin/Password/Link/Expirationperiod.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Admin/Password/Link/Expirationperiod.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Admin/Password/Link/Expirationperiod.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Admin/Usecustom.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Admin/Usecustom.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Admin/Usecustom.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Admin/Usecustom.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Admin/Usecustom.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Admin/Usecustom.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Admin/Usecustompath.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Admin/Usecustompath.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Admin/Usecustompath.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Admin/Usecustompath.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Admin/Usecustompath.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Admin/Usecustompath.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Admin/Usesecretkey.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Admin/Usesecretkey.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Admin/Usesecretkey.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Admin/Usesecretkey.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Admin/Usesecretkey.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Admin/Usesecretkey.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Baseurl.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Baseurl.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Baseurl.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Baseurl.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Baseurl.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Baseurl.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Cache.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Cache.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Cache.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Cache.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Cache.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Cache.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Catalog/Inventory/Managestock.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Catalog/Inventory/Managestock.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Catalog/Inventory/Managestock.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Catalog/Inventory/Managestock.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Catalog/Inventory/Managestock.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Catalog/Inventory/Managestock.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Catalog/Search/Separator.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Catalog/Search/Separator.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Catalog/Search/Separator.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Catalog/Search/Separator.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Catalog/Search/Separator.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Catalog/Search/Separator.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Catalog/Search/Type.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Catalog/Search/Type.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Catalog/Search/Type.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Catalog/Search/Type.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Catalog/Search/Type.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Catalog/Search/Type.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Category.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Category.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Category.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Category.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Category.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Category.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Color.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Color.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Color.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Color.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Color.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Color.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Cookie.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Cookie.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Cookie.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Cookie.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Cookie.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Cookie.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Currency/Abstract.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Currency/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Currency/Abstract.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Currency/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Currency/Abstract.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Currency/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Currency/Allow.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Currency/Allow.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Currency/Allow.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Currency/Allow.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Currency/Allow.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Currency/Allow.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Currency/Base.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Currency/Base.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Currency/Base.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Currency/Base.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Currency/Base.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Currency/Base.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Currency/Cron.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Currency/Cron.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Currency/Cron.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Currency/Cron.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Currency/Cron.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Currency/Cron.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Currency/Default.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Currency/Default.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Currency/Default.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Currency/Default.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Currency/Default.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Currency/Default.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Customer/Address/Street.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Customer/Address/Street.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Customer/Address/Street.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Customer/Address/Street.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Customer/Address/Street.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Customer/Address/Street.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Customer/Password/Link/Expirationperiod.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Customer/Password/Link/Expirationperiod.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Customer/Password/Link/Expirationperiod.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Customer/Password/Link/Expirationperiod.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Customer/Password/Link/Expirationperiod.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Customer/Password/Link/Expirationperiod.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Customer/Show/Address.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Customer/Show/Address.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Customer/Show/Address.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Customer/Show/Address.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Customer/Show/Address.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Customer/Show/Address.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Customer/Show/Customer.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Customer/Show/Customer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Customer/Show/Customer.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Customer/Show/Customer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Customer/Show/Customer.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Customer/Show/Customer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Datashare.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Datashare.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Datashare.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Datashare.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Datashare.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Datashare.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Design/Exception.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Design/Exception.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Design/Exception.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Design/Exception.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Design/Exception.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Design/Exception.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Design/Package.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Design/Package.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Design/Package.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Design/Package.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Design/Package.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Design/Package.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Email/Address.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Email/Address.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Email/Address.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Email/Address.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Email/Address.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Email/Address.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Email/Logo.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Email/Logo.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Email/Logo.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Email/Logo.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Email/Logo.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Email/Logo.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Email/Sender.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Email/Sender.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Email/Sender.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Email/Sender.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Email/Sender.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Email/Sender.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Encrypted.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Encrypted.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Encrypted.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Encrypted.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Encrypted.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Encrypted.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/File.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/File.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/File.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/File.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/File.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/File.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Filename.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Filename.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Filename.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Filename.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Filename.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Filename.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Gatewayurl.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Gatewayurl.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Gatewayurl.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Gatewayurl.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Gatewayurl.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Gatewayurl.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Image.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Image.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Image.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Image.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Image.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Image.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Image/Favicon.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Image/Favicon.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Image/Favicon.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Image/Favicon.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Image/Favicon.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Image/Favicon.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Image/Pdf.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Image/Pdf.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Image/Pdf.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Image/Pdf.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Image/Pdf.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Image/Pdf.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Layer/Children.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Layer/Children.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Layer/Children.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Layer/Children.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Layer/Children.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Layer/Children.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Locale.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Locale.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Locale.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Locale.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Locale.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Locale.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Locale/Timezone.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Locale/Timezone.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Locale/Timezone.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Locale/Timezone.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Locale/Timezone.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Locale/Timezone.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Log/Cron.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Log/Cron.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Log/Cron.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Log/Cron.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Log/Cron.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Log/Cron.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Passwordlength.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Passwordlength.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Passwordlength.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Passwordlength.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Passwordlength.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Passwordlength.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Price/Scope.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Price/Scope.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Price/Scope.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Price/Scope.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Price/Scope.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Price/Scope.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Product/Alert/Cron.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Product/Alert/Cron.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Product/Alert/Cron.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Product/Alert/Cron.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Product/Alert/Cron.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Product/Alert/Cron.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Protected.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Protected.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Protected.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Protected.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Protected.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Protected.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Secure.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Secure.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Secure.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Secure.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Secure.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Secure.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Seo/Product.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Seo/Product.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Seo/Product.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Seo/Product.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Seo/Product.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Seo/Product.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Serialized.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Serialized.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Serialized.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Serialized.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Serialized.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Serialized.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Serialized/Array.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Serialized/Array.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Serialized/Array.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Serialized/Array.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Serialized/Array.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Serialized/Array.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Shipping/Tablerate.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Shipping/Tablerate.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Shipping/Tablerate.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Shipping/Tablerate.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Shipping/Tablerate.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Shipping/Tablerate.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Sitemap.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Sitemap.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Sitemap.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Sitemap.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Sitemap.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Sitemap.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Sitemap/Cron.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Sitemap/Cron.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Sitemap/Cron.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Sitemap/Cron.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Sitemap/Cron.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Sitemap/Cron.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Storage/Media/Database.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Storage/Media/Database.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Storage/Media/Database.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Storage/Media/Database.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Storage/Media/Database.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Storage/Media/Database.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Store.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Store.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Store.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Store.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Store.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Store.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Symlink.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Symlink.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Symlink.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Symlink.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Symlink.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Symlink.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Translate.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Translate.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Translate.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Translate.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Translate.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Translate.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Web/Secure/Offloaderheader.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Web/Secure/Offloaderheader.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Web/Secure/Offloaderheader.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Web/Secure/Offloaderheader.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Web/Secure/Offloaderheader.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Web/Secure/Offloaderheader.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Clone/Media/Image.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Clone/Media/Image.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Clone/Media/Image.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Clone/Media/Image.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Clone/Media/Image.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Clone/Media/Image.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Admin/Page.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Admin/Page.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Admin/Page.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Admin/Page.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Admin/Page.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Admin/Page.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Allregion.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Allregion.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Allregion.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Allregion.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Allregion.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Allregion.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Catalog/GridPerPage.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Catalog/GridPerPage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Catalog/GridPerPage.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Catalog/GridPerPage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Catalog/GridPerPage.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Catalog/GridPerPage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Catalog/ListMode.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Catalog/ListMode.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Catalog/ListMode.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Catalog/ListMode.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Catalog/ListMode.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Catalog/ListMode.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Catalog/ListPerPage.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Catalog/ListPerPage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Catalog/ListPerPage.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Catalog/ListPerPage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Catalog/ListPerPage.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Catalog/ListPerPage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Catalog/ListSort.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Catalog/ListSort.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Catalog/ListSort.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Catalog/ListSort.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Catalog/ListSort.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Catalog/ListSort.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Catalog/Search/Separator.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Catalog/Search/Separator.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Catalog/Search/Separator.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Catalog/Search/Separator.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Catalog/Search/Separator.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Catalog/Search/Separator.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Catalog/Search/Type.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Catalog/Search/Type.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Catalog/Search/Type.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Catalog/Search/Type.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Catalog/Search/Type.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Catalog/Search/Type.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Catalog/TimeFormat.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Catalog/TimeFormat.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Catalog/TimeFormat.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Catalog/TimeFormat.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Catalog/TimeFormat.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Catalog/TimeFormat.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Category.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Category.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Category.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Category.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Category.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Category.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Checktype.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Checktype.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Checktype.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Checktype.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Checktype.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Checktype.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Cms/Page.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Cms/Page.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Cms/Page.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Cms/Page.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Cms/Page.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Cms/Page.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Cms/Wysiwyg/Enabled.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Cms/Wysiwyg/Enabled.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Cms/Wysiwyg/Enabled.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Cms/Wysiwyg/Enabled.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Cms/Wysiwyg/Enabled.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Cms/Wysiwyg/Enabled.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Cookie/Samesite.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Cookie/Samesite.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Cookie/Samesite.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Cookie/Samesite.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Cookie/Samesite.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Cookie/Samesite.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Country.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Country.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Country.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Country.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Country.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Country.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Country/Full.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Country/Full.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Country/Full.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Country/Full.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Country/Full.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Country/Full.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Cron/Frequency.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Cron/Frequency.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Cron/Frequency.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Cron/Frequency.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Cron/Frequency.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Cron/Frequency.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Currency.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Currency.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Currency.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Currency.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Currency.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Currency.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Currency/Service.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Currency/Service.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Currency/Service.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Currency/Service.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Currency/Service.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Currency/Service.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Customer/Address/Type.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Customer/Address/Type.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Customer/Address/Type.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Customer/Address/Type.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Customer/Address/Type.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Customer/Address/Type.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Customer/Forgotpassword.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Customer/Forgotpassword.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Customer/Forgotpassword.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Customer/Forgotpassword.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Customer/Forgotpassword.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Customer/Forgotpassword.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Customer/Group.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Customer/Group.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Customer/Group.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Customer/Group.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Customer/Group.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Customer/Group.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Customer/Group/Multiselect.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Customer/Group/Multiselect.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Customer/Group/Multiselect.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Customer/Group/Multiselect.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Customer/Group/Multiselect.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Customer/Group/Multiselect.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Date/Short.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Date/Short.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Date/Short.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Date/Short.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Date/Short.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Date/Short.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Design/Package.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Design/Package.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Design/Package.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Design/Package.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Design/Package.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Design/Package.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Design/Robots.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Design/Robots.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Design/Robots.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Design/Robots.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Design/Robots.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Design/Robots.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Dev/Dbautoup.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Dev/Dbautoup.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Dev/Dbautoup.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Dev/Dbautoup.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Dev/Dbautoup.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Dev/Dbautoup.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Email/Identity.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Email/Identity.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Email/Identity.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Email/Identity.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Email/Identity.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Email/Identity.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Email/Method.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Email/Method.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Email/Method.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Email/Method.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Email/Method.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Email/Method.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Email/Smtpauth.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Email/Smtpauth.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Email/Smtpauth.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Email/Smtpauth.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Email/Smtpauth.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Email/Smtpauth.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Email/Template.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Email/Template.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Email/Template.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Email/Template.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Email/Template.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Email/Template.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Enabledisable.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Enabledisable.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Enabledisable.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Enabledisable.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Enabledisable.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Enabledisable.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Frequency.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Frequency.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Frequency.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Frequency.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Frequency.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Frequency.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Language.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Language.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Language.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Language.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Language.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Language.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Locale.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Locale.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Locale.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Locale.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Locale.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Locale.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Locale/Country.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Locale/Country.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Locale/Country.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Locale/Country.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Locale/Country.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Locale/Country.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Locale/Currency.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Locale/Currency.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Locale/Currency.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Locale/Currency.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Locale/Currency.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Locale/Currency.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Locale/Currency/All.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Locale/Currency/All.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Locale/Currency/All.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Locale/Currency/All.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Locale/Currency/All.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Locale/Currency/All.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Locale/Timezone.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Locale/Timezone.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Locale/Timezone.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Locale/Timezone.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Locale/Timezone.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Locale/Timezone.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Locale/Weekdaycodes.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Locale/Weekdaycodes.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Locale/Weekdaycodes.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Locale/Weekdaycodes.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Locale/Weekdaycodes.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Locale/Weekdaycodes.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Locale/Weekdays.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Locale/Weekdays.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Locale/Weekdays.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Locale/Weekdays.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Locale/Weekdays.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Locale/Weekdays.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Log/Level.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Log/Level.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Log/Level.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Log/Level.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Log/Level.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Log/Level.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Nooptreq.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Nooptreq.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Nooptreq.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Nooptreq.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Nooptreq.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Nooptreq.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Notification/Frequency.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Notification/Frequency.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Notification/Frequency.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Notification/Frequency.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Notification/Frequency.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Notification/Frequency.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Order/Status.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Order/Status.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Order/Status.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Order/Status.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Order/Status.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Order/Status.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Order/Status/New.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Order/Status/New.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Order/Status/New.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Order/Status/New.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Order/Status/New.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Order/Status/New.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Order/Status/Newprocessing.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Order/Status/Newprocessing.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Order/Status/Newprocessing.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Order/Status/Newprocessing.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Order/Status/Newprocessing.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Order/Status/Newprocessing.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Order/Status/Processing.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Order/Status/Processing.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Order/Status/Processing.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Order/Status/Processing.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Order/Status/Processing.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Order/Status/Processing.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Payment/Allmethods.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Payment/Allmethods.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Payment/Allmethods.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Payment/Allmethods.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Payment/Allmethods.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Payment/Allmethods.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Payment/Allowedmethods.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Payment/Allowedmethods.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Payment/Allowedmethods.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Payment/Allowedmethods.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Payment/Allowedmethods.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Payment/Allowedmethods.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Payment/Allspecificcountries.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Payment/Allspecificcountries.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Payment/Allspecificcountries.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Payment/Allspecificcountries.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Payment/Allspecificcountries.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Payment/Allspecificcountries.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Payment/Cctype.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Payment/Cctype.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Payment/Cctype.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Payment/Cctype.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Payment/Cctype.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Payment/Cctype.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Price/Scope.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Price/Scope.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Price/Scope.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Price/Scope.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Price/Scope.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Price/Scope.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Price/Step.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Price/Step.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Price/Step.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Price/Step.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Price/Step.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Price/Step.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Product/Options/Price.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Product/Options/Price.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Product/Options/Price.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Product/Options/Price.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Product/Options/Price.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Product/Options/Price.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Product/Options/Type.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Product/Options/Type.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Product/Options/Type.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Product/Options/Type.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Product/Options/Type.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Product/Options/Type.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Product/Thumbnail.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Product/Thumbnail.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Product/Thumbnail.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Product/Thumbnail.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Product/Thumbnail.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Product/Thumbnail.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Reports/Scope.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Reports/Scope.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Reports/Scope.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Reports/Scope.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Reports/Scope.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Reports/Scope.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Security/Domainpolicy.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Security/Domainpolicy.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Security/Domainpolicy.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Security/Domainpolicy.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Security/Domainpolicy.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Security/Domainpolicy.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Shipping/Allmethods.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Shipping/Allmethods.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Shipping/Allmethods.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Shipping/Allmethods.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Shipping/Allmethods.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Shipping/Allmethods.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Shipping/Allowedmethods.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Shipping/Allowedmethods.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Shipping/Allowedmethods.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Shipping/Allowedmethods.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Shipping/Allowedmethods.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Shipping/Allowedmethods.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Shipping/Allspecificcountries.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Shipping/Allspecificcountries.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Shipping/Allspecificcountries.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Shipping/Allspecificcountries.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Shipping/Allspecificcountries.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Shipping/Allspecificcountries.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Shipping/Flatrate.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Shipping/Flatrate.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Shipping/Flatrate.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Shipping/Flatrate.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Shipping/Flatrate.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Shipping/Flatrate.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Shipping/Tablerate.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Shipping/Tablerate.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Shipping/Tablerate.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Shipping/Tablerate.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Shipping/Tablerate.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Shipping/Tablerate.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Shipping/Taxclass.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Shipping/Taxclass.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Shipping/Taxclass.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Shipping/Taxclass.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Shipping/Taxclass.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Shipping/Taxclass.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Storage/Media/Database.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Storage/Media/Database.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Storage/Media/Database.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Storage/Media/Database.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Storage/Media/Database.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Storage/Media/Database.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Storage/Media/Storage.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Storage/Media/Storage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Storage/Media/Storage.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Storage/Media/Storage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Storage/Media/Storage.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Storage/Media/Storage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Store.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Store.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Store.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Store.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Store.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Store.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Tax/Apply/On.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Tax/Apply/On.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Tax/Apply/On.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Tax/Apply/On.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Tax/Apply/On.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Tax/Apply/On.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Tax/Basedon.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Tax/Basedon.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Tax/Basedon.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Tax/Basedon.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Tax/Basedon.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Tax/Basedon.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Tax/Catalog.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Tax/Catalog.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Tax/Catalog.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Tax/Catalog.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Tax/Catalog.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Tax/Catalog.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Watermark/Position.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Watermark/Position.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Watermark/Position.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Watermark/Position.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Watermark/Position.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Watermark/Position.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Web/Protocol.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Web/Protocol.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Web/Protocol.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Web/Protocol.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Web/Protocol.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Web/Protocol.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Web/Redirect.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Web/Redirect.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Web/Redirect.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Web/Redirect.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Web/Redirect.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Web/Redirect.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Website.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Website.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Website.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Website.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Website.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Website.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Yesno.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Yesno.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Yesno.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Yesno.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Yesno.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Yesno.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Yesnocustom.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Yesnocustom.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Yesnocustom.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Yesnocustom.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Yesnocustom.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Yesnocustom.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Store.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Store.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/System/Store.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Store.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/System/Store.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Store.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/Url.php
+++ b/app/code/core/Mage/Adminhtml/Model/Url.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/Model/Url.php
+++ b/app/code/core/Mage/Adminhtml/Model/Url.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/Model/Url.php
+++ b/app/code/core/Mage/Adminhtml/Model/Url.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/AjaxController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/AjaxController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/AjaxController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/AjaxController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/AjaxController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/AjaxController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Api/RoleController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Api/RoleController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/Api/RoleController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Api/RoleController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Api/RoleController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Api/RoleController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Api/UserController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Api/UserController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/Api/UserController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Api/UserController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Api/UserController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Api/UserController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/CacheController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/CacheController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/CacheController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/CacheController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/CacheController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/CacheController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Catalog/Category/WidgetController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Catalog/Category/WidgetController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/Catalog/Category/WidgetController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Catalog/Category/WidgetController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Catalog/Category/WidgetController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Catalog/Category/WidgetController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Catalog/CategoryController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Catalog/CategoryController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/Catalog/CategoryController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Catalog/CategoryController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Catalog/CategoryController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Catalog/CategoryController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Catalog/Product/Action/AttributeController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Catalog/Product/Action/AttributeController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/Catalog/Product/Action/AttributeController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Catalog/Product/Action/AttributeController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Catalog/Product/Action/AttributeController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Catalog/Product/Action/AttributeController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Catalog/Product/AttributeController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Catalog/Product/AttributeController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/Catalog/Product/AttributeController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Catalog/Product/AttributeController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Catalog/Product/AttributeController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Catalog/Product/AttributeController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Catalog/Product/DatafeedsController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Catalog/Product/DatafeedsController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/Catalog/Product/DatafeedsController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Catalog/Product/DatafeedsController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Catalog/Product/DatafeedsController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Catalog/Product/DatafeedsController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Catalog/Product/GalleryController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Catalog/Product/GalleryController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/Catalog/Product/GalleryController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Catalog/Product/GalleryController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Catalog/Product/GalleryController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Catalog/Product/GalleryController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Catalog/Product/GroupController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Catalog/Product/GroupController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/Catalog/Product/GroupController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Catalog/Product/GroupController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Catalog/Product/GroupController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Catalog/Product/GroupController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Catalog/Product/ReviewController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Catalog/Product/ReviewController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/Catalog/Product/ReviewController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Catalog/Product/ReviewController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Catalog/Product/ReviewController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Catalog/Product/ReviewController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Catalog/Product/SetController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Catalog/Product/SetController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/Catalog/Product/SetController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Catalog/Product/SetController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Catalog/Product/SetController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Catalog/Product/SetController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Catalog/Product/WidgetController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Catalog/Product/WidgetController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/Catalog/Product/WidgetController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Catalog/Product/WidgetController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Catalog/Product/WidgetController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Catalog/Product/WidgetController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Catalog/ProductController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Catalog/ProductController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/Catalog/ProductController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Catalog/ProductController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Catalog/ProductController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Catalog/ProductController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Catalog/SearchController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Catalog/SearchController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/Catalog/SearchController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Catalog/SearchController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Catalog/SearchController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Catalog/SearchController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/CatalogController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/CatalogController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/CatalogController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/CatalogController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/CatalogController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/CatalogController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Checkout/AgreementController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Checkout/AgreementController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/Checkout/AgreementController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Checkout/AgreementController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Checkout/AgreementController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Checkout/AgreementController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Cms/Block/WidgetController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Cms/Block/WidgetController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/Cms/Block/WidgetController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Cms/Block/WidgetController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Cms/Block/WidgetController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Cms/Block/WidgetController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Cms/BlockController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Cms/BlockController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/Cms/BlockController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Cms/BlockController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Cms/BlockController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Cms/BlockController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Cms/Page/WidgetController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Cms/Page/WidgetController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/Cms/Page/WidgetController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Cms/Page/WidgetController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Cms/Page/WidgetController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Cms/Page/WidgetController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Cms/PageController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Cms/PageController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/Cms/PageController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Cms/PageController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Cms/PageController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Cms/PageController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Cms/Wysiwyg/ImagesController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Cms/Wysiwyg/ImagesController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/Cms/Wysiwyg/ImagesController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Cms/Wysiwyg/ImagesController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Cms/Wysiwyg/ImagesController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Cms/Wysiwyg/ImagesController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Cms/WysiwygController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Cms/WysiwygController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/Cms/WysiwygController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Cms/WysiwygController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Cms/WysiwygController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Cms/WysiwygController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Customer/Cart/Product/Composite/CartController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Customer/Cart/Product/Composite/CartController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/Customer/Cart/Product/Composite/CartController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Customer/Cart/Product/Composite/CartController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Customer/Cart/Product/Composite/CartController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Customer/Cart/Product/Composite/CartController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Customer/ConfigController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Customer/ConfigController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/Customer/ConfigController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Customer/ConfigController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Customer/ConfigController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Customer/ConfigController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Customer/GroupController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Customer/GroupController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/Customer/GroupController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Customer/GroupController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Customer/GroupController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Customer/GroupController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Customer/OnlineController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Customer/OnlineController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/Customer/OnlineController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Customer/OnlineController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Customer/OnlineController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Customer/OnlineController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Customer/System/Config/ValidatevatController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Customer/System/Config/ValidatevatController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/Customer/System/Config/ValidatevatController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Customer/System/Config/ValidatevatController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Customer/System/Config/ValidatevatController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Customer/System/Config/ValidatevatController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Customer/Wishlist/Product/Composite/WishlistController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Customer/Wishlist/Product/Composite/WishlistController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/Customer/Wishlist/Product/Composite/WishlistController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Customer/Wishlist/Product/Composite/WishlistController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Customer/Wishlist/Product/Composite/WishlistController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Customer/Wishlist/Product/Composite/WishlistController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/CustomerController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/CustomerController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/CustomerController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/CustomerController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/CustomerController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/CustomerController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/DashboardController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/DashboardController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/DashboardController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/DashboardController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/DashboardController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/DashboardController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/IndexController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/IndexController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/IndexController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/IndexController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/IndexController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/IndexController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/JsonController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/JsonController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/JsonController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/JsonController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/JsonController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/JsonController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Media/EditorController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Media/EditorController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/Media/EditorController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Media/EditorController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Media/EditorController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Media/EditorController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Media/UploaderController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Media/UploaderController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/Media/UploaderController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Media/UploaderController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Media/UploaderController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Media/UploaderController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Newsletter/ProblemController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Newsletter/ProblemController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/Newsletter/ProblemController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Newsletter/ProblemController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Newsletter/ProblemController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Newsletter/ProblemController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Newsletter/QueueController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Newsletter/QueueController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/Newsletter/QueueController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Newsletter/QueueController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Newsletter/QueueController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Newsletter/QueueController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Newsletter/SubscriberController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Newsletter/SubscriberController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/Newsletter/SubscriberController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Newsletter/SubscriberController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Newsletter/SubscriberController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Newsletter/SubscriberController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Newsletter/TemplateController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Newsletter/TemplateController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/Newsletter/TemplateController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Newsletter/TemplateController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Newsletter/TemplateController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Newsletter/TemplateController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/NotificationController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/NotificationController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/NotificationController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/NotificationController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/NotificationController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/NotificationController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Permissions/BlockController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Permissions/BlockController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/Permissions/BlockController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Permissions/BlockController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Permissions/BlockController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Permissions/BlockController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Permissions/RoleController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Permissions/RoleController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/Permissions/RoleController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Permissions/RoleController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Permissions/RoleController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Permissions/RoleController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Permissions/UserController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Permissions/UserController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/Permissions/UserController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Permissions/UserController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Permissions/UserController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Permissions/UserController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Permissions/VariableController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Permissions/VariableController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/Permissions/VariableController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Permissions/VariableController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Permissions/VariableController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Permissions/VariableController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Poll/AnswerController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Poll/AnswerController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/Poll/AnswerController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Poll/AnswerController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Poll/AnswerController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Poll/AnswerController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/PollController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/PollController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/PollController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/PollController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/PollController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/PollController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Promo/CatalogController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Promo/CatalogController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/Promo/CatalogController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Promo/CatalogController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Promo/CatalogController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Promo/CatalogController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Promo/QuoteController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Promo/QuoteController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/Promo/QuoteController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Promo/QuoteController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Promo/QuoteController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Promo/QuoteController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Promo/WidgetController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Promo/WidgetController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/Promo/WidgetController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Promo/WidgetController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Promo/WidgetController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Promo/WidgetController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/PromoController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/PromoController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/PromoController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/PromoController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/PromoController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/PromoController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/RatingController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/RatingController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/RatingController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/RatingController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/RatingController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/RatingController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Report/CustomerController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Report/CustomerController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/Report/CustomerController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Report/CustomerController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Report/CustomerController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Report/CustomerController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Report/ProductController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Report/ProductController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/Report/ProductController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Report/ProductController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Report/ProductController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Report/ProductController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Report/ReviewController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Report/ReviewController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/Report/ReviewController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Report/ReviewController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Report/ReviewController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Report/ReviewController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Report/SalesController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Report/SalesController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/Report/SalesController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Report/SalesController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Report/SalesController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Report/SalesController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Report/ShopcartController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Report/ShopcartController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/Report/ShopcartController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Report/ShopcartController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Report/ShopcartController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Report/ShopcartController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Report/StatisticsController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Report/StatisticsController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/Report/StatisticsController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Report/StatisticsController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Report/StatisticsController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Report/StatisticsController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Report/TagController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Report/TagController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/Report/TagController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Report/TagController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Report/TagController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Report/TagController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/ReportController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/ReportController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/ReportController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/ReportController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/ReportController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/ReportController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Rss/CatalogController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Rss/CatalogController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/Rss/CatalogController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Rss/CatalogController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Rss/CatalogController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Rss/CatalogController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Rss/OrderController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Rss/OrderController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/Rss/OrderController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Rss/OrderController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Rss/OrderController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Rss/OrderController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Sales/Billing/AgreementController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Sales/Billing/AgreementController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/Sales/Billing/AgreementController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Sales/Billing/AgreementController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Sales/Billing/AgreementController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Sales/Billing/AgreementController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Sales/CreditmemoController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Sales/CreditmemoController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/Sales/CreditmemoController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Sales/CreditmemoController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Sales/CreditmemoController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Sales/CreditmemoController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Sales/InvoiceController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Sales/InvoiceController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/Sales/InvoiceController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Sales/InvoiceController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Sales/InvoiceController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Sales/InvoiceController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Sales/Order/CreateController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Sales/Order/CreateController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/Sales/Order/CreateController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Sales/Order/CreateController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Sales/Order/CreateController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Sales/Order/CreateController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Sales/Order/CreditmemoController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Sales/Order/CreditmemoController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/Sales/Order/CreditmemoController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Sales/Order/CreditmemoController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Sales/Order/CreditmemoController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Sales/Order/CreditmemoController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Sales/Order/EditController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Sales/Order/EditController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/Sales/Order/EditController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Sales/Order/EditController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Sales/Order/EditController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Sales/Order/EditController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Sales/Order/InvoiceController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Sales/Order/InvoiceController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/Sales/Order/InvoiceController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Sales/Order/InvoiceController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Sales/Order/InvoiceController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Sales/Order/InvoiceController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Sales/Order/ShipmentController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Sales/Order/ShipmentController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/Sales/Order/ShipmentController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Sales/Order/ShipmentController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Sales/Order/ShipmentController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Sales/Order/ShipmentController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Sales/Order/StatusController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Sales/Order/StatusController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/Sales/Order/StatusController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Sales/Order/StatusController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Sales/Order/StatusController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Sales/Order/StatusController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Sales/Order/View/GiftmessageController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Sales/Order/View/GiftmessageController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/Sales/Order/View/GiftmessageController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Sales/Order/View/GiftmessageController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Sales/Order/View/GiftmessageController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Sales/Order/View/GiftmessageController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Sales/OrderController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Sales/OrderController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/Sales/OrderController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Sales/OrderController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Sales/OrderController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Sales/OrderController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Sales/Recurring/ProfileController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Sales/Recurring/ProfileController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/Sales/Recurring/ProfileController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Sales/Recurring/ProfileController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Sales/Recurring/ProfileController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Sales/Recurring/ProfileController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Sales/ShipmentController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Sales/ShipmentController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/Sales/ShipmentController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Sales/ShipmentController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Sales/ShipmentController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Sales/ShipmentController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Sales/TransactionsController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Sales/TransactionsController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/Sales/TransactionsController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Sales/TransactionsController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Sales/TransactionsController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Sales/TransactionsController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/SalesController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/SalesController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/SalesController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/SalesController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/SalesController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/SalesController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/SitemapController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/SitemapController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/SitemapController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/SitemapController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/SitemapController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/SitemapController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/System/AccountController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/System/AccountController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/System/AccountController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/System/AccountController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/System/AccountController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/System/AccountController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/System/CacheController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/System/CacheController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/System/CacheController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/System/CacheController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/System/CacheController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/System/CacheController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/System/Config/System/StorageController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/System/Config/System/StorageController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/System/Config/System/StorageController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/System/Config/System/StorageController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/System/Config/System/StorageController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/System/Config/System/StorageController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/System/ConfigController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/System/ConfigController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/System/ConfigController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/System/ConfigController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/System/ConfigController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/System/ConfigController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/System/Convert/GuiController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/System/Convert/GuiController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/System/Convert/GuiController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/System/Convert/GuiController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/System/Convert/GuiController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/System/Convert/GuiController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/System/Convert/ProfileController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/System/Convert/ProfileController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/System/Convert/ProfileController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/System/Convert/ProfileController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/System/Convert/ProfileController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/System/Convert/ProfileController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/System/CurrencyController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/System/CurrencyController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/System/CurrencyController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/System/CurrencyController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/System/CurrencyController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/System/CurrencyController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/System/DesignController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/System/DesignController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/System/DesignController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/System/DesignController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/System/DesignController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/System/DesignController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/System/Email/TemplateController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/System/Email/TemplateController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/System/Email/TemplateController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/System/Email/TemplateController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/System/Email/TemplateController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/System/Email/TemplateController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/System/StoreController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/System/StoreController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/System/StoreController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/System/StoreController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/System/StoreController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/System/StoreController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/System/VariableController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/System/VariableController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/System/VariableController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/System/VariableController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/System/VariableController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/System/VariableController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/SystemController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/SystemController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/SystemController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/SystemController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/SystemController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/SystemController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/TagController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/TagController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/TagController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/TagController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/TagController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/TagController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Tax/Class/CustomerController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Tax/Class/CustomerController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/Tax/Class/CustomerController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Tax/Class/CustomerController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Tax/Class/CustomerController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Tax/Class/CustomerController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Tax/Class/ProductController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Tax/Class/ProductController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/Tax/Class/ProductController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Tax/Class/ProductController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Tax/Class/ProductController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Tax/Class/ProductController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Tax/ClassController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Tax/ClassController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/Tax/ClassController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Tax/ClassController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Tax/ClassController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Tax/ClassController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Tax/RateController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Tax/RateController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/Tax/RateController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Tax/RateController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Tax/RateController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Tax/RateController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Tax/RuleController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Tax/RuleController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/Tax/RuleController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Tax/RuleController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/Tax/RuleController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Tax/RuleController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/TaxController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/TaxController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/TaxController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/TaxController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/TaxController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/TaxController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/UrlrewriteController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/UrlrewriteController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/controllers/UrlrewriteController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/UrlrewriteController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/controllers/UrlrewriteController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/UrlrewriteController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/etc/adminhtml.xml
+++ b/app/code/core/Mage/Adminhtml/etc/adminhtml.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/etc/adminhtml.xml
+++ b/app/code/core/Mage/Adminhtml/etc/adminhtml.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/etc/adminhtml.xml
+++ b/app/code/core/Mage/Adminhtml/etc/adminhtml.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/etc/config.xml
+++ b/app/code/core/Mage/Adminhtml/etc/config.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/etc/config.xml
+++ b/app/code/core/Mage/Adminhtml/etc/config.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/etc/config.xml
+++ b/app/code/core/Mage/Adminhtml/etc/config.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/etc/jstranslator.xml
+++ b/app/code/core/Mage/Adminhtml/etc/jstranslator.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Adminhtml/etc/jstranslator.xml
+++ b/app/code/core/Mage/Adminhtml/etc/jstranslator.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Adminhtml/etc/jstranslator.xml
+++ b/app/code/core/Mage/Adminhtml/etc/jstranslator.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/code/core/Mage/Api/Controller/Action.php
+++ b/app/code/core/Mage/Api/Controller/Action.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api/Controller/Action.php
+++ b/app/code/core/Mage/Api/Controller/Action.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Controller/Action.php
+++ b/app/code/core/Mage/Api/Controller/Action.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Exception.php
+++ b/app/code/core/Mage/Api/Exception.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api/Exception.php
+++ b/app/code/core/Mage/Api/Exception.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Exception.php
+++ b/app/code/core/Mage/Api/Exception.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Helper/Data.php
+++ b/app/code/core/Mage/Api/Helper/Data.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api/Helper/Data.php
+++ b/app/code/core/Mage/Api/Helper/Data.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Helper/Data.php
+++ b/app/code/core/Mage/Api/Helper/Data.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Acl.php
+++ b/app/code/core/Mage/Api/Model/Acl.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api/Model/Acl.php
+++ b/app/code/core/Mage/Api/Model/Acl.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Acl.php
+++ b/app/code/core/Mage/Api/Model/Acl.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Acl/Assert/Ip.php
+++ b/app/code/core/Mage/Api/Model/Acl/Assert/Ip.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api/Model/Acl/Assert/Ip.php
+++ b/app/code/core/Mage/Api/Model/Acl/Assert/Ip.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Acl/Assert/Ip.php
+++ b/app/code/core/Mage/Api/Model/Acl/Assert/Ip.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Acl/Assert/Time.php
+++ b/app/code/core/Mage/Api/Model/Acl/Assert/Time.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api/Model/Acl/Assert/Time.php
+++ b/app/code/core/Mage/Api/Model/Acl/Assert/Time.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Acl/Assert/Time.php
+++ b/app/code/core/Mage/Api/Model/Acl/Assert/Time.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Acl/Resource.php
+++ b/app/code/core/Mage/Api/Model/Acl/Resource.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api/Model/Acl/Resource.php
+++ b/app/code/core/Mage/Api/Model/Acl/Resource.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Acl/Resource.php
+++ b/app/code/core/Mage/Api/Model/Acl/Resource.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Acl/Role.php
+++ b/app/code/core/Mage/Api/Model/Acl/Role.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api/Model/Acl/Role.php
+++ b/app/code/core/Mage/Api/Model/Acl/Role.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Acl/Role.php
+++ b/app/code/core/Mage/Api/Model/Acl/Role.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Acl/Role/Generic.php
+++ b/app/code/core/Mage/Api/Model/Acl/Role/Generic.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api/Model/Acl/Role/Generic.php
+++ b/app/code/core/Mage/Api/Model/Acl/Role/Generic.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Acl/Role/Generic.php
+++ b/app/code/core/Mage/Api/Model/Acl/Role/Generic.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Acl/Role/Group.php
+++ b/app/code/core/Mage/Api/Model/Acl/Role/Group.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api/Model/Acl/Role/Group.php
+++ b/app/code/core/Mage/Api/Model/Acl/Role/Group.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Acl/Role/Group.php
+++ b/app/code/core/Mage/Api/Model/Acl/Role/Group.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Acl/Role/Registry.php
+++ b/app/code/core/Mage/Api/Model/Acl/Role/Registry.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api/Model/Acl/Role/Registry.php
+++ b/app/code/core/Mage/Api/Model/Acl/Role/Registry.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Acl/Role/Registry.php
+++ b/app/code/core/Mage/Api/Model/Acl/Role/Registry.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Acl/Role/User.php
+++ b/app/code/core/Mage/Api/Model/Acl/Role/User.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api/Model/Acl/Role/User.php
+++ b/app/code/core/Mage/Api/Model/Acl/Role/User.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Acl/Role/User.php
+++ b/app/code/core/Mage/Api/Model/Acl/Role/User.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Config.php
+++ b/app/code/core/Mage/Api/Model/Config.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api/Model/Config.php
+++ b/app/code/core/Mage/Api/Model/Config.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Config.php
+++ b/app/code/core/Mage/Api/Model/Config.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Mysql4/Acl.php
+++ b/app/code/core/Mage/Api/Model/Mysql4/Acl.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api/Model/Mysql4/Acl.php
+++ b/app/code/core/Mage/Api/Model/Mysql4/Acl.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Mysql4/Acl.php
+++ b/app/code/core/Mage/Api/Model/Mysql4/Acl.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Mysql4/Acl/Role.php
+++ b/app/code/core/Mage/Api/Model/Mysql4/Acl/Role.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api/Model/Mysql4/Acl/Role.php
+++ b/app/code/core/Mage/Api/Model/Mysql4/Acl/Role.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Mysql4/Acl/Role.php
+++ b/app/code/core/Mage/Api/Model/Mysql4/Acl/Role.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Mysql4/Acl/Role/Collection.php
+++ b/app/code/core/Mage/Api/Model/Mysql4/Acl/Role/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api/Model/Mysql4/Acl/Role/Collection.php
+++ b/app/code/core/Mage/Api/Model/Mysql4/Acl/Role/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Mysql4/Acl/Role/Collection.php
+++ b/app/code/core/Mage/Api/Model/Mysql4/Acl/Role/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Mysql4/Permissions/Collection.php
+++ b/app/code/core/Mage/Api/Model/Mysql4/Permissions/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api/Model/Mysql4/Permissions/Collection.php
+++ b/app/code/core/Mage/Api/Model/Mysql4/Permissions/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Mysql4/Permissions/Collection.php
+++ b/app/code/core/Mage/Api/Model/Mysql4/Permissions/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Mysql4/Role.php
+++ b/app/code/core/Mage/Api/Model/Mysql4/Role.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api/Model/Mysql4/Role.php
+++ b/app/code/core/Mage/Api/Model/Mysql4/Role.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Mysql4/Role.php
+++ b/app/code/core/Mage/Api/Model/Mysql4/Role.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Mysql4/Role/Collection.php
+++ b/app/code/core/Mage/Api/Model/Mysql4/Role/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api/Model/Mysql4/Role/Collection.php
+++ b/app/code/core/Mage/Api/Model/Mysql4/Role/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Mysql4/Role/Collection.php
+++ b/app/code/core/Mage/Api/Model/Mysql4/Role/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Mysql4/Roles.php
+++ b/app/code/core/Mage/Api/Model/Mysql4/Roles.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api/Model/Mysql4/Roles.php
+++ b/app/code/core/Mage/Api/Model/Mysql4/Roles.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Mysql4/Roles.php
+++ b/app/code/core/Mage/Api/Model/Mysql4/Roles.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Mysql4/Roles/Collection.php
+++ b/app/code/core/Mage/Api/Model/Mysql4/Roles/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api/Model/Mysql4/Roles/Collection.php
+++ b/app/code/core/Mage/Api/Model/Mysql4/Roles/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Mysql4/Roles/Collection.php
+++ b/app/code/core/Mage/Api/Model/Mysql4/Roles/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Mysql4/Roles/User/Collection.php
+++ b/app/code/core/Mage/Api/Model/Mysql4/Roles/User/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api/Model/Mysql4/Roles/User/Collection.php
+++ b/app/code/core/Mage/Api/Model/Mysql4/Roles/User/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Mysql4/Roles/User/Collection.php
+++ b/app/code/core/Mage/Api/Model/Mysql4/Roles/User/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Mysql4/Rules.php
+++ b/app/code/core/Mage/Api/Model/Mysql4/Rules.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api/Model/Mysql4/Rules.php
+++ b/app/code/core/Mage/Api/Model/Mysql4/Rules.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Mysql4/Rules.php
+++ b/app/code/core/Mage/Api/Model/Mysql4/Rules.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Mysql4/Rules/Collection.php
+++ b/app/code/core/Mage/Api/Model/Mysql4/Rules/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api/Model/Mysql4/Rules/Collection.php
+++ b/app/code/core/Mage/Api/Model/Mysql4/Rules/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Mysql4/Rules/Collection.php
+++ b/app/code/core/Mage/Api/Model/Mysql4/Rules/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Mysql4/User.php
+++ b/app/code/core/Mage/Api/Model/Mysql4/User.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api/Model/Mysql4/User.php
+++ b/app/code/core/Mage/Api/Model/Mysql4/User.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Mysql4/User.php
+++ b/app/code/core/Mage/Api/Model/Mysql4/User.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Mysql4/User/Collection.php
+++ b/app/code/core/Mage/Api/Model/Mysql4/User/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api/Model/Mysql4/User/Collection.php
+++ b/app/code/core/Mage/Api/Model/Mysql4/User/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Mysql4/User/Collection.php
+++ b/app/code/core/Mage/Api/Model/Mysql4/User/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Resource/Abstract.php
+++ b/app/code/core/Mage/Api/Model/Resource/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api/Model/Resource/Abstract.php
+++ b/app/code/core/Mage/Api/Model/Resource/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Resource/Abstract.php
+++ b/app/code/core/Mage/Api/Model/Resource/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Resource/Acl.php
+++ b/app/code/core/Mage/Api/Model/Resource/Acl.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api/Model/Resource/Acl.php
+++ b/app/code/core/Mage/Api/Model/Resource/Acl.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Resource/Acl.php
+++ b/app/code/core/Mage/Api/Model/Resource/Acl.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Resource/Acl/Role.php
+++ b/app/code/core/Mage/Api/Model/Resource/Acl/Role.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api/Model/Resource/Acl/Role.php
+++ b/app/code/core/Mage/Api/Model/Resource/Acl/Role.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Resource/Acl/Role.php
+++ b/app/code/core/Mage/Api/Model/Resource/Acl/Role.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Resource/Acl/Role/Collection.php
+++ b/app/code/core/Mage/Api/Model/Resource/Acl/Role/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api/Model/Resource/Acl/Role/Collection.php
+++ b/app/code/core/Mage/Api/Model/Resource/Acl/Role/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Resource/Acl/Role/Collection.php
+++ b/app/code/core/Mage/Api/Model/Resource/Acl/Role/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Resource/Permissions/Collection.php
+++ b/app/code/core/Mage/Api/Model/Resource/Permissions/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api/Model/Resource/Permissions/Collection.php
+++ b/app/code/core/Mage/Api/Model/Resource/Permissions/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Resource/Permissions/Collection.php
+++ b/app/code/core/Mage/Api/Model/Resource/Permissions/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Resource/Role.php
+++ b/app/code/core/Mage/Api/Model/Resource/Role.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api/Model/Resource/Role.php
+++ b/app/code/core/Mage/Api/Model/Resource/Role.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Resource/Role.php
+++ b/app/code/core/Mage/Api/Model/Resource/Role.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Resource/Role/Collection.php
+++ b/app/code/core/Mage/Api/Model/Resource/Role/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api/Model/Resource/Role/Collection.php
+++ b/app/code/core/Mage/Api/Model/Resource/Role/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Resource/Role/Collection.php
+++ b/app/code/core/Mage/Api/Model/Resource/Role/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Resource/Roles.php
+++ b/app/code/core/Mage/Api/Model/Resource/Roles.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api/Model/Resource/Roles.php
+++ b/app/code/core/Mage/Api/Model/Resource/Roles.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Resource/Roles.php
+++ b/app/code/core/Mage/Api/Model/Resource/Roles.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Resource/Roles/Collection.php
+++ b/app/code/core/Mage/Api/Model/Resource/Roles/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api/Model/Resource/Roles/Collection.php
+++ b/app/code/core/Mage/Api/Model/Resource/Roles/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Resource/Roles/Collection.php
+++ b/app/code/core/Mage/Api/Model/Resource/Roles/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Resource/Roles/User/Collection.php
+++ b/app/code/core/Mage/Api/Model/Resource/Roles/User/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api/Model/Resource/Roles/User/Collection.php
+++ b/app/code/core/Mage/Api/Model/Resource/Roles/User/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Resource/Roles/User/Collection.php
+++ b/app/code/core/Mage/Api/Model/Resource/Roles/User/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Resource/Rules.php
+++ b/app/code/core/Mage/Api/Model/Resource/Rules.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api/Model/Resource/Rules.php
+++ b/app/code/core/Mage/Api/Model/Resource/Rules.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Resource/Rules.php
+++ b/app/code/core/Mage/Api/Model/Resource/Rules.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Resource/Rules/Collection.php
+++ b/app/code/core/Mage/Api/Model/Resource/Rules/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api/Model/Resource/Rules/Collection.php
+++ b/app/code/core/Mage/Api/Model/Resource/Rules/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Resource/Rules/Collection.php
+++ b/app/code/core/Mage/Api/Model/Resource/Rules/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Resource/User.php
+++ b/app/code/core/Mage/Api/Model/Resource/User.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api/Model/Resource/User.php
+++ b/app/code/core/Mage/Api/Model/Resource/User.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Resource/User.php
+++ b/app/code/core/Mage/Api/Model/Resource/User.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Resource/User/Collection.php
+++ b/app/code/core/Mage/Api/Model/Resource/User/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api/Model/Resource/User/Collection.php
+++ b/app/code/core/Mage/Api/Model/Resource/User/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Resource/User/Collection.php
+++ b/app/code/core/Mage/Api/Model/Resource/User/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Role.php
+++ b/app/code/core/Mage/Api/Model/Role.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api/Model/Role.php
+++ b/app/code/core/Mage/Api/Model/Role.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Role.php
+++ b/app/code/core/Mage/Api/Model/Role.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Roles.php
+++ b/app/code/core/Mage/Api/Model/Roles.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api/Model/Roles.php
+++ b/app/code/core/Mage/Api/Model/Roles.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Roles.php
+++ b/app/code/core/Mage/Api/Model/Roles.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Rules.php
+++ b/app/code/core/Mage/Api/Model/Rules.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api/Model/Rules.php
+++ b/app/code/core/Mage/Api/Model/Rules.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Rules.php
+++ b/app/code/core/Mage/Api/Model/Rules.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Server.php
+++ b/app/code/core/Mage/Api/Model/Server.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api/Model/Server.php
+++ b/app/code/core/Mage/Api/Model/Server.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Server.php
+++ b/app/code/core/Mage/Api/Model/Server.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Server/Adapter/Interface.php
+++ b/app/code/core/Mage/Api/Model/Server/Adapter/Interface.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api/Model/Server/Adapter/Interface.php
+++ b/app/code/core/Mage/Api/Model/Server/Adapter/Interface.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Server/Adapter/Interface.php
+++ b/app/code/core/Mage/Api/Model/Server/Adapter/Interface.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Server/Adapter/Soap.php
+++ b/app/code/core/Mage/Api/Model/Server/Adapter/Soap.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api/Model/Server/Adapter/Soap.php
+++ b/app/code/core/Mage/Api/Model/Server/Adapter/Soap.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Server/Adapter/Soap.php
+++ b/app/code/core/Mage/Api/Model/Server/Adapter/Soap.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Server/Adapter/Xmlrpc.php
+++ b/app/code/core/Mage/Api/Model/Server/Adapter/Xmlrpc.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api/Model/Server/Adapter/Xmlrpc.php
+++ b/app/code/core/Mage/Api/Model/Server/Adapter/Xmlrpc.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Server/Adapter/Xmlrpc.php
+++ b/app/code/core/Mage/Api/Model/Server/Adapter/Xmlrpc.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Server/Handler.php
+++ b/app/code/core/Mage/Api/Model/Server/Handler.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api/Model/Server/Handler.php
+++ b/app/code/core/Mage/Api/Model/Server/Handler.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Server/Handler.php
+++ b/app/code/core/Mage/Api/Model/Server/Handler.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Server/Handler/Abstract.php
+++ b/app/code/core/Mage/Api/Model/Server/Handler/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api/Model/Server/Handler/Abstract.php
+++ b/app/code/core/Mage/Api/Model/Server/Handler/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Server/Handler/Abstract.php
+++ b/app/code/core/Mage/Api/Model/Server/Handler/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Server/V2/Adapter/Soap.php
+++ b/app/code/core/Mage/Api/Model/Server/V2/Adapter/Soap.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api/Model/Server/V2/Adapter/Soap.php
+++ b/app/code/core/Mage/Api/Model/Server/V2/Adapter/Soap.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Server/V2/Adapter/Soap.php
+++ b/app/code/core/Mage/Api/Model/Server/V2/Adapter/Soap.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Server/V2/Handler.php
+++ b/app/code/core/Mage/Api/Model/Server/V2/Handler.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api/Model/Server/V2/Handler.php
+++ b/app/code/core/Mage/Api/Model/Server/V2/Handler.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Server/V2/Handler.php
+++ b/app/code/core/Mage/Api/Model/Server/V2/Handler.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Server/Wsi/Adapter/Soap.php
+++ b/app/code/core/Mage/Api/Model/Server/Wsi/Adapter/Soap.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api/Model/Server/Wsi/Adapter/Soap.php
+++ b/app/code/core/Mage/Api/Model/Server/Wsi/Adapter/Soap.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Server/Wsi/Adapter/Soap.php
+++ b/app/code/core/Mage/Api/Model/Server/Wsi/Adapter/Soap.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Server/Wsi/Handler.php
+++ b/app/code/core/Mage/Api/Model/Server/Wsi/Handler.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api/Model/Server/Wsi/Handler.php
+++ b/app/code/core/Mage/Api/Model/Server/Wsi/Handler.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Server/Wsi/Handler.php
+++ b/app/code/core/Mage/Api/Model/Server/Wsi/Handler.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Session.php
+++ b/app/code/core/Mage/Api/Model/Session.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api/Model/Session.php
+++ b/app/code/core/Mage/Api/Model/Session.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Session.php
+++ b/app/code/core/Mage/Api/Model/Session.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/User.php
+++ b/app/code/core/Mage/Api/Model/User.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api/Model/User.php
+++ b/app/code/core/Mage/Api/Model/User.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/User.php
+++ b/app/code/core/Mage/Api/Model/User.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Wsdl/Config.php
+++ b/app/code/core/Mage/Api/Model/Wsdl/Config.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api/Model/Wsdl/Config.php
+++ b/app/code/core/Mage/Api/Model/Wsdl/Config.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Wsdl/Config.php
+++ b/app/code/core/Mage/Api/Model/Wsdl/Config.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Wsdl/Config/Base.php
+++ b/app/code/core/Mage/Api/Model/Wsdl/Config/Base.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api/Model/Wsdl/Config/Base.php
+++ b/app/code/core/Mage/Api/Model/Wsdl/Config/Base.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Wsdl/Config/Base.php
+++ b/app/code/core/Mage/Api/Model/Wsdl/Config/Base.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Wsdl/Config/Element.php
+++ b/app/code/core/Mage/Api/Model/Wsdl/Config/Element.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api/Model/Wsdl/Config/Element.php
+++ b/app/code/core/Mage/Api/Model/Wsdl/Config/Element.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/Model/Wsdl/Config/Element.php
+++ b/app/code/core/Mage/Api/Model/Wsdl/Config/Element.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/controllers/IndexController.php
+++ b/app/code/core/Mage/Api/controllers/IndexController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api/controllers/IndexController.php
+++ b/app/code/core/Mage/Api/controllers/IndexController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/controllers/IndexController.php
+++ b/app/code/core/Mage/Api/controllers/IndexController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/controllers/SoapController.php
+++ b/app/code/core/Mage/Api/controllers/SoapController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api/controllers/SoapController.php
+++ b/app/code/core/Mage/Api/controllers/SoapController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/controllers/SoapController.php
+++ b/app/code/core/Mage/Api/controllers/SoapController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/controllers/V2/SoapController.php
+++ b/app/code/core/Mage/Api/controllers/V2/SoapController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api/controllers/V2/SoapController.php
+++ b/app/code/core/Mage/Api/controllers/V2/SoapController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/controllers/V2/SoapController.php
+++ b/app/code/core/Mage/Api/controllers/V2/SoapController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/controllers/XmlrpcController.php
+++ b/app/code/core/Mage/Api/controllers/XmlrpcController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api/controllers/XmlrpcController.php
+++ b/app/code/core/Mage/Api/controllers/XmlrpcController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/controllers/XmlrpcController.php
+++ b/app/code/core/Mage/Api/controllers/XmlrpcController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/etc/adminhtml.xml
+++ b/app/code/core/Mage/Api/etc/adminhtml.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/etc/adminhtml.xml
+++ b/app/code/core/Mage/Api/etc/adminhtml.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/etc/adminhtml.xml
+++ b/app/code/core/Mage/Api/etc/adminhtml.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api/etc/api.xml
+++ b/app/code/core/Mage/Api/etc/api.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/etc/api.xml
+++ b/app/code/core/Mage/Api/etc/api.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/etc/api.xml
+++ b/app/code/core/Mage/Api/etc/api.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api/etc/config.xml
+++ b/app/code/core/Mage/Api/etc/config.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/etc/config.xml
+++ b/app/code/core/Mage/Api/etc/config.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/etc/config.xml
+++ b/app/code/core/Mage/Api/etc/config.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api/etc/system.xml
+++ b/app/code/core/Mage/Api/etc/system.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/etc/system.xml
+++ b/app/code/core/Mage/Api/etc/system.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/etc/system.xml
+++ b/app/code/core/Mage/Api/etc/system.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api/sql/api_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Api/sql/api_setup/install-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api/sql/api_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Api/sql/api_setup/install-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/sql/api_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Api/sql/api_setup/install-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/sql/api_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/Api/sql/api_setup/mysql4-install-0.7.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api/sql/api_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/Api/sql/api_setup/mysql4-install-0.7.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/sql/api_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/Api/sql/api_setup/mysql4-install-0.7.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/sql/api_setup/mysql4-upgrade-0.7.0-0.7.1.php
+++ b/app/code/core/Mage/Api/sql/api_setup/mysql4-upgrade-0.7.0-0.7.1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api/sql/api_setup/mysql4-upgrade-0.7.0-0.7.1.php
+++ b/app/code/core/Mage/Api/sql/api_setup/mysql4-upgrade-0.7.0-0.7.1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/sql/api_setup/mysql4-upgrade-0.7.0-0.7.1.php
+++ b/app/code/core/Mage/Api/sql/api_setup/mysql4-upgrade-0.7.0-0.7.1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/sql/api_setup/mysql4-upgrade-0.8.0-0.8.1.php
+++ b/app/code/core/Mage/Api/sql/api_setup/mysql4-upgrade-0.8.0-0.8.1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api/sql/api_setup/mysql4-upgrade-0.8.0-0.8.1.php
+++ b/app/code/core/Mage/Api/sql/api_setup/mysql4-upgrade-0.8.0-0.8.1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/sql/api_setup/mysql4-upgrade-0.8.0-0.8.1.php
+++ b/app/code/core/Mage/Api/sql/api_setup/mysql4-upgrade-0.8.0-0.8.1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/sql/api_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/Api/sql/api_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api/sql/api_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/Api/sql/api_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/sql/api_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/Api/sql/api_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/sql/api_setup/mysql4-upgrade-1.6.0.0-1.6.0.1.php
+++ b/app/code/core/Mage/Api/sql/api_setup/mysql4-upgrade-1.6.0.0-1.6.0.1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api/sql/api_setup/mysql4-upgrade-1.6.0.0-1.6.0.1.php
+++ b/app/code/core/Mage/Api/sql/api_setup/mysql4-upgrade-1.6.0.0-1.6.0.1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/sql/api_setup/mysql4-upgrade-1.6.0.0-1.6.0.1.php
+++ b/app/code/core/Mage/Api/sql/api_setup/mysql4-upgrade-1.6.0.0-1.6.0.1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/sql/api_setup/mysql4-upgrade-1.6.0.1-1.6.0.2.php
+++ b/app/code/core/Mage/Api/sql/api_setup/mysql4-upgrade-1.6.0.1-1.6.0.2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api/sql/api_setup/mysql4-upgrade-1.6.0.1-1.6.0.2.php
+++ b/app/code/core/Mage/Api/sql/api_setup/mysql4-upgrade-1.6.0.1-1.6.0.2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api/sql/api_setup/mysql4-upgrade-1.6.0.1-1.6.0.2.php
+++ b/app/code/core/Mage/Api/sql/api_setup/mysql4-upgrade-1.6.0.1-1.6.0.2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/code/core/Mage/Api2/Block/Adminhtml/Attribute.php
+++ b/app/code/core/Mage/Api2/Block/Adminhtml/Attribute.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api2/Block/Adminhtml/Attribute.php
+++ b/app/code/core/Mage/Api2/Block/Adminhtml/Attribute.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Block/Adminhtml/Attribute.php
+++ b/app/code/core/Mage/Api2/Block/Adminhtml/Attribute.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Block/Adminhtml/Attribute/Buttons.php
+++ b/app/code/core/Mage/Api2/Block/Adminhtml/Attribute/Buttons.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api2/Block/Adminhtml/Attribute/Buttons.php
+++ b/app/code/core/Mage/Api2/Block/Adminhtml/Attribute/Buttons.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Block/Adminhtml/Attribute/Buttons.php
+++ b/app/code/core/Mage/Api2/Block/Adminhtml/Attribute/Buttons.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Block/Adminhtml/Attribute/Edit.php
+++ b/app/code/core/Mage/Api2/Block/Adminhtml/Attribute/Edit.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api2/Block/Adminhtml/Attribute/Edit.php
+++ b/app/code/core/Mage/Api2/Block/Adminhtml/Attribute/Edit.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Block/Adminhtml/Attribute/Edit.php
+++ b/app/code/core/Mage/Api2/Block/Adminhtml/Attribute/Edit.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Block/Adminhtml/Attribute/Edit/Form.php
+++ b/app/code/core/Mage/Api2/Block/Adminhtml/Attribute/Edit/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api2/Block/Adminhtml/Attribute/Edit/Form.php
+++ b/app/code/core/Mage/Api2/Block/Adminhtml/Attribute/Edit/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Block/Adminhtml/Attribute/Edit/Form.php
+++ b/app/code/core/Mage/Api2/Block/Adminhtml/Attribute/Edit/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Block/Adminhtml/Attribute/Grid.php
+++ b/app/code/core/Mage/Api2/Block/Adminhtml/Attribute/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api2/Block/Adminhtml/Attribute/Grid.php
+++ b/app/code/core/Mage/Api2/Block/Adminhtml/Attribute/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Block/Adminhtml/Attribute/Grid.php
+++ b/app/code/core/Mage/Api2/Block/Adminhtml/Attribute/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Block/Adminhtml/Attribute/Tab/Resource.php
+++ b/app/code/core/Mage/Api2/Block/Adminhtml/Attribute/Tab/Resource.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api2/Block/Adminhtml/Attribute/Tab/Resource.php
+++ b/app/code/core/Mage/Api2/Block/Adminhtml/Attribute/Tab/Resource.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Block/Adminhtml/Attribute/Tab/Resource.php
+++ b/app/code/core/Mage/Api2/Block/Adminhtml/Attribute/Tab/Resource.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Block/Adminhtml/Attribute/Tabs.php
+++ b/app/code/core/Mage/Api2/Block/Adminhtml/Attribute/Tabs.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api2/Block/Adminhtml/Attribute/Tabs.php
+++ b/app/code/core/Mage/Api2/Block/Adminhtml/Attribute/Tabs.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Block/Adminhtml/Attribute/Tabs.php
+++ b/app/code/core/Mage/Api2/Block/Adminhtml/Attribute/Tabs.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Block/Adminhtml/Permissions/User/Edit/Tab/Roles.php
+++ b/app/code/core/Mage/Api2/Block/Adminhtml/Permissions/User/Edit/Tab/Roles.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api2/Block/Adminhtml/Permissions/User/Edit/Tab/Roles.php
+++ b/app/code/core/Mage/Api2/Block/Adminhtml/Permissions/User/Edit/Tab/Roles.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Block/Adminhtml/Permissions/User/Edit/Tab/Roles.php
+++ b/app/code/core/Mage/Api2/Block/Adminhtml/Permissions/User/Edit/Tab/Roles.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Block/Adminhtml/Roles.php
+++ b/app/code/core/Mage/Api2/Block/Adminhtml/Roles.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api2/Block/Adminhtml/Roles.php
+++ b/app/code/core/Mage/Api2/Block/Adminhtml/Roles.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Block/Adminhtml/Roles.php
+++ b/app/code/core/Mage/Api2/Block/Adminhtml/Roles.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Block/Adminhtml/Roles/Buttons.php
+++ b/app/code/core/Mage/Api2/Block/Adminhtml/Roles/Buttons.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api2/Block/Adminhtml/Roles/Buttons.php
+++ b/app/code/core/Mage/Api2/Block/Adminhtml/Roles/Buttons.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Block/Adminhtml/Roles/Buttons.php
+++ b/app/code/core/Mage/Api2/Block/Adminhtml/Roles/Buttons.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Block/Adminhtml/Roles/Grid.php
+++ b/app/code/core/Mage/Api2/Block/Adminhtml/Roles/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api2/Block/Adminhtml/Roles/Grid.php
+++ b/app/code/core/Mage/Api2/Block/Adminhtml/Roles/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Block/Adminhtml/Roles/Grid.php
+++ b/app/code/core/Mage/Api2/Block/Adminhtml/Roles/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Block/Adminhtml/Roles/Tab/Info.php
+++ b/app/code/core/Mage/Api2/Block/Adminhtml/Roles/Tab/Info.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api2/Block/Adminhtml/Roles/Tab/Info.php
+++ b/app/code/core/Mage/Api2/Block/Adminhtml/Roles/Tab/Info.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Block/Adminhtml/Roles/Tab/Info.php
+++ b/app/code/core/Mage/Api2/Block/Adminhtml/Roles/Tab/Info.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Block/Adminhtml/Roles/Tab/Resources.php
+++ b/app/code/core/Mage/Api2/Block/Adminhtml/Roles/Tab/Resources.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api2/Block/Adminhtml/Roles/Tab/Resources.php
+++ b/app/code/core/Mage/Api2/Block/Adminhtml/Roles/Tab/Resources.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Block/Adminhtml/Roles/Tab/Resources.php
+++ b/app/code/core/Mage/Api2/Block/Adminhtml/Roles/Tab/Resources.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Block/Adminhtml/Roles/Tab/Users.php
+++ b/app/code/core/Mage/Api2/Block/Adminhtml/Roles/Tab/Users.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api2/Block/Adminhtml/Roles/Tab/Users.php
+++ b/app/code/core/Mage/Api2/Block/Adminhtml/Roles/Tab/Users.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Block/Adminhtml/Roles/Tab/Users.php
+++ b/app/code/core/Mage/Api2/Block/Adminhtml/Roles/Tab/Users.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Block/Adminhtml/Roles/Tabs.php
+++ b/app/code/core/Mage/Api2/Block/Adminhtml/Roles/Tabs.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api2/Block/Adminhtml/Roles/Tabs.php
+++ b/app/code/core/Mage/Api2/Block/Adminhtml/Roles/Tabs.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Block/Adminhtml/Roles/Tabs.php
+++ b/app/code/core/Mage/Api2/Block/Adminhtml/Roles/Tabs.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Exception.php
+++ b/app/code/core/Mage/Api2/Exception.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api2/Exception.php
+++ b/app/code/core/Mage/Api2/Exception.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Exception.php
+++ b/app/code/core/Mage/Api2/Exception.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Helper/Data.php
+++ b/app/code/core/Mage/Api2/Helper/Data.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api2/Helper/Data.php
+++ b/app/code/core/Mage/Api2/Helper/Data.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Helper/Data.php
+++ b/app/code/core/Mage/Api2/Helper/Data.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Acl.php
+++ b/app/code/core/Mage/Api2/Model/Acl.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api2/Model/Acl.php
+++ b/app/code/core/Mage/Api2/Model/Acl.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Acl.php
+++ b/app/code/core/Mage/Api2/Model/Acl.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Acl/Filter.php
+++ b/app/code/core/Mage/Api2/Model/Acl/Filter.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api2/Model/Acl/Filter.php
+++ b/app/code/core/Mage/Api2/Model/Acl/Filter.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Acl/Filter.php
+++ b/app/code/core/Mage/Api2/Model/Acl/Filter.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Acl/Filter/Attribute.php
+++ b/app/code/core/Mage/Api2/Model/Acl/Filter/Attribute.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api2/Model/Acl/Filter/Attribute.php
+++ b/app/code/core/Mage/Api2/Model/Acl/Filter/Attribute.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Acl/Filter/Attribute.php
+++ b/app/code/core/Mage/Api2/Model/Acl/Filter/Attribute.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Acl/Filter/Attribute/Operation.php
+++ b/app/code/core/Mage/Api2/Model/Acl/Filter/Attribute/Operation.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api2/Model/Acl/Filter/Attribute/Operation.php
+++ b/app/code/core/Mage/Api2/Model/Acl/Filter/Attribute/Operation.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Acl/Filter/Attribute/Operation.php
+++ b/app/code/core/Mage/Api2/Model/Acl/Filter/Attribute/Operation.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Acl/Filter/Attribute/ResourcePermission.php
+++ b/app/code/core/Mage/Api2/Model/Acl/Filter/Attribute/ResourcePermission.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api2/Model/Acl/Filter/Attribute/ResourcePermission.php
+++ b/app/code/core/Mage/Api2/Model/Acl/Filter/Attribute/ResourcePermission.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Acl/Filter/Attribute/ResourcePermission.php
+++ b/app/code/core/Mage/Api2/Model/Acl/Filter/Attribute/ResourcePermission.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Acl/Global.php
+++ b/app/code/core/Mage/Api2/Model/Acl/Global.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api2/Model/Acl/Global.php
+++ b/app/code/core/Mage/Api2/Model/Acl/Global.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Acl/Global.php
+++ b/app/code/core/Mage/Api2/Model/Acl/Global.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Acl/Global/Role.php
+++ b/app/code/core/Mage/Api2/Model/Acl/Global/Role.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api2/Model/Acl/Global/Role.php
+++ b/app/code/core/Mage/Api2/Model/Acl/Global/Role.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Acl/Global/Role.php
+++ b/app/code/core/Mage/Api2/Model/Acl/Global/Role.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Acl/Global/Rule.php
+++ b/app/code/core/Mage/Api2/Model/Acl/Global/Rule.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api2/Model/Acl/Global/Rule.php
+++ b/app/code/core/Mage/Api2/Model/Acl/Global/Rule.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Acl/Global/Rule.php
+++ b/app/code/core/Mage/Api2/Model/Acl/Global/Rule.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Acl/Global/Rule/Permission.php
+++ b/app/code/core/Mage/Api2/Model/Acl/Global/Rule/Permission.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api2/Model/Acl/Global/Rule/Permission.php
+++ b/app/code/core/Mage/Api2/Model/Acl/Global/Rule/Permission.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Acl/Global/Rule/Permission.php
+++ b/app/code/core/Mage/Api2/Model/Acl/Global/Rule/Permission.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Acl/Global/Rule/Privilege.php
+++ b/app/code/core/Mage/Api2/Model/Acl/Global/Rule/Privilege.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api2/Model/Acl/Global/Rule/Privilege.php
+++ b/app/code/core/Mage/Api2/Model/Acl/Global/Rule/Privilege.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Acl/Global/Rule/Privilege.php
+++ b/app/code/core/Mage/Api2/Model/Acl/Global/Rule/Privilege.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Acl/Global/Rule/ResourcePermission.php
+++ b/app/code/core/Mage/Api2/Model/Acl/Global/Rule/ResourcePermission.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api2/Model/Acl/Global/Rule/ResourcePermission.php
+++ b/app/code/core/Mage/Api2/Model/Acl/Global/Rule/ResourcePermission.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Acl/Global/Rule/ResourcePermission.php
+++ b/app/code/core/Mage/Api2/Model/Acl/Global/Rule/ResourcePermission.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Acl/Global/Rule/Tree.php
+++ b/app/code/core/Mage/Api2/Model/Acl/Global/Rule/Tree.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api2/Model/Acl/Global/Rule/Tree.php
+++ b/app/code/core/Mage/Api2/Model/Acl/Global/Rule/Tree.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Acl/Global/Rule/Tree.php
+++ b/app/code/core/Mage/Api2/Model/Acl/Global/Rule/Tree.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Acl/PermissionInterface.php
+++ b/app/code/core/Mage/Api2/Model/Acl/PermissionInterface.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api2/Model/Acl/PermissionInterface.php
+++ b/app/code/core/Mage/Api2/Model/Acl/PermissionInterface.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Acl/PermissionInterface.php
+++ b/app/code/core/Mage/Api2/Model/Acl/PermissionInterface.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Auth.php
+++ b/app/code/core/Mage/Api2/Model/Auth.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api2/Model/Auth.php
+++ b/app/code/core/Mage/Api2/Model/Auth.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Auth.php
+++ b/app/code/core/Mage/Api2/Model/Auth.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Auth/Adapter.php
+++ b/app/code/core/Mage/Api2/Model/Auth/Adapter.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api2/Model/Auth/Adapter.php
+++ b/app/code/core/Mage/Api2/Model/Auth/Adapter.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Auth/Adapter.php
+++ b/app/code/core/Mage/Api2/Model/Auth/Adapter.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Auth/Adapter/Abstract.php
+++ b/app/code/core/Mage/Api2/Model/Auth/Adapter/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api2/Model/Auth/Adapter/Abstract.php
+++ b/app/code/core/Mage/Api2/Model/Auth/Adapter/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Auth/Adapter/Abstract.php
+++ b/app/code/core/Mage/Api2/Model/Auth/Adapter/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Auth/Adapter/Oauth.php
+++ b/app/code/core/Mage/Api2/Model/Auth/Adapter/Oauth.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api2/Model/Auth/Adapter/Oauth.php
+++ b/app/code/core/Mage/Api2/Model/Auth/Adapter/Oauth.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Auth/Adapter/Oauth.php
+++ b/app/code/core/Mage/Api2/Model/Auth/Adapter/Oauth.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Auth/User.php
+++ b/app/code/core/Mage/Api2/Model/Auth/User.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api2/Model/Auth/User.php
+++ b/app/code/core/Mage/Api2/Model/Auth/User.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Auth/User.php
+++ b/app/code/core/Mage/Api2/Model/Auth/User.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Auth/User/Abstract.php
+++ b/app/code/core/Mage/Api2/Model/Auth/User/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api2/Model/Auth/User/Abstract.php
+++ b/app/code/core/Mage/Api2/Model/Auth/User/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Auth/User/Abstract.php
+++ b/app/code/core/Mage/Api2/Model/Auth/User/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Auth/User/Admin.php
+++ b/app/code/core/Mage/Api2/Model/Auth/User/Admin.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api2/Model/Auth/User/Admin.php
+++ b/app/code/core/Mage/Api2/Model/Auth/User/Admin.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Auth/User/Admin.php
+++ b/app/code/core/Mage/Api2/Model/Auth/User/Admin.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Auth/User/Customer.php
+++ b/app/code/core/Mage/Api2/Model/Auth/User/Customer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api2/Model/Auth/User/Customer.php
+++ b/app/code/core/Mage/Api2/Model/Auth/User/Customer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Auth/User/Customer.php
+++ b/app/code/core/Mage/Api2/Model/Auth/User/Customer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Auth/User/Guest.php
+++ b/app/code/core/Mage/Api2/Model/Auth/User/Guest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api2/Model/Auth/User/Guest.php
+++ b/app/code/core/Mage/Api2/Model/Auth/User/Guest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Auth/User/Guest.php
+++ b/app/code/core/Mage/Api2/Model/Auth/User/Guest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Config.php
+++ b/app/code/core/Mage/Api2/Model/Config.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api2/Model/Config.php
+++ b/app/code/core/Mage/Api2/Model/Config.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Config.php
+++ b/app/code/core/Mage/Api2/Model/Config.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Dispatcher.php
+++ b/app/code/core/Mage/Api2/Model/Dispatcher.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api2/Model/Dispatcher.php
+++ b/app/code/core/Mage/Api2/Model/Dispatcher.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Dispatcher.php
+++ b/app/code/core/Mage/Api2/Model/Dispatcher.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Multicall.php
+++ b/app/code/core/Mage/Api2/Model/Multicall.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api2/Model/Multicall.php
+++ b/app/code/core/Mage/Api2/Model/Multicall.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Multicall.php
+++ b/app/code/core/Mage/Api2/Model/Multicall.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Observer.php
+++ b/app/code/core/Mage/Api2/Model/Observer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api2/Model/Observer.php
+++ b/app/code/core/Mage/Api2/Model/Observer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Observer.php
+++ b/app/code/core/Mage/Api2/Model/Observer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Renderer.php
+++ b/app/code/core/Mage/Api2/Model/Renderer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api2/Model/Renderer.php
+++ b/app/code/core/Mage/Api2/Model/Renderer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Renderer.php
+++ b/app/code/core/Mage/Api2/Model/Renderer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Renderer/Interface.php
+++ b/app/code/core/Mage/Api2/Model/Renderer/Interface.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api2/Model/Renderer/Interface.php
+++ b/app/code/core/Mage/Api2/Model/Renderer/Interface.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Renderer/Interface.php
+++ b/app/code/core/Mage/Api2/Model/Renderer/Interface.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Renderer/Json.php
+++ b/app/code/core/Mage/Api2/Model/Renderer/Json.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api2/Model/Renderer/Json.php
+++ b/app/code/core/Mage/Api2/Model/Renderer/Json.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Renderer/Json.php
+++ b/app/code/core/Mage/Api2/Model/Renderer/Json.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Renderer/Query.php
+++ b/app/code/core/Mage/Api2/Model/Renderer/Query.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api2/Model/Renderer/Query.php
+++ b/app/code/core/Mage/Api2/Model/Renderer/Query.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Renderer/Query.php
+++ b/app/code/core/Mage/Api2/Model/Renderer/Query.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Renderer/Xml.php
+++ b/app/code/core/Mage/Api2/Model/Renderer/Xml.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api2/Model/Renderer/Xml.php
+++ b/app/code/core/Mage/Api2/Model/Renderer/Xml.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Renderer/Xml.php
+++ b/app/code/core/Mage/Api2/Model/Renderer/Xml.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Renderer/Xml/Writer.php
+++ b/app/code/core/Mage/Api2/Model/Renderer/Xml/Writer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api2/Model/Renderer/Xml/Writer.php
+++ b/app/code/core/Mage/Api2/Model/Renderer/Xml/Writer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Renderer/Xml/Writer.php
+++ b/app/code/core/Mage/Api2/Model/Renderer/Xml/Writer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Request.php
+++ b/app/code/core/Mage/Api2/Model/Request.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api2/Model/Request.php
+++ b/app/code/core/Mage/Api2/Model/Request.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Request.php
+++ b/app/code/core/Mage/Api2/Model/Request.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Request/Internal.php
+++ b/app/code/core/Mage/Api2/Model/Request/Internal.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api2/Model/Request/Internal.php
+++ b/app/code/core/Mage/Api2/Model/Request/Internal.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Request/Internal.php
+++ b/app/code/core/Mage/Api2/Model/Request/Internal.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Request/Interpreter.php
+++ b/app/code/core/Mage/Api2/Model/Request/Interpreter.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api2/Model/Request/Interpreter.php
+++ b/app/code/core/Mage/Api2/Model/Request/Interpreter.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Request/Interpreter.php
+++ b/app/code/core/Mage/Api2/Model/Request/Interpreter.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Request/Interpreter/Interface.php
+++ b/app/code/core/Mage/Api2/Model/Request/Interpreter/Interface.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api2/Model/Request/Interpreter/Interface.php
+++ b/app/code/core/Mage/Api2/Model/Request/Interpreter/Interface.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Request/Interpreter/Interface.php
+++ b/app/code/core/Mage/Api2/Model/Request/Interpreter/Interface.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Request/Interpreter/Json.php
+++ b/app/code/core/Mage/Api2/Model/Request/Interpreter/Json.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api2/Model/Request/Interpreter/Json.php
+++ b/app/code/core/Mage/Api2/Model/Request/Interpreter/Json.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Request/Interpreter/Json.php
+++ b/app/code/core/Mage/Api2/Model/Request/Interpreter/Json.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Request/Interpreter/Query.php
+++ b/app/code/core/Mage/Api2/Model/Request/Interpreter/Query.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api2/Model/Request/Interpreter/Query.php
+++ b/app/code/core/Mage/Api2/Model/Request/Interpreter/Query.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Request/Interpreter/Query.php
+++ b/app/code/core/Mage/Api2/Model/Request/Interpreter/Query.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Request/Interpreter/Xml.php
+++ b/app/code/core/Mage/Api2/Model/Request/Interpreter/Xml.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api2/Model/Request/Interpreter/Xml.php
+++ b/app/code/core/Mage/Api2/Model/Request/Interpreter/Xml.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Request/Interpreter/Xml.php
+++ b/app/code/core/Mage/Api2/Model/Request/Interpreter/Xml.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Resource.php
+++ b/app/code/core/Mage/Api2/Model/Resource.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api2/Model/Resource.php
+++ b/app/code/core/Mage/Api2/Model/Resource.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Resource.php
+++ b/app/code/core/Mage/Api2/Model/Resource.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Resource/Acl/Filter/Attribute.php
+++ b/app/code/core/Mage/Api2/Model/Resource/Acl/Filter/Attribute.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api2/Model/Resource/Acl/Filter/Attribute.php
+++ b/app/code/core/Mage/Api2/Model/Resource/Acl/Filter/Attribute.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Resource/Acl/Filter/Attribute.php
+++ b/app/code/core/Mage/Api2/Model/Resource/Acl/Filter/Attribute.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Resource/Acl/Filter/Attribute/Collection.php
+++ b/app/code/core/Mage/Api2/Model/Resource/Acl/Filter/Attribute/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api2/Model/Resource/Acl/Filter/Attribute/Collection.php
+++ b/app/code/core/Mage/Api2/Model/Resource/Acl/Filter/Attribute/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Resource/Acl/Filter/Attribute/Collection.php
+++ b/app/code/core/Mage/Api2/Model/Resource/Acl/Filter/Attribute/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Resource/Acl/Global/Role.php
+++ b/app/code/core/Mage/Api2/Model/Resource/Acl/Global/Role.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api2/Model/Resource/Acl/Global/Role.php
+++ b/app/code/core/Mage/Api2/Model/Resource/Acl/Global/Role.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Resource/Acl/Global/Role.php
+++ b/app/code/core/Mage/Api2/Model/Resource/Acl/Global/Role.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Resource/Acl/Global/Role/Collection.php
+++ b/app/code/core/Mage/Api2/Model/Resource/Acl/Global/Role/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api2/Model/Resource/Acl/Global/Role/Collection.php
+++ b/app/code/core/Mage/Api2/Model/Resource/Acl/Global/Role/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Resource/Acl/Global/Role/Collection.php
+++ b/app/code/core/Mage/Api2/Model/Resource/Acl/Global/Role/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Resource/Acl/Global/Rule.php
+++ b/app/code/core/Mage/Api2/Model/Resource/Acl/Global/Rule.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api2/Model/Resource/Acl/Global/Rule.php
+++ b/app/code/core/Mage/Api2/Model/Resource/Acl/Global/Rule.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Resource/Acl/Global/Rule.php
+++ b/app/code/core/Mage/Api2/Model/Resource/Acl/Global/Rule.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Resource/Acl/Global/Rule/Collection.php
+++ b/app/code/core/Mage/Api2/Model/Resource/Acl/Global/Rule/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api2/Model/Resource/Acl/Global/Rule/Collection.php
+++ b/app/code/core/Mage/Api2/Model/Resource/Acl/Global/Rule/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Resource/Acl/Global/Rule/Collection.php
+++ b/app/code/core/Mage/Api2/Model/Resource/Acl/Global/Rule/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Resource/Setup.php
+++ b/app/code/core/Mage/Api2/Model/Resource/Setup.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api2/Model/Resource/Setup.php
+++ b/app/code/core/Mage/Api2/Model/Resource/Setup.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Resource/Setup.php
+++ b/app/code/core/Mage/Api2/Model/Resource/Setup.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Resource/Validator.php
+++ b/app/code/core/Mage/Api2/Model/Resource/Validator.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api2/Model/Resource/Validator.php
+++ b/app/code/core/Mage/Api2/Model/Resource/Validator.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Resource/Validator.php
+++ b/app/code/core/Mage/Api2/Model/Resource/Validator.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Resource/Validator/Eav.php
+++ b/app/code/core/Mage/Api2/Model/Resource/Validator/Eav.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api2/Model/Resource/Validator/Eav.php
+++ b/app/code/core/Mage/Api2/Model/Resource/Validator/Eav.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Resource/Validator/Eav.php
+++ b/app/code/core/Mage/Api2/Model/Resource/Validator/Eav.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Resource/Validator/Fields.php
+++ b/app/code/core/Mage/Api2/Model/Resource/Validator/Fields.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api2/Model/Resource/Validator/Fields.php
+++ b/app/code/core/Mage/Api2/Model/Resource/Validator/Fields.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Resource/Validator/Fields.php
+++ b/app/code/core/Mage/Api2/Model/Resource/Validator/Fields.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Response.php
+++ b/app/code/core/Mage/Api2/Model/Response.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api2/Model/Response.php
+++ b/app/code/core/Mage/Api2/Model/Response.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Response.php
+++ b/app/code/core/Mage/Api2/Model/Response.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Route/Abstract.php
+++ b/app/code/core/Mage/Api2/Model/Route/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api2/Model/Route/Abstract.php
+++ b/app/code/core/Mage/Api2/Model/Route/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Route/Abstract.php
+++ b/app/code/core/Mage/Api2/Model/Route/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Route/ApiType.php
+++ b/app/code/core/Mage/Api2/Model/Route/ApiType.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api2/Model/Route/ApiType.php
+++ b/app/code/core/Mage/Api2/Model/Route/ApiType.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Route/ApiType.php
+++ b/app/code/core/Mage/Api2/Model/Route/ApiType.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Route/Interface.php
+++ b/app/code/core/Mage/Api2/Model/Route/Interface.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api2/Model/Route/Interface.php
+++ b/app/code/core/Mage/Api2/Model/Route/Interface.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Route/Interface.php
+++ b/app/code/core/Mage/Api2/Model/Route/Interface.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Route/Rest.php
+++ b/app/code/core/Mage/Api2/Model/Route/Rest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api2/Model/Route/Rest.php
+++ b/app/code/core/Mage/Api2/Model/Route/Rest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Route/Rest.php
+++ b/app/code/core/Mage/Api2/Model/Route/Rest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Router.php
+++ b/app/code/core/Mage/Api2/Model/Router.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api2/Model/Router.php
+++ b/app/code/core/Mage/Api2/Model/Router.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Router.php
+++ b/app/code/core/Mage/Api2/Model/Router.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Server.php
+++ b/app/code/core/Mage/Api2/Model/Server.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api2/Model/Server.php
+++ b/app/code/core/Mage/Api2/Model/Server.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/Model/Server.php
+++ b/app/code/core/Mage/Api2/Model/Server.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/controllers/Adminhtml/Api2/AttributeController.php
+++ b/app/code/core/Mage/Api2/controllers/Adminhtml/Api2/AttributeController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api2/controllers/Adminhtml/Api2/AttributeController.php
+++ b/app/code/core/Mage/Api2/controllers/Adminhtml/Api2/AttributeController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/controllers/Adminhtml/Api2/AttributeController.php
+++ b/app/code/core/Mage/Api2/controllers/Adminhtml/Api2/AttributeController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/controllers/Adminhtml/Api2/RoleController.php
+++ b/app/code/core/Mage/Api2/controllers/Adminhtml/Api2/RoleController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api2/controllers/Adminhtml/Api2/RoleController.php
+++ b/app/code/core/Mage/Api2/controllers/Adminhtml/Api2/RoleController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/controllers/Adminhtml/Api2/RoleController.php
+++ b/app/code/core/Mage/Api2/controllers/Adminhtml/Api2/RoleController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/etc/adminhtml.xml
+++ b/app/code/core/Mage/Api2/etc/adminhtml.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/etc/adminhtml.xml
+++ b/app/code/core/Mage/Api2/etc/adminhtml.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/etc/adminhtml.xml
+++ b/app/code/core/Mage/Api2/etc/adminhtml.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api2/etc/config.xml
+++ b/app/code/core/Mage/Api2/etc/config.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/etc/config.xml
+++ b/app/code/core/Mage/Api2/etc/config.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/etc/config.xml
+++ b/app/code/core/Mage/Api2/etc/config.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api2/sql/api2_setup/install-1.0.0.0.php
+++ b/app/code/core/Mage/Api2/sql/api2_setup/install-1.0.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Api2/sql/api2_setup/install-1.0.0.0.php
+++ b/app/code/core/Mage/Api2/sql/api2_setup/install-1.0.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Api2/sql/api2_setup/install-1.0.0.0.php
+++ b/app/code/core/Mage/Api2/sql/api2_setup/install-1.0.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/code/core/Mage/Authorizenet/Block/Directpost/Form.php
+++ b/app/code/core/Mage/Authorizenet/Block/Directpost/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Authorizenet/Block/Directpost/Form.php
+++ b/app/code/core/Mage/Authorizenet/Block/Directpost/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Authorizenet

--- a/app/code/core/Mage/Authorizenet/Block/Directpost/Form.php
+++ b/app/code/core/Mage/Authorizenet/Block/Directpost/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Authorizenet

--- a/app/code/core/Mage/Authorizenet/Block/Directpost/Iframe.php
+++ b/app/code/core/Mage/Authorizenet/Block/Directpost/Iframe.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Authorizenet/Block/Directpost/Iframe.php
+++ b/app/code/core/Mage/Authorizenet/Block/Directpost/Iframe.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Authorizenet

--- a/app/code/core/Mage/Authorizenet/Block/Directpost/Iframe.php
+++ b/app/code/core/Mage/Authorizenet/Block/Directpost/Iframe.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Authorizenet

--- a/app/code/core/Mage/Authorizenet/Helper/Admin.php
+++ b/app/code/core/Mage/Authorizenet/Helper/Admin.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Authorizenet/Helper/Admin.php
+++ b/app/code/core/Mage/Authorizenet/Helper/Admin.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Authorizenet

--- a/app/code/core/Mage/Authorizenet/Helper/Admin.php
+++ b/app/code/core/Mage/Authorizenet/Helper/Admin.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Authorizenet

--- a/app/code/core/Mage/Authorizenet/Helper/Data.php
+++ b/app/code/core/Mage/Authorizenet/Helper/Data.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Authorizenet/Helper/Data.php
+++ b/app/code/core/Mage/Authorizenet/Helper/Data.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Authorizenet

--- a/app/code/core/Mage/Authorizenet/Helper/Data.php
+++ b/app/code/core/Mage/Authorizenet/Helper/Data.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Authorizenet

--- a/app/code/core/Mage/Authorizenet/Model/Directpost.php
+++ b/app/code/core/Mage/Authorizenet/Model/Directpost.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Authorizenet/Model/Directpost.php
+++ b/app/code/core/Mage/Authorizenet/Model/Directpost.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Authorizenet

--- a/app/code/core/Mage/Authorizenet/Model/Directpost.php
+++ b/app/code/core/Mage/Authorizenet/Model/Directpost.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Authorizenet

--- a/app/code/core/Mage/Authorizenet/Model/Directpost/Observer.php
+++ b/app/code/core/Mage/Authorizenet/Model/Directpost/Observer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Authorizenet/Model/Directpost/Observer.php
+++ b/app/code/core/Mage/Authorizenet/Model/Directpost/Observer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Authorizenet

--- a/app/code/core/Mage/Authorizenet/Model/Directpost/Observer.php
+++ b/app/code/core/Mage/Authorizenet/Model/Directpost/Observer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Authorizenet

--- a/app/code/core/Mage/Authorizenet/Model/Directpost/Request.php
+++ b/app/code/core/Mage/Authorizenet/Model/Directpost/Request.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Authorizenet/Model/Directpost/Request.php
+++ b/app/code/core/Mage/Authorizenet/Model/Directpost/Request.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Authorizenet

--- a/app/code/core/Mage/Authorizenet/Model/Directpost/Request.php
+++ b/app/code/core/Mage/Authorizenet/Model/Directpost/Request.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Authorizenet

--- a/app/code/core/Mage/Authorizenet/Model/Directpost/Response.php
+++ b/app/code/core/Mage/Authorizenet/Model/Directpost/Response.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Authorizenet/Model/Directpost/Response.php
+++ b/app/code/core/Mage/Authorizenet/Model/Directpost/Response.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Authorizenet

--- a/app/code/core/Mage/Authorizenet/Model/Directpost/Response.php
+++ b/app/code/core/Mage/Authorizenet/Model/Directpost/Response.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Authorizenet

--- a/app/code/core/Mage/Authorizenet/Model/Directpost/Session.php
+++ b/app/code/core/Mage/Authorizenet/Model/Directpost/Session.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Authorizenet/Model/Directpost/Session.php
+++ b/app/code/core/Mage/Authorizenet/Model/Directpost/Session.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Authorizenet

--- a/app/code/core/Mage/Authorizenet/Model/Directpost/Session.php
+++ b/app/code/core/Mage/Authorizenet/Model/Directpost/Session.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Authorizenet

--- a/app/code/core/Mage/Authorizenet/controllers/Adminhtml/Authorizenet/Directpost/PaymentController.php
+++ b/app/code/core/Mage/Authorizenet/controllers/Adminhtml/Authorizenet/Directpost/PaymentController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Authorizenet/controllers/Adminhtml/Authorizenet/Directpost/PaymentController.php
+++ b/app/code/core/Mage/Authorizenet/controllers/Adminhtml/Authorizenet/Directpost/PaymentController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Authorizenet

--- a/app/code/core/Mage/Authorizenet/controllers/Adminhtml/Authorizenet/Directpost/PaymentController.php
+++ b/app/code/core/Mage/Authorizenet/controllers/Adminhtml/Authorizenet/Directpost/PaymentController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Authorizenet

--- a/app/code/core/Mage/Authorizenet/controllers/Directpost/PaymentController.php
+++ b/app/code/core/Mage/Authorizenet/controllers/Directpost/PaymentController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Authorizenet/controllers/Directpost/PaymentController.php
+++ b/app/code/core/Mage/Authorizenet/controllers/Directpost/PaymentController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Authorizenet

--- a/app/code/core/Mage/Authorizenet/controllers/Directpost/PaymentController.php
+++ b/app/code/core/Mage/Authorizenet/controllers/Directpost/PaymentController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Authorizenet

--- a/app/code/core/Mage/Authorizenet/etc/config.xml
+++ b/app/code/core/Mage/Authorizenet/etc/config.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Authorizenet

--- a/app/code/core/Mage/Authorizenet/etc/config.xml
+++ b/app/code/core/Mage/Authorizenet/etc/config.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Authorizenet

--- a/app/code/core/Mage/Authorizenet/etc/config.xml
+++ b/app/code/core/Mage/Authorizenet/etc/config.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Authorizenet/etc/system.xml
+++ b/app/code/core/Mage/Authorizenet/etc/system.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Authorizenet

--- a/app/code/core/Mage/Authorizenet/etc/system.xml
+++ b/app/code/core/Mage/Authorizenet/etc/system.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Authorizenet

--- a/app/code/core/Mage/Authorizenet/etc/system.xml
+++ b/app/code/core/Mage/Authorizenet/etc/system.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Composite/Fieldset/Bundle.php
+++ b/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Composite/Fieldset/Bundle.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Composite/Fieldset/Bundle.php
+++ b/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Composite/Fieldset/Bundle.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Composite/Fieldset/Bundle.php
+++ b/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Composite/Fieldset/Bundle.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Composite/Fieldset/Options/Type/Checkbox.php
+++ b/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Composite/Fieldset/Options/Type/Checkbox.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Composite/Fieldset/Options/Type/Checkbox.php
+++ b/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Composite/Fieldset/Options/Type/Checkbox.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Composite/Fieldset/Options/Type/Checkbox.php
+++ b/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Composite/Fieldset/Options/Type/Checkbox.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Composite/Fieldset/Options/Type/Multi.php
+++ b/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Composite/Fieldset/Options/Type/Multi.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Composite/Fieldset/Options/Type/Multi.php
+++ b/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Composite/Fieldset/Options/Type/Multi.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Composite/Fieldset/Options/Type/Multi.php
+++ b/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Composite/Fieldset/Options/Type/Multi.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Composite/Fieldset/Options/Type/Radio.php
+++ b/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Composite/Fieldset/Options/Type/Radio.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Composite/Fieldset/Options/Type/Radio.php
+++ b/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Composite/Fieldset/Options/Type/Radio.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Composite/Fieldset/Options/Type/Radio.php
+++ b/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Composite/Fieldset/Options/Type/Radio.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Composite/Fieldset/Options/Type/Select.php
+++ b/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Composite/Fieldset/Options/Type/Select.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Composite/Fieldset/Options/Type/Select.php
+++ b/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Composite/Fieldset/Options/Type/Select.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Composite/Fieldset/Options/Type/Select.php
+++ b/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Composite/Fieldset/Options/Type/Select.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Attributes.php
+++ b/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Attributes.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Attributes.php
+++ b/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Attributes.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Attributes.php
+++ b/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Attributes.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Attributes/Extend.php
+++ b/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Attributes/Extend.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Attributes/Extend.php
+++ b/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Attributes/Extend.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Attributes/Extend.php
+++ b/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Attributes/Extend.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Attributes/Special.php
+++ b/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Attributes/Special.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Attributes/Special.php
+++ b/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Attributes/Special.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Attributes/Special.php
+++ b/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Attributes/Special.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle.php
+++ b/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle.php
+++ b/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle.php
+++ b/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle/Option.php
+++ b/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle/Option.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle/Option.php
+++ b/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle/Option.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle/Option.php
+++ b/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle/Option.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle/Option/Search.php
+++ b/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle/Option/Search.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle/Option/Search.php
+++ b/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle/Option/Search.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle/Option/Search.php
+++ b/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle/Option/Search.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle/Option/Search/Grid.php
+++ b/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle/Option/Search/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle/Option/Search/Grid.php
+++ b/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle/Option/Search/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle/Option/Search/Grid.php
+++ b/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle/Option/Search/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle/Option/Selection.php
+++ b/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle/Option/Selection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle/Option/Selection.php
+++ b/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle/Option/Selection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle/Option/Selection.php
+++ b/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle/Option/Selection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tabs.php
+++ b/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tabs.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tabs.php
+++ b/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tabs.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tabs.php
+++ b/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tabs.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Block/Adminhtml/Sales/Order/Items/Renderer.php
+++ b/app/code/core/Mage/Bundle/Block/Adminhtml/Sales/Order/Items/Renderer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Bundle/Block/Adminhtml/Sales/Order/Items/Renderer.php
+++ b/app/code/core/Mage/Bundle/Block/Adminhtml/Sales/Order/Items/Renderer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Block/Adminhtml/Sales/Order/Items/Renderer.php
+++ b/app/code/core/Mage/Bundle/Block/Adminhtml/Sales/Order/Items/Renderer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Block/Adminhtml/Sales/Order/View/Items/Renderer.php
+++ b/app/code/core/Mage/Bundle/Block/Adminhtml/Sales/Order/View/Items/Renderer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Bundle/Block/Adminhtml/Sales/Order/View/Items/Renderer.php
+++ b/app/code/core/Mage/Bundle/Block/Adminhtml/Sales/Order/View/Items/Renderer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Block/Adminhtml/Sales/Order/View/Items/Renderer.php
+++ b/app/code/core/Mage/Bundle/Block/Adminhtml/Sales/Order/View/Items/Renderer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Block/Catalog/Product/List/Partof.php
+++ b/app/code/core/Mage/Bundle/Block/Catalog/Product/List/Partof.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Bundle/Block/Catalog/Product/List/Partof.php
+++ b/app/code/core/Mage/Bundle/Block/Catalog/Product/List/Partof.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Block/Catalog/Product/List/Partof.php
+++ b/app/code/core/Mage/Bundle/Block/Catalog/Product/List/Partof.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Block/Catalog/Product/Price.php
+++ b/app/code/core/Mage/Bundle/Block/Catalog/Product/Price.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Bundle/Block/Catalog/Product/Price.php
+++ b/app/code/core/Mage/Bundle/Block/Catalog/Product/Price.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Block/Catalog/Product/Price.php
+++ b/app/code/core/Mage/Bundle/Block/Catalog/Product/Price.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Block/Catalog/Product/View.php
+++ b/app/code/core/Mage/Bundle/Block/Catalog/Product/View.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Bundle/Block/Catalog/Product/View.php
+++ b/app/code/core/Mage/Bundle/Block/Catalog/Product/View.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Block/Catalog/Product/View.php
+++ b/app/code/core/Mage/Bundle/Block/Catalog/Product/View.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Block/Catalog/Product/View/Type/Bundle.php
+++ b/app/code/core/Mage/Bundle/Block/Catalog/Product/View/Type/Bundle.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Bundle/Block/Catalog/Product/View/Type/Bundle.php
+++ b/app/code/core/Mage/Bundle/Block/Catalog/Product/View/Type/Bundle.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Block/Catalog/Product/View/Type/Bundle.php
+++ b/app/code/core/Mage/Bundle/Block/Catalog/Product/View/Type/Bundle.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Block/Catalog/Product/View/Type/Bundle/Option.php
+++ b/app/code/core/Mage/Bundle/Block/Catalog/Product/View/Type/Bundle/Option.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Bundle/Block/Catalog/Product/View/Type/Bundle/Option.php
+++ b/app/code/core/Mage/Bundle/Block/Catalog/Product/View/Type/Bundle/Option.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Block/Catalog/Product/View/Type/Bundle/Option.php
+++ b/app/code/core/Mage/Bundle/Block/Catalog/Product/View/Type/Bundle/Option.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Block/Catalog/Product/View/Type/Bundle/Option/Checkbox.php
+++ b/app/code/core/Mage/Bundle/Block/Catalog/Product/View/Type/Bundle/Option/Checkbox.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Bundle/Block/Catalog/Product/View/Type/Bundle/Option/Checkbox.php
+++ b/app/code/core/Mage/Bundle/Block/Catalog/Product/View/Type/Bundle/Option/Checkbox.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Block/Catalog/Product/View/Type/Bundle/Option/Checkbox.php
+++ b/app/code/core/Mage/Bundle/Block/Catalog/Product/View/Type/Bundle/Option/Checkbox.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Block/Catalog/Product/View/Type/Bundle/Option/Multi.php
+++ b/app/code/core/Mage/Bundle/Block/Catalog/Product/View/Type/Bundle/Option/Multi.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Bundle/Block/Catalog/Product/View/Type/Bundle/Option/Multi.php
+++ b/app/code/core/Mage/Bundle/Block/Catalog/Product/View/Type/Bundle/Option/Multi.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Block/Catalog/Product/View/Type/Bundle/Option/Multi.php
+++ b/app/code/core/Mage/Bundle/Block/Catalog/Product/View/Type/Bundle/Option/Multi.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Block/Catalog/Product/View/Type/Bundle/Option/Radio.php
+++ b/app/code/core/Mage/Bundle/Block/Catalog/Product/View/Type/Bundle/Option/Radio.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Bundle/Block/Catalog/Product/View/Type/Bundle/Option/Radio.php
+++ b/app/code/core/Mage/Bundle/Block/Catalog/Product/View/Type/Bundle/Option/Radio.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Block/Catalog/Product/View/Type/Bundle/Option/Radio.php
+++ b/app/code/core/Mage/Bundle/Block/Catalog/Product/View/Type/Bundle/Option/Radio.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Block/Catalog/Product/View/Type/Bundle/Option/Select.php
+++ b/app/code/core/Mage/Bundle/Block/Catalog/Product/View/Type/Bundle/Option/Select.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Bundle/Block/Catalog/Product/View/Type/Bundle/Option/Select.php
+++ b/app/code/core/Mage/Bundle/Block/Catalog/Product/View/Type/Bundle/Option/Select.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Block/Catalog/Product/View/Type/Bundle/Option/Select.php
+++ b/app/code/core/Mage/Bundle/Block/Catalog/Product/View/Type/Bundle/Option/Select.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Block/Checkout/Cart/Item/Renderer.php
+++ b/app/code/core/Mage/Bundle/Block/Checkout/Cart/Item/Renderer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Bundle/Block/Checkout/Cart/Item/Renderer.php
+++ b/app/code/core/Mage/Bundle/Block/Checkout/Cart/Item/Renderer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Block/Checkout/Cart/Item/Renderer.php
+++ b/app/code/core/Mage/Bundle/Block/Checkout/Cart/Item/Renderer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Block/Sales/Order/Items/Renderer.php
+++ b/app/code/core/Mage/Bundle/Block/Sales/Order/Items/Renderer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Bundle/Block/Sales/Order/Items/Renderer.php
+++ b/app/code/core/Mage/Bundle/Block/Sales/Order/Items/Renderer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Block/Sales/Order/Items/Renderer.php
+++ b/app/code/core/Mage/Bundle/Block/Sales/Order/Items/Renderer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Helper/Catalog/Product/Configuration.php
+++ b/app/code/core/Mage/Bundle/Helper/Catalog/Product/Configuration.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Bundle/Helper/Catalog/Product/Configuration.php
+++ b/app/code/core/Mage/Bundle/Helper/Catalog/Product/Configuration.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Helper/Catalog/Product/Configuration.php
+++ b/app/code/core/Mage/Bundle/Helper/Catalog/Product/Configuration.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Helper/Data.php
+++ b/app/code/core/Mage/Bundle/Helper/Data.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Bundle/Helper/Data.php
+++ b/app/code/core/Mage/Bundle/Helper/Data.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Helper/Data.php
+++ b/app/code/core/Mage/Bundle/Helper/Data.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Model/CatalogIndex/Data/Bundle.php
+++ b/app/code/core/Mage/Bundle/Model/CatalogIndex/Data/Bundle.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Bundle/Model/CatalogIndex/Data/Bundle.php
+++ b/app/code/core/Mage/Bundle/Model/CatalogIndex/Data/Bundle.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Model/CatalogIndex/Data/Bundle.php
+++ b/app/code/core/Mage/Bundle/Model/CatalogIndex/Data/Bundle.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Model/Mysql4/Bundle.php
+++ b/app/code/core/Mage/Bundle/Model/Mysql4/Bundle.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Bundle/Model/Mysql4/Bundle.php
+++ b/app/code/core/Mage/Bundle/Model/Mysql4/Bundle.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Model/Mysql4/Bundle.php
+++ b/app/code/core/Mage/Bundle/Model/Mysql4/Bundle.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Model/Mysql4/Indexer/Price.php
+++ b/app/code/core/Mage/Bundle/Model/Mysql4/Indexer/Price.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Bundle/Model/Mysql4/Indexer/Price.php
+++ b/app/code/core/Mage/Bundle/Model/Mysql4/Indexer/Price.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Model/Mysql4/Indexer/Price.php
+++ b/app/code/core/Mage/Bundle/Model/Mysql4/Indexer/Price.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Model/Mysql4/Indexer/Stock.php
+++ b/app/code/core/Mage/Bundle/Model/Mysql4/Indexer/Stock.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Bundle/Model/Mysql4/Indexer/Stock.php
+++ b/app/code/core/Mage/Bundle/Model/Mysql4/Indexer/Stock.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Model/Mysql4/Indexer/Stock.php
+++ b/app/code/core/Mage/Bundle/Model/Mysql4/Indexer/Stock.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Model/Mysql4/Option.php
+++ b/app/code/core/Mage/Bundle/Model/Mysql4/Option.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Bundle/Model/Mysql4/Option.php
+++ b/app/code/core/Mage/Bundle/Model/Mysql4/Option.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Model/Mysql4/Option.php
+++ b/app/code/core/Mage/Bundle/Model/Mysql4/Option.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Model/Mysql4/Option/Collection.php
+++ b/app/code/core/Mage/Bundle/Model/Mysql4/Option/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Bundle/Model/Mysql4/Option/Collection.php
+++ b/app/code/core/Mage/Bundle/Model/Mysql4/Option/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Model/Mysql4/Option/Collection.php
+++ b/app/code/core/Mage/Bundle/Model/Mysql4/Option/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Model/Mysql4/Price/Index.php
+++ b/app/code/core/Mage/Bundle/Model/Mysql4/Price/Index.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Bundle/Model/Mysql4/Price/Index.php
+++ b/app/code/core/Mage/Bundle/Model/Mysql4/Price/Index.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Model/Mysql4/Price/Index.php
+++ b/app/code/core/Mage/Bundle/Model/Mysql4/Price/Index.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Model/Mysql4/Selection.php
+++ b/app/code/core/Mage/Bundle/Model/Mysql4/Selection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Bundle/Model/Mysql4/Selection.php
+++ b/app/code/core/Mage/Bundle/Model/Mysql4/Selection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Model/Mysql4/Selection.php
+++ b/app/code/core/Mage/Bundle/Model/Mysql4/Selection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Model/Mysql4/Selection/Collection.php
+++ b/app/code/core/Mage/Bundle/Model/Mysql4/Selection/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Bundle/Model/Mysql4/Selection/Collection.php
+++ b/app/code/core/Mage/Bundle/Model/Mysql4/Selection/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Model/Mysql4/Selection/Collection.php
+++ b/app/code/core/Mage/Bundle/Model/Mysql4/Selection/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Model/Observer.php
+++ b/app/code/core/Mage/Bundle/Model/Observer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Bundle/Model/Observer.php
+++ b/app/code/core/Mage/Bundle/Model/Observer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Model/Observer.php
+++ b/app/code/core/Mage/Bundle/Model/Observer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Model/Option.php
+++ b/app/code/core/Mage/Bundle/Model/Option.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Bundle/Model/Option.php
+++ b/app/code/core/Mage/Bundle/Model/Option.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Model/Option.php
+++ b/app/code/core/Mage/Bundle/Model/Option.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Model/Price/Index.php
+++ b/app/code/core/Mage/Bundle/Model/Price/Index.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Bundle/Model/Price/Index.php
+++ b/app/code/core/Mage/Bundle/Model/Price/Index.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Model/Price/Index.php
+++ b/app/code/core/Mage/Bundle/Model/Price/Index.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Model/Product/Attribute/Source/Price/View.php
+++ b/app/code/core/Mage/Bundle/Model/Product/Attribute/Source/Price/View.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Bundle/Model/Product/Attribute/Source/Price/View.php
+++ b/app/code/core/Mage/Bundle/Model/Product/Attribute/Source/Price/View.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Model/Product/Attribute/Source/Price/View.php
+++ b/app/code/core/Mage/Bundle/Model/Product/Attribute/Source/Price/View.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Model/Product/Price.php
+++ b/app/code/core/Mage/Bundle/Model/Product/Price.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Bundle/Model/Product/Price.php
+++ b/app/code/core/Mage/Bundle/Model/Product/Price.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Model/Product/Price.php
+++ b/app/code/core/Mage/Bundle/Model/Product/Price.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Model/Product/Type.php
+++ b/app/code/core/Mage/Bundle/Model/Product/Type.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Bundle/Model/Product/Type.php
+++ b/app/code/core/Mage/Bundle/Model/Product/Type.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Model/Product/Type.php
+++ b/app/code/core/Mage/Bundle/Model/Product/Type.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Model/Resource/Bundle.php
+++ b/app/code/core/Mage/Bundle/Model/Resource/Bundle.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Bundle/Model/Resource/Bundle.php
+++ b/app/code/core/Mage/Bundle/Model/Resource/Bundle.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Model/Resource/Bundle.php
+++ b/app/code/core/Mage/Bundle/Model/Resource/Bundle.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Model/Resource/Indexer/Price.php
+++ b/app/code/core/Mage/Bundle/Model/Resource/Indexer/Price.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Bundle/Model/Resource/Indexer/Price.php
+++ b/app/code/core/Mage/Bundle/Model/Resource/Indexer/Price.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Model/Resource/Indexer/Price.php
+++ b/app/code/core/Mage/Bundle/Model/Resource/Indexer/Price.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Model/Resource/Indexer/Stock.php
+++ b/app/code/core/Mage/Bundle/Model/Resource/Indexer/Stock.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Bundle/Model/Resource/Indexer/Stock.php
+++ b/app/code/core/Mage/Bundle/Model/Resource/Indexer/Stock.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Model/Resource/Indexer/Stock.php
+++ b/app/code/core/Mage/Bundle/Model/Resource/Indexer/Stock.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Model/Resource/Option.php
+++ b/app/code/core/Mage/Bundle/Model/Resource/Option.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Bundle/Model/Resource/Option.php
+++ b/app/code/core/Mage/Bundle/Model/Resource/Option.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Model/Resource/Option.php
+++ b/app/code/core/Mage/Bundle/Model/Resource/Option.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Model/Resource/Option/Collection.php
+++ b/app/code/core/Mage/Bundle/Model/Resource/Option/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Bundle/Model/Resource/Option/Collection.php
+++ b/app/code/core/Mage/Bundle/Model/Resource/Option/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Model/Resource/Option/Collection.php
+++ b/app/code/core/Mage/Bundle/Model/Resource/Option/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Model/Resource/Price/Index.php
+++ b/app/code/core/Mage/Bundle/Model/Resource/Price/Index.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Bundle/Model/Resource/Price/Index.php
+++ b/app/code/core/Mage/Bundle/Model/Resource/Price/Index.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Model/Resource/Price/Index.php
+++ b/app/code/core/Mage/Bundle/Model/Resource/Price/Index.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Model/Resource/Selection.php
+++ b/app/code/core/Mage/Bundle/Model/Resource/Selection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Bundle/Model/Resource/Selection.php
+++ b/app/code/core/Mage/Bundle/Model/Resource/Selection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Model/Resource/Selection.php
+++ b/app/code/core/Mage/Bundle/Model/Resource/Selection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Model/Resource/Selection/Collection.php
+++ b/app/code/core/Mage/Bundle/Model/Resource/Selection/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Bundle/Model/Resource/Selection/Collection.php
+++ b/app/code/core/Mage/Bundle/Model/Resource/Selection/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Model/Resource/Selection/Collection.php
+++ b/app/code/core/Mage/Bundle/Model/Resource/Selection/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Model/Sales/Order/Pdf/Items/Abstract.php
+++ b/app/code/core/Mage/Bundle/Model/Sales/Order/Pdf/Items/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Bundle/Model/Sales/Order/Pdf/Items/Abstract.php
+++ b/app/code/core/Mage/Bundle/Model/Sales/Order/Pdf/Items/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Model/Sales/Order/Pdf/Items/Abstract.php
+++ b/app/code/core/Mage/Bundle/Model/Sales/Order/Pdf/Items/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Model/Sales/Order/Pdf/Items/Creditmemo.php
+++ b/app/code/core/Mage/Bundle/Model/Sales/Order/Pdf/Items/Creditmemo.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Bundle/Model/Sales/Order/Pdf/Items/Creditmemo.php
+++ b/app/code/core/Mage/Bundle/Model/Sales/Order/Pdf/Items/Creditmemo.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Model/Sales/Order/Pdf/Items/Creditmemo.php
+++ b/app/code/core/Mage/Bundle/Model/Sales/Order/Pdf/Items/Creditmemo.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Model/Sales/Order/Pdf/Items/Invoice.php
+++ b/app/code/core/Mage/Bundle/Model/Sales/Order/Pdf/Items/Invoice.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Bundle/Model/Sales/Order/Pdf/Items/Invoice.php
+++ b/app/code/core/Mage/Bundle/Model/Sales/Order/Pdf/Items/Invoice.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Model/Sales/Order/Pdf/Items/Invoice.php
+++ b/app/code/core/Mage/Bundle/Model/Sales/Order/Pdf/Items/Invoice.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Model/Sales/Order/Pdf/Items/Shipment.php
+++ b/app/code/core/Mage/Bundle/Model/Sales/Order/Pdf/Items/Shipment.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Bundle/Model/Sales/Order/Pdf/Items/Shipment.php
+++ b/app/code/core/Mage/Bundle/Model/Sales/Order/Pdf/Items/Shipment.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Model/Sales/Order/Pdf/Items/Shipment.php
+++ b/app/code/core/Mage/Bundle/Model/Sales/Order/Pdf/Items/Shipment.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Model/Selection.php
+++ b/app/code/core/Mage/Bundle/Model/Selection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Bundle/Model/Selection.php
+++ b/app/code/core/Mage/Bundle/Model/Selection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Model/Selection.php
+++ b/app/code/core/Mage/Bundle/Model/Selection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Model/Source/Option/Selection/Price/Type.php
+++ b/app/code/core/Mage/Bundle/Model/Source/Option/Selection/Price/Type.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Bundle/Model/Source/Option/Selection/Price/Type.php
+++ b/app/code/core/Mage/Bundle/Model/Source/Option/Selection/Price/Type.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Model/Source/Option/Selection/Price/Type.php
+++ b/app/code/core/Mage/Bundle/Model/Source/Option/Selection/Price/Type.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Model/Source/Option/Type.php
+++ b/app/code/core/Mage/Bundle/Model/Source/Option/Type.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Bundle/Model/Source/Option/Type.php
+++ b/app/code/core/Mage/Bundle/Model/Source/Option/Type.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/Model/Source/Option/Type.php
+++ b/app/code/core/Mage/Bundle/Model/Source/Option/Type.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/controllers/Adminhtml/Bundle/Product/EditController.php
+++ b/app/code/core/Mage/Bundle/controllers/Adminhtml/Bundle/Product/EditController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Bundle/controllers/Adminhtml/Bundle/Product/EditController.php
+++ b/app/code/core/Mage/Bundle/controllers/Adminhtml/Bundle/Product/EditController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/controllers/Adminhtml/Bundle/Product/EditController.php
+++ b/app/code/core/Mage/Bundle/controllers/Adminhtml/Bundle/Product/EditController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/controllers/Adminhtml/Bundle/SelectionController.php
+++ b/app/code/core/Mage/Bundle/controllers/Adminhtml/Bundle/SelectionController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Bundle/controllers/Adminhtml/Bundle/SelectionController.php
+++ b/app/code/core/Mage/Bundle/controllers/Adminhtml/Bundle/SelectionController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/controllers/Adminhtml/Bundle/SelectionController.php
+++ b/app/code/core/Mage/Bundle/controllers/Adminhtml/Bundle/SelectionController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/controllers/Product/EditController.php
+++ b/app/code/core/Mage/Bundle/controllers/Product/EditController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Bundle/controllers/Product/EditController.php
+++ b/app/code/core/Mage/Bundle/controllers/Product/EditController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/controllers/Product/EditController.php
+++ b/app/code/core/Mage/Bundle/controllers/Product/EditController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/controllers/SelectionController.php
+++ b/app/code/core/Mage/Bundle/controllers/SelectionController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Bundle/controllers/SelectionController.php
+++ b/app/code/core/Mage/Bundle/controllers/SelectionController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/controllers/SelectionController.php
+++ b/app/code/core/Mage/Bundle/controllers/SelectionController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/data/bundle_setup/data-install-1.6.0.0.php
+++ b/app/code/core/Mage/Bundle/data/bundle_setup/data-install-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Bundle/data/bundle_setup/data-install-1.6.0.0.php
+++ b/app/code/core/Mage/Bundle/data/bundle_setup/data-install-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/data/bundle_setup/data-install-1.6.0.0.php
+++ b/app/code/core/Mage/Bundle/data/bundle_setup/data-install-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/etc/config.xml
+++ b/app/code/core/Mage/Bundle/etc/config.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/etc/config.xml
+++ b/app/code/core/Mage/Bundle/etc/config.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/etc/config.xml
+++ b/app/code/core/Mage/Bundle/etc/config.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Bundle/sql/bundle_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Bundle/sql/bundle_setup/install-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Bundle/sql/bundle_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Bundle/sql/bundle_setup/install-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/sql/bundle_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Bundle/sql/bundle_setup/install-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-data-upgrade-0.1.13-0.1.14.php
+++ b/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-data-upgrade-0.1.13-0.1.14.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-data-upgrade-0.1.13-0.1.14.php
+++ b/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-data-upgrade-0.1.13-0.1.14.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-data-upgrade-0.1.13-0.1.14.php
+++ b/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-data-upgrade-0.1.13-0.1.14.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-install-0.1.0.php
+++ b/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-install-0.1.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-install-0.1.0.php
+++ b/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-install-0.1.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-install-0.1.0.php
+++ b/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-install-0.1.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-upgrade-0.1.0-0.1.1.php
+++ b/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-upgrade-0.1.0-0.1.1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-upgrade-0.1.0-0.1.1.php
+++ b/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-upgrade-0.1.0-0.1.1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-upgrade-0.1.0-0.1.1.php
+++ b/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-upgrade-0.1.0-0.1.1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-upgrade-0.1.1-0.1.2.php
+++ b/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-upgrade-0.1.1-0.1.2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-upgrade-0.1.1-0.1.2.php
+++ b/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-upgrade-0.1.1-0.1.2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-upgrade-0.1.1-0.1.2.php
+++ b/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-upgrade-0.1.1-0.1.2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-upgrade-0.1.10-0.1.11.php
+++ b/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-upgrade-0.1.10-0.1.11.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-upgrade-0.1.10-0.1.11.php
+++ b/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-upgrade-0.1.10-0.1.11.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-upgrade-0.1.10-0.1.11.php
+++ b/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-upgrade-0.1.10-0.1.11.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-upgrade-0.1.11-0.1.12.php
+++ b/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-upgrade-0.1.11-0.1.12.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-upgrade-0.1.11-0.1.12.php
+++ b/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-upgrade-0.1.11-0.1.12.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-upgrade-0.1.11-0.1.12.php
+++ b/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-upgrade-0.1.11-0.1.12.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-upgrade-0.1.12-0.1.13.php
+++ b/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-upgrade-0.1.12-0.1.13.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-upgrade-0.1.12-0.1.13.php
+++ b/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-upgrade-0.1.12-0.1.13.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-upgrade-0.1.12-0.1.13.php
+++ b/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-upgrade-0.1.12-0.1.13.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-upgrade-0.1.2-0.1.3.php
+++ b/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-upgrade-0.1.2-0.1.3.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-upgrade-0.1.2-0.1.3.php
+++ b/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-upgrade-0.1.2-0.1.3.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-upgrade-0.1.2-0.1.3.php
+++ b/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-upgrade-0.1.2-0.1.3.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-upgrade-0.1.3-0.1.4.php
+++ b/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-upgrade-0.1.3-0.1.4.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-upgrade-0.1.3-0.1.4.php
+++ b/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-upgrade-0.1.3-0.1.4.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-upgrade-0.1.3-0.1.4.php
+++ b/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-upgrade-0.1.3-0.1.4.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-upgrade-0.1.4-0.1.5.php
+++ b/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-upgrade-0.1.4-0.1.5.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-upgrade-0.1.4-0.1.5.php
+++ b/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-upgrade-0.1.4-0.1.5.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-upgrade-0.1.4-0.1.5.php
+++ b/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-upgrade-0.1.4-0.1.5.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-upgrade-0.1.5-0.1.6.php
+++ b/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-upgrade-0.1.5-0.1.6.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-upgrade-0.1.5-0.1.6.php
+++ b/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-upgrade-0.1.5-0.1.6.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-upgrade-0.1.5-0.1.6.php
+++ b/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-upgrade-0.1.5-0.1.6.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-upgrade-0.1.6-0.1.7.php
+++ b/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-upgrade-0.1.6-0.1.7.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-upgrade-0.1.6-0.1.7.php
+++ b/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-upgrade-0.1.6-0.1.7.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-upgrade-0.1.6-0.1.7.php
+++ b/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-upgrade-0.1.6-0.1.7.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-upgrade-0.1.7-0.1.8.php
+++ b/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-upgrade-0.1.7-0.1.8.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-upgrade-0.1.7-0.1.8.php
+++ b/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-upgrade-0.1.7-0.1.8.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-upgrade-0.1.7-0.1.8.php
+++ b/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-upgrade-0.1.7-0.1.8.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-upgrade-0.1.8-0.1.9.php
+++ b/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-upgrade-0.1.8-0.1.9.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-upgrade-0.1.8-0.1.9.php
+++ b/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-upgrade-0.1.8-0.1.9.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-upgrade-0.1.8-0.1.9.php
+++ b/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-upgrade-0.1.8-0.1.9.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-upgrade-0.1.9-0.1.10.php
+++ b/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-upgrade-0.1.9-0.1.10.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-upgrade-0.1.9-0.1.10.php
+++ b/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-upgrade-0.1.9-0.1.10.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-upgrade-0.1.9-0.1.10.php
+++ b/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-upgrade-0.1.9-0.1.10.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-upgrade-1.6.0.0-1.6.0.0.1.php
+++ b/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-upgrade-1.6.0.0-1.6.0.0.1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-upgrade-1.6.0.0-1.6.0.0.1.php
+++ b/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-upgrade-1.6.0.0-1.6.0.0.1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-upgrade-1.6.0.0-1.6.0.0.1.php
+++ b/app/code/core/Mage/Bundle/sql/bundle_setup/mysql4-upgrade-1.6.0.0-1.6.0.0.1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/sql/bundle_setup/upgrade-1.6.0.0-1.6.0.0.1.php
+++ b/app/code/core/Mage/Bundle/sql/bundle_setup/upgrade-1.6.0.0-1.6.0.0.1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Bundle/sql/bundle_setup/upgrade-1.6.0.0-1.6.0.0.1.php
+++ b/app/code/core/Mage/Bundle/sql/bundle_setup/upgrade-1.6.0.0-1.6.0.0.1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Bundle/sql/bundle_setup/upgrade-1.6.0.0-1.6.0.0.1.php
+++ b/app/code/core/Mage/Bundle/sql/bundle_setup/upgrade-1.6.0.0-1.6.0.0.1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/code/core/Mage/Captcha/Block/Captcha.php
+++ b/app/code/core/Mage/Captcha/Block/Captcha.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Captcha

--- a/app/code/core/Mage/Captcha/Block/Captcha.php
+++ b/app/code/core/Mage/Captcha/Block/Captcha.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Captcha/Block/Captcha.php
+++ b/app/code/core/Mage/Captcha/Block/Captcha.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Captcha

--- a/app/code/core/Mage/Captcha/Block/Captcha/Zend.php
+++ b/app/code/core/Mage/Captcha/Block/Captcha/Zend.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Captcha

--- a/app/code/core/Mage/Captcha/Block/Captcha/Zend.php
+++ b/app/code/core/Mage/Captcha/Block/Captcha/Zend.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Captcha/Block/Captcha/Zend.php
+++ b/app/code/core/Mage/Captcha/Block/Captcha/Zend.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Captcha

--- a/app/code/core/Mage/Captcha/Helper/Data.php
+++ b/app/code/core/Mage/Captcha/Helper/Data.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Captcha

--- a/app/code/core/Mage/Captcha/Helper/Data.php
+++ b/app/code/core/Mage/Captcha/Helper/Data.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Captcha/Helper/Data.php
+++ b/app/code/core/Mage/Captcha/Helper/Data.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Captcha

--- a/app/code/core/Mage/Captcha/Model/Config/Font.php
+++ b/app/code/core/Mage/Captcha/Model/Config/Font.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Captcha

--- a/app/code/core/Mage/Captcha/Model/Config/Font.php
+++ b/app/code/core/Mage/Captcha/Model/Config/Font.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Captcha/Model/Config/Font.php
+++ b/app/code/core/Mage/Captcha/Model/Config/Font.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Captcha

--- a/app/code/core/Mage/Captcha/Model/Config/Form/Abstract.php
+++ b/app/code/core/Mage/Captcha/Model/Config/Form/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Captcha

--- a/app/code/core/Mage/Captcha/Model/Config/Form/Abstract.php
+++ b/app/code/core/Mage/Captcha/Model/Config/Form/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Captcha/Model/Config/Form/Abstract.php
+++ b/app/code/core/Mage/Captcha/Model/Config/Form/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Captcha

--- a/app/code/core/Mage/Captcha/Model/Config/Form/Backend.php
+++ b/app/code/core/Mage/Captcha/Model/Config/Form/Backend.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Captcha

--- a/app/code/core/Mage/Captcha/Model/Config/Form/Backend.php
+++ b/app/code/core/Mage/Captcha/Model/Config/Form/Backend.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Captcha/Model/Config/Form/Backend.php
+++ b/app/code/core/Mage/Captcha/Model/Config/Form/Backend.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Captcha

--- a/app/code/core/Mage/Captcha/Model/Config/Form/Frontend.php
+++ b/app/code/core/Mage/Captcha/Model/Config/Form/Frontend.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Captcha

--- a/app/code/core/Mage/Captcha/Model/Config/Form/Frontend.php
+++ b/app/code/core/Mage/Captcha/Model/Config/Form/Frontend.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Captcha/Model/Config/Form/Frontend.php
+++ b/app/code/core/Mage/Captcha/Model/Config/Form/Frontend.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Captcha

--- a/app/code/core/Mage/Captcha/Model/Config/Mode.php
+++ b/app/code/core/Mage/Captcha/Model/Config/Mode.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Captcha

--- a/app/code/core/Mage/Captcha/Model/Config/Mode.php
+++ b/app/code/core/Mage/Captcha/Model/Config/Mode.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Captcha/Model/Config/Mode.php
+++ b/app/code/core/Mage/Captcha/Model/Config/Mode.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Captcha

--- a/app/code/core/Mage/Captcha/Model/Interface.php
+++ b/app/code/core/Mage/Captcha/Model/Interface.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Captcha

--- a/app/code/core/Mage/Captcha/Model/Interface.php
+++ b/app/code/core/Mage/Captcha/Model/Interface.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Captcha/Model/Interface.php
+++ b/app/code/core/Mage/Captcha/Model/Interface.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Captcha

--- a/app/code/core/Mage/Captcha/Model/Observer.php
+++ b/app/code/core/Mage/Captcha/Model/Observer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Captcha

--- a/app/code/core/Mage/Captcha/Model/Observer.php
+++ b/app/code/core/Mage/Captcha/Model/Observer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Captcha/Model/Observer.php
+++ b/app/code/core/Mage/Captcha/Model/Observer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Captcha

--- a/app/code/core/Mage/Captcha/Model/Resource/Log.php
+++ b/app/code/core/Mage/Captcha/Model/Resource/Log.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Captcha

--- a/app/code/core/Mage/Captcha/Model/Resource/Log.php
+++ b/app/code/core/Mage/Captcha/Model/Resource/Log.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Captcha/Model/Resource/Log.php
+++ b/app/code/core/Mage/Captcha/Model/Resource/Log.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Captcha

--- a/app/code/core/Mage/Captcha/Model/Zend.php
+++ b/app/code/core/Mage/Captcha/Model/Zend.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Captcha

--- a/app/code/core/Mage/Captcha/Model/Zend.php
+++ b/app/code/core/Mage/Captcha/Model/Zend.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Captcha/Model/Zend.php
+++ b/app/code/core/Mage/Captcha/Model/Zend.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Captcha

--- a/app/code/core/Mage/Captcha/controllers/Adminhtml/RefreshController.php
+++ b/app/code/core/Mage/Captcha/controllers/Adminhtml/RefreshController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Captcha

--- a/app/code/core/Mage/Captcha/controllers/Adminhtml/RefreshController.php
+++ b/app/code/core/Mage/Captcha/controllers/Adminhtml/RefreshController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Captcha/controllers/Adminhtml/RefreshController.php
+++ b/app/code/core/Mage/Captcha/controllers/Adminhtml/RefreshController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Captcha

--- a/app/code/core/Mage/Captcha/controllers/RefreshController.php
+++ b/app/code/core/Mage/Captcha/controllers/RefreshController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Captcha

--- a/app/code/core/Mage/Captcha/controllers/RefreshController.php
+++ b/app/code/core/Mage/Captcha/controllers/RefreshController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Captcha/controllers/RefreshController.php
+++ b/app/code/core/Mage/Captcha/controllers/RefreshController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Captcha

--- a/app/code/core/Mage/Captcha/etc/config.xml
+++ b/app/code/core/Mage/Captcha/etc/config.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Captcha

--- a/app/code/core/Mage/Captcha/etc/config.xml
+++ b/app/code/core/Mage/Captcha/etc/config.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Captcha/etc/config.xml
+++ b/app/code/core/Mage/Captcha/etc/config.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Captcha

--- a/app/code/core/Mage/Captcha/etc/system.xml
+++ b/app/code/core/Mage/Captcha/etc/system.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Captcha

--- a/app/code/core/Mage/Captcha/etc/system.xml
+++ b/app/code/core/Mage/Captcha/etc/system.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Captcha/etc/system.xml
+++ b/app/code/core/Mage/Captcha/etc/system.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Captcha

--- a/app/code/core/Mage/Captcha/sql/captcha_setup/install-1.7.0.0.0.php
+++ b/app/code/core/Mage/Captcha/sql/captcha_setup/install-1.7.0.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Captcha

--- a/app/code/core/Mage/Captcha/sql/captcha_setup/install-1.7.0.0.0.php
+++ b/app/code/core/Mage/Captcha/sql/captcha_setup/install-1.7.0.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Captcha/sql/captcha_setup/install-1.7.0.0.0.php
+++ b/app/code/core/Mage/Captcha/sql/captcha_setup/install-1.7.0.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Captcha

--- a/app/code/core/Mage/Catalog/Block/Breadcrumbs.php
+++ b/app/code/core/Mage/Catalog/Block/Breadcrumbs.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Breadcrumbs.php
+++ b/app/code/core/Mage/Catalog/Block/Breadcrumbs.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Block/Breadcrumbs.php
+++ b/app/code/core/Mage/Catalog/Block/Breadcrumbs.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Category/View.php
+++ b/app/code/core/Mage/Catalog/Block/Category/View.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Category/View.php
+++ b/app/code/core/Mage/Catalog/Block/Category/View.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Block/Category/View.php
+++ b/app/code/core/Mage/Catalog/Block/Category/View.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Category/Widget/Link.php
+++ b/app/code/core/Mage/Catalog/Block/Category/Widget/Link.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Category/Widget/Link.php
+++ b/app/code/core/Mage/Catalog/Block/Category/Widget/Link.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Block/Category/Widget/Link.php
+++ b/app/code/core/Mage/Catalog/Block/Category/Widget/Link.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Layer/Filter/Abstract.php
+++ b/app/code/core/Mage/Catalog/Block/Layer/Filter/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Layer/Filter/Abstract.php
+++ b/app/code/core/Mage/Catalog/Block/Layer/Filter/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Block/Layer/Filter/Abstract.php
+++ b/app/code/core/Mage/Catalog/Block/Layer/Filter/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Layer/Filter/Attribute.php
+++ b/app/code/core/Mage/Catalog/Block/Layer/Filter/Attribute.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Layer/Filter/Attribute.php
+++ b/app/code/core/Mage/Catalog/Block/Layer/Filter/Attribute.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Block/Layer/Filter/Attribute.php
+++ b/app/code/core/Mage/Catalog/Block/Layer/Filter/Attribute.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Layer/Filter/Category.php
+++ b/app/code/core/Mage/Catalog/Block/Layer/Filter/Category.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Layer/Filter/Category.php
+++ b/app/code/core/Mage/Catalog/Block/Layer/Filter/Category.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Block/Layer/Filter/Category.php
+++ b/app/code/core/Mage/Catalog/Block/Layer/Filter/Category.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Layer/Filter/Decimal.php
+++ b/app/code/core/Mage/Catalog/Block/Layer/Filter/Decimal.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Layer/Filter/Decimal.php
+++ b/app/code/core/Mage/Catalog/Block/Layer/Filter/Decimal.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Block/Layer/Filter/Decimal.php
+++ b/app/code/core/Mage/Catalog/Block/Layer/Filter/Decimal.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Layer/Filter/Price.php
+++ b/app/code/core/Mage/Catalog/Block/Layer/Filter/Price.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Layer/Filter/Price.php
+++ b/app/code/core/Mage/Catalog/Block/Layer/Filter/Price.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Block/Layer/Filter/Price.php
+++ b/app/code/core/Mage/Catalog/Block/Layer/Filter/Price.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Layer/State.php
+++ b/app/code/core/Mage/Catalog/Block/Layer/State.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Layer/State.php
+++ b/app/code/core/Mage/Catalog/Block/Layer/State.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Block/Layer/State.php
+++ b/app/code/core/Mage/Catalog/Block/Layer/State.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Layer/View.php
+++ b/app/code/core/Mage/Catalog/Block/Layer/View.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Layer/View.php
+++ b/app/code/core/Mage/Catalog/Block/Layer/View.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Block/Layer/View.php
+++ b/app/code/core/Mage/Catalog/Block/Layer/View.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Navigation.php
+++ b/app/code/core/Mage/Catalog/Block/Navigation.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Navigation.php
+++ b/app/code/core/Mage/Catalog/Block/Navigation.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Block/Navigation.php
+++ b/app/code/core/Mage/Catalog/Block/Navigation.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Product.php
+++ b/app/code/core/Mage/Catalog/Block/Product.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Product.php
+++ b/app/code/core/Mage/Catalog/Block/Product.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Block/Product.php
+++ b/app/code/core/Mage/Catalog/Block/Product.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Product/Abstract.php
+++ b/app/code/core/Mage/Catalog/Block/Product/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Product/Abstract.php
+++ b/app/code/core/Mage/Catalog/Block/Product/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Block/Product/Abstract.php
+++ b/app/code/core/Mage/Catalog/Block/Product/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Product/Compare/Abstract.php
+++ b/app/code/core/Mage/Catalog/Block/Product/Compare/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Product/Compare/Abstract.php
+++ b/app/code/core/Mage/Catalog/Block/Product/Compare/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Block/Product/Compare/Abstract.php
+++ b/app/code/core/Mage/Catalog/Block/Product/Compare/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Product/Compare/List.php
+++ b/app/code/core/Mage/Catalog/Block/Product/Compare/List.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Product/Compare/List.php
+++ b/app/code/core/Mage/Catalog/Block/Product/Compare/List.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Block/Product/Compare/List.php
+++ b/app/code/core/Mage/Catalog/Block/Product/Compare/List.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Product/Compare/Sidebar.php
+++ b/app/code/core/Mage/Catalog/Block/Product/Compare/Sidebar.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Product/Compare/Sidebar.php
+++ b/app/code/core/Mage/Catalog/Block/Product/Compare/Sidebar.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Block/Product/Compare/Sidebar.php
+++ b/app/code/core/Mage/Catalog/Block/Product/Compare/Sidebar.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Product/Gallery.php
+++ b/app/code/core/Mage/Catalog/Block/Product/Gallery.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Product/Gallery.php
+++ b/app/code/core/Mage/Catalog/Block/Product/Gallery.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Block/Product/Gallery.php
+++ b/app/code/core/Mage/Catalog/Block/Product/Gallery.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Product/List.php
+++ b/app/code/core/Mage/Catalog/Block/Product/List.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Product/List.php
+++ b/app/code/core/Mage/Catalog/Block/Product/List.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Block/Product/List.php
+++ b/app/code/core/Mage/Catalog/Block/Product/List.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Product/List/Crosssell.php
+++ b/app/code/core/Mage/Catalog/Block/Product/List/Crosssell.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Product/List/Crosssell.php
+++ b/app/code/core/Mage/Catalog/Block/Product/List/Crosssell.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Block/Product/List/Crosssell.php
+++ b/app/code/core/Mage/Catalog/Block/Product/List/Crosssell.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Product/List/Promotion.php
+++ b/app/code/core/Mage/Catalog/Block/Product/List/Promotion.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Product/List/Promotion.php
+++ b/app/code/core/Mage/Catalog/Block/Product/List/Promotion.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Block/Product/List/Promotion.php
+++ b/app/code/core/Mage/Catalog/Block/Product/List/Promotion.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Product/List/Random.php
+++ b/app/code/core/Mage/Catalog/Block/Product/List/Random.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Product/List/Random.php
+++ b/app/code/core/Mage/Catalog/Block/Product/List/Random.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Block/Product/List/Random.php
+++ b/app/code/core/Mage/Catalog/Block/Product/List/Random.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Product/List/Related.php
+++ b/app/code/core/Mage/Catalog/Block/Product/List/Related.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Product/List/Related.php
+++ b/app/code/core/Mage/Catalog/Block/Product/List/Related.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Block/Product/List/Related.php
+++ b/app/code/core/Mage/Catalog/Block/Product/List/Related.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Product/List/Toolbar.php
+++ b/app/code/core/Mage/Catalog/Block/Product/List/Toolbar.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Product/List/Toolbar.php
+++ b/app/code/core/Mage/Catalog/Block/Product/List/Toolbar.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Block/Product/List/Toolbar.php
+++ b/app/code/core/Mage/Catalog/Block/Product/List/Toolbar.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Product/List/Upsell.php
+++ b/app/code/core/Mage/Catalog/Block/Product/List/Upsell.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Product/List/Upsell.php
+++ b/app/code/core/Mage/Catalog/Block/Product/List/Upsell.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Block/Product/List/Upsell.php
+++ b/app/code/core/Mage/Catalog/Block/Product/List/Upsell.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Product/New.php
+++ b/app/code/core/Mage/Catalog/Block/Product/New.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Product/New.php
+++ b/app/code/core/Mage/Catalog/Block/Product/New.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Block/Product/New.php
+++ b/app/code/core/Mage/Catalog/Block/Product/New.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Product/Price.php
+++ b/app/code/core/Mage/Catalog/Block/Product/Price.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Product/Price.php
+++ b/app/code/core/Mage/Catalog/Block/Product/Price.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Block/Product/Price.php
+++ b/app/code/core/Mage/Catalog/Block/Product/Price.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Product/Price/Template.php
+++ b/app/code/core/Mage/Catalog/Block/Product/Price/Template.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Product/Price/Template.php
+++ b/app/code/core/Mage/Catalog/Block/Product/Price/Template.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Block/Product/Price/Template.php
+++ b/app/code/core/Mage/Catalog/Block/Product/Price/Template.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Product/Send.php
+++ b/app/code/core/Mage/Catalog/Block/Product/Send.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Product/Send.php
+++ b/app/code/core/Mage/Catalog/Block/Product/Send.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Block/Product/Send.php
+++ b/app/code/core/Mage/Catalog/Block/Product/Send.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Product/View.php
+++ b/app/code/core/Mage/Catalog/Block/Product/View.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Product/View.php
+++ b/app/code/core/Mage/Catalog/Block/Product/View.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Block/Product/View.php
+++ b/app/code/core/Mage/Catalog/Block/Product/View.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Product/View/Abstract.php
+++ b/app/code/core/Mage/Catalog/Block/Product/View/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Product/View/Abstract.php
+++ b/app/code/core/Mage/Catalog/Block/Product/View/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Block/Product/View/Abstract.php
+++ b/app/code/core/Mage/Catalog/Block/Product/View/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Product/View/Additional.php
+++ b/app/code/core/Mage/Catalog/Block/Product/View/Additional.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Product/View/Additional.php
+++ b/app/code/core/Mage/Catalog/Block/Product/View/Additional.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Block/Product/View/Additional.php
+++ b/app/code/core/Mage/Catalog/Block/Product/View/Additional.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Product/View/Attributes.php
+++ b/app/code/core/Mage/Catalog/Block/Product/View/Attributes.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Product/View/Attributes.php
+++ b/app/code/core/Mage/Catalog/Block/Product/View/Attributes.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Block/Product/View/Attributes.php
+++ b/app/code/core/Mage/Catalog/Block/Product/View/Attributes.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Product/View/Description.php
+++ b/app/code/core/Mage/Catalog/Block/Product/View/Description.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Product/View/Description.php
+++ b/app/code/core/Mage/Catalog/Block/Product/View/Description.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Block/Product/View/Description.php
+++ b/app/code/core/Mage/Catalog/Block/Product/View/Description.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Product/View/Media.php
+++ b/app/code/core/Mage/Catalog/Block/Product/View/Media.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Product/View/Media.php
+++ b/app/code/core/Mage/Catalog/Block/Product/View/Media.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Block/Product/View/Media.php
+++ b/app/code/core/Mage/Catalog/Block/Product/View/Media.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Product/View/Options.php
+++ b/app/code/core/Mage/Catalog/Block/Product/View/Options.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Product/View/Options.php
+++ b/app/code/core/Mage/Catalog/Block/Product/View/Options.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Block/Product/View/Options.php
+++ b/app/code/core/Mage/Catalog/Block/Product/View/Options.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Product/View/Options/Abstract.php
+++ b/app/code/core/Mage/Catalog/Block/Product/View/Options/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Product/View/Options/Abstract.php
+++ b/app/code/core/Mage/Catalog/Block/Product/View/Options/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Block/Product/View/Options/Abstract.php
+++ b/app/code/core/Mage/Catalog/Block/Product/View/Options/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Product/View/Options/Type/Date.php
+++ b/app/code/core/Mage/Catalog/Block/Product/View/Options/Type/Date.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Product/View/Options/Type/Date.php
+++ b/app/code/core/Mage/Catalog/Block/Product/View/Options/Type/Date.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Block/Product/View/Options/Type/Date.php
+++ b/app/code/core/Mage/Catalog/Block/Product/View/Options/Type/Date.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Product/View/Options/Type/Default.php
+++ b/app/code/core/Mage/Catalog/Block/Product/View/Options/Type/Default.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Product/View/Options/Type/Default.php
+++ b/app/code/core/Mage/Catalog/Block/Product/View/Options/Type/Default.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Block/Product/View/Options/Type/Default.php
+++ b/app/code/core/Mage/Catalog/Block/Product/View/Options/Type/Default.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Product/View/Options/Type/File.php
+++ b/app/code/core/Mage/Catalog/Block/Product/View/Options/Type/File.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Product/View/Options/Type/File.php
+++ b/app/code/core/Mage/Catalog/Block/Product/View/Options/Type/File.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Block/Product/View/Options/Type/File.php
+++ b/app/code/core/Mage/Catalog/Block/Product/View/Options/Type/File.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Product/View/Options/Type/Select.php
+++ b/app/code/core/Mage/Catalog/Block/Product/View/Options/Type/Select.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Product/View/Options/Type/Select.php
+++ b/app/code/core/Mage/Catalog/Block/Product/View/Options/Type/Select.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Block/Product/View/Options/Type/Select.php
+++ b/app/code/core/Mage/Catalog/Block/Product/View/Options/Type/Select.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Product/View/Options/Type/Text.php
+++ b/app/code/core/Mage/Catalog/Block/Product/View/Options/Type/Text.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Product/View/Options/Type/Text.php
+++ b/app/code/core/Mage/Catalog/Block/Product/View/Options/Type/Text.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Block/Product/View/Options/Type/Text.php
+++ b/app/code/core/Mage/Catalog/Block/Product/View/Options/Type/Text.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Product/View/Price.php
+++ b/app/code/core/Mage/Catalog/Block/Product/View/Price.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Product/View/Price.php
+++ b/app/code/core/Mage/Catalog/Block/Product/View/Price.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Block/Product/View/Price.php
+++ b/app/code/core/Mage/Catalog/Block/Product/View/Price.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Product/View/Tabs.php
+++ b/app/code/core/Mage/Catalog/Block/Product/View/Tabs.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Product/View/Tabs.php
+++ b/app/code/core/Mage/Catalog/Block/Product/View/Tabs.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Block/Product/View/Tabs.php
+++ b/app/code/core/Mage/Catalog/Block/Product/View/Tabs.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Product/View/Type/Configurable.php
+++ b/app/code/core/Mage/Catalog/Block/Product/View/Type/Configurable.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Product/View/Type/Configurable.php
+++ b/app/code/core/Mage/Catalog/Block/Product/View/Type/Configurable.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Block/Product/View/Type/Configurable.php
+++ b/app/code/core/Mage/Catalog/Block/Product/View/Type/Configurable.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Product/View/Type/Grouped.php
+++ b/app/code/core/Mage/Catalog/Block/Product/View/Type/Grouped.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Product/View/Type/Grouped.php
+++ b/app/code/core/Mage/Catalog/Block/Product/View/Type/Grouped.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Block/Product/View/Type/Grouped.php
+++ b/app/code/core/Mage/Catalog/Block/Product/View/Type/Grouped.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Product/View/Type/Simple.php
+++ b/app/code/core/Mage/Catalog/Block/Product/View/Type/Simple.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Product/View/Type/Simple.php
+++ b/app/code/core/Mage/Catalog/Block/Product/View/Type/Simple.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Block/Product/View/Type/Simple.php
+++ b/app/code/core/Mage/Catalog/Block/Product/View/Type/Simple.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Product/View/Type/Virtual.php
+++ b/app/code/core/Mage/Catalog/Block/Product/View/Type/Virtual.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Product/View/Type/Virtual.php
+++ b/app/code/core/Mage/Catalog/Block/Product/View/Type/Virtual.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Block/Product/View/Type/Virtual.php
+++ b/app/code/core/Mage/Catalog/Block/Product/View/Type/Virtual.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Product/Widget/Html/Pager.php
+++ b/app/code/core/Mage/Catalog/Block/Product/Widget/Html/Pager.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Product/Widget/Html/Pager.php
+++ b/app/code/core/Mage/Catalog/Block/Product/Widget/Html/Pager.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Block/Product/Widget/Html/Pager.php
+++ b/app/code/core/Mage/Catalog/Block/Product/Widget/Html/Pager.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Product/Widget/Link.php
+++ b/app/code/core/Mage/Catalog/Block/Product/Widget/Link.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Product/Widget/Link.php
+++ b/app/code/core/Mage/Catalog/Block/Product/Widget/Link.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Block/Product/Widget/Link.php
+++ b/app/code/core/Mage/Catalog/Block/Product/Widget/Link.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Product/Widget/New.php
+++ b/app/code/core/Mage/Catalog/Block/Product/Widget/New.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Product/Widget/New.php
+++ b/app/code/core/Mage/Catalog/Block/Product/Widget/New.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Block/Product/Widget/New.php
+++ b/app/code/core/Mage/Catalog/Block/Product/Widget/New.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Seo/Sitemap/Abstract.php
+++ b/app/code/core/Mage/Catalog/Block/Seo/Sitemap/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Seo/Sitemap/Abstract.php
+++ b/app/code/core/Mage/Catalog/Block/Seo/Sitemap/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Block/Seo/Sitemap/Abstract.php
+++ b/app/code/core/Mage/Catalog/Block/Seo/Sitemap/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Seo/Sitemap/Category.php
+++ b/app/code/core/Mage/Catalog/Block/Seo/Sitemap/Category.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Seo/Sitemap/Category.php
+++ b/app/code/core/Mage/Catalog/Block/Seo/Sitemap/Category.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Block/Seo/Sitemap/Category.php
+++ b/app/code/core/Mage/Catalog/Block/Seo/Sitemap/Category.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Seo/Sitemap/Product.php
+++ b/app/code/core/Mage/Catalog/Block/Seo/Sitemap/Product.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Seo/Sitemap/Product.php
+++ b/app/code/core/Mage/Catalog/Block/Seo/Sitemap/Product.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Block/Seo/Sitemap/Product.php
+++ b/app/code/core/Mage/Catalog/Block/Seo/Sitemap/Product.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Seo/Sitemap/Tree/Category.php
+++ b/app/code/core/Mage/Catalog/Block/Seo/Sitemap/Tree/Category.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Seo/Sitemap/Tree/Category.php
+++ b/app/code/core/Mage/Catalog/Block/Seo/Sitemap/Tree/Category.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Block/Seo/Sitemap/Tree/Category.php
+++ b/app/code/core/Mage/Catalog/Block/Seo/Sitemap/Tree/Category.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Seo/Sitemap/Tree/Pager.php
+++ b/app/code/core/Mage/Catalog/Block/Seo/Sitemap/Tree/Pager.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Seo/Sitemap/Tree/Pager.php
+++ b/app/code/core/Mage/Catalog/Block/Seo/Sitemap/Tree/Pager.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Block/Seo/Sitemap/Tree/Pager.php
+++ b/app/code/core/Mage/Catalog/Block/Seo/Sitemap/Tree/Pager.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Widget/Link.php
+++ b/app/code/core/Mage/Catalog/Block/Widget/Link.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Block/Widget/Link.php
+++ b/app/code/core/Mage/Catalog/Block/Widget/Link.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Block/Widget/Link.php
+++ b/app/code/core/Mage/Catalog/Block/Widget/Link.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Exception.php
+++ b/app/code/core/Mage/Catalog/Exception.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Exception.php
+++ b/app/code/core/Mage/Catalog/Exception.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Exception.php
+++ b/app/code/core/Mage/Catalog/Exception.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Helper/Category.php
+++ b/app/code/core/Mage/Catalog/Helper/Category.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Helper/Category.php
+++ b/app/code/core/Mage/Catalog/Helper/Category.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Helper/Category.php
+++ b/app/code/core/Mage/Catalog/Helper/Category.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Helper/Category/Flat.php
+++ b/app/code/core/Mage/Catalog/Helper/Category/Flat.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Helper/Category/Flat.php
+++ b/app/code/core/Mage/Catalog/Helper/Category/Flat.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Helper/Category/Flat.php
+++ b/app/code/core/Mage/Catalog/Helper/Category/Flat.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Helper/Category/Url/Rewrite.php
+++ b/app/code/core/Mage/Catalog/Helper/Category/Url/Rewrite.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Helper/Category/Url/Rewrite.php
+++ b/app/code/core/Mage/Catalog/Helper/Category/Url/Rewrite.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Helper/Category/Url/Rewrite.php
+++ b/app/code/core/Mage/Catalog/Helper/Category/Url/Rewrite.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Helper/Category/Url/Rewrite/Interface.php
+++ b/app/code/core/Mage/Catalog/Helper/Category/Url/Rewrite/Interface.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Helper/Category/Url/Rewrite/Interface.php
+++ b/app/code/core/Mage/Catalog/Helper/Category/Url/Rewrite/Interface.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Helper/Category/Url/Rewrite/Interface.php
+++ b/app/code/core/Mage/Catalog/Helper/Category/Url/Rewrite/Interface.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Helper/Data.php
+++ b/app/code/core/Mage/Catalog/Helper/Data.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Helper/Data.php
+++ b/app/code/core/Mage/Catalog/Helper/Data.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Helper/Data.php
+++ b/app/code/core/Mage/Catalog/Helper/Data.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Helper/Flat/Abstract.php
+++ b/app/code/core/Mage/Catalog/Helper/Flat/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Helper/Flat/Abstract.php
+++ b/app/code/core/Mage/Catalog/Helper/Flat/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Helper/Flat/Abstract.php
+++ b/app/code/core/Mage/Catalog/Helper/Flat/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Helper/Image.php
+++ b/app/code/core/Mage/Catalog/Helper/Image.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Helper/Image.php
+++ b/app/code/core/Mage/Catalog/Helper/Image.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Helper/Image.php
+++ b/app/code/core/Mage/Catalog/Helper/Image.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Helper/Map.php
+++ b/app/code/core/Mage/Catalog/Helper/Map.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Helper/Map.php
+++ b/app/code/core/Mage/Catalog/Helper/Map.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Helper/Map.php
+++ b/app/code/core/Mage/Catalog/Helper/Map.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Helper/Output.php
+++ b/app/code/core/Mage/Catalog/Helper/Output.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Helper/Output.php
+++ b/app/code/core/Mage/Catalog/Helper/Output.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Helper/Output.php
+++ b/app/code/core/Mage/Catalog/Helper/Output.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Helper/Product.php
+++ b/app/code/core/Mage/Catalog/Helper/Product.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Helper/Product.php
+++ b/app/code/core/Mage/Catalog/Helper/Product.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Helper/Product.php
+++ b/app/code/core/Mage/Catalog/Helper/Product.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Helper/Product/Compare.php
+++ b/app/code/core/Mage/Catalog/Helper/Product/Compare.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Helper/Product/Compare.php
+++ b/app/code/core/Mage/Catalog/Helper/Product/Compare.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Helper/Product/Compare.php
+++ b/app/code/core/Mage/Catalog/Helper/Product/Compare.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Helper/Product/Configuration.php
+++ b/app/code/core/Mage/Catalog/Helper/Product/Configuration.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Helper/Product/Configuration.php
+++ b/app/code/core/Mage/Catalog/Helper/Product/Configuration.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Helper/Product/Configuration.php
+++ b/app/code/core/Mage/Catalog/Helper/Product/Configuration.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Helper/Product/Configuration/Interface.php
+++ b/app/code/core/Mage/Catalog/Helper/Product/Configuration/Interface.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Helper/Product/Configuration/Interface.php
+++ b/app/code/core/Mage/Catalog/Helper/Product/Configuration/Interface.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Helper/Product/Configuration/Interface.php
+++ b/app/code/core/Mage/Catalog/Helper/Product/Configuration/Interface.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Helper/Product/Flat.php
+++ b/app/code/core/Mage/Catalog/Helper/Product/Flat.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Helper/Product/Flat.php
+++ b/app/code/core/Mage/Catalog/Helper/Product/Flat.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Helper/Product/Flat.php
+++ b/app/code/core/Mage/Catalog/Helper/Product/Flat.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Helper/Product/Options.php
+++ b/app/code/core/Mage/Catalog/Helper/Product/Options.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Helper/Product/Options.php
+++ b/app/code/core/Mage/Catalog/Helper/Product/Options.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Helper/Product/Options.php
+++ b/app/code/core/Mage/Catalog/Helper/Product/Options.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Helper/Product/Type/Composite.php
+++ b/app/code/core/Mage/Catalog/Helper/Product/Type/Composite.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Helper/Product/Type/Composite.php
+++ b/app/code/core/Mage/Catalog/Helper/Product/Type/Composite.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Helper/Product/Type/Composite.php
+++ b/app/code/core/Mage/Catalog/Helper/Product/Type/Composite.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Helper/Product/Url.php
+++ b/app/code/core/Mage/Catalog/Helper/Product/Url.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Helper/Product/Url.php
+++ b/app/code/core/Mage/Catalog/Helper/Product/Url.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Helper/Product/Url.php
+++ b/app/code/core/Mage/Catalog/Helper/Product/Url.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Helper/Product/Url/Rewrite.php
+++ b/app/code/core/Mage/Catalog/Helper/Product/Url/Rewrite.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Helper/Product/Url/Rewrite.php
+++ b/app/code/core/Mage/Catalog/Helper/Product/Url/Rewrite.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Helper/Product/Url/Rewrite.php
+++ b/app/code/core/Mage/Catalog/Helper/Product/Url/Rewrite.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Helper/Product/Url/Rewrite/Interface.php
+++ b/app/code/core/Mage/Catalog/Helper/Product/Url/Rewrite/Interface.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Helper/Product/Url/Rewrite/Interface.php
+++ b/app/code/core/Mage/Catalog/Helper/Product/Url/Rewrite/Interface.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Helper/Product/Url/Rewrite/Interface.php
+++ b/app/code/core/Mage/Catalog/Helper/Product/Url/Rewrite/Interface.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Helper/Product/View.php
+++ b/app/code/core/Mage/Catalog/Helper/Product/View.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Helper/Product/View.php
+++ b/app/code/core/Mage/Catalog/Helper/Product/View.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Helper/Product/View.php
+++ b/app/code/core/Mage/Catalog/Helper/Product/View.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Abstract.php
+++ b/app/code/core/Mage/Catalog/Model/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Abstract.php
+++ b/app/code/core/Mage/Catalog/Model/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Abstract.php
+++ b/app/code/core/Mage/Catalog/Model/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Api/Resource.php
+++ b/app/code/core/Mage/Catalog/Model/Api/Resource.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Api/Resource.php
+++ b/app/code/core/Mage/Catalog/Model/Api/Resource.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Api/Resource.php
+++ b/app/code/core/Mage/Catalog/Model/Api/Resource.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Api2/Product.php
+++ b/app/code/core/Mage/Catalog/Model/Api2/Product.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Api2/Product.php
+++ b/app/code/core/Mage/Catalog/Model/Api2/Product.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Api2/Product.php
+++ b/app/code/core/Mage/Catalog/Model/Api2/Product.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Api2/Product/Category.php
+++ b/app/code/core/Mage/Catalog/Model/Api2/Product/Category.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Api2/Product/Category.php
+++ b/app/code/core/Mage/Catalog/Model/Api2/Product/Category.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Api2/Product/Category.php
+++ b/app/code/core/Mage/Catalog/Model/Api2/Product/Category.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Api2/Product/Category/Rest.php
+++ b/app/code/core/Mage/Catalog/Model/Api2/Product/Category/Rest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Api2/Product/Category/Rest.php
+++ b/app/code/core/Mage/Catalog/Model/Api2/Product/Category/Rest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Api2/Product/Category/Rest.php
+++ b/app/code/core/Mage/Catalog/Model/Api2/Product/Category/Rest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Api2/Product/Category/Rest/Admin/V1.php
+++ b/app/code/core/Mage/Catalog/Model/Api2/Product/Category/Rest/Admin/V1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Api2/Product/Category/Rest/Admin/V1.php
+++ b/app/code/core/Mage/Catalog/Model/Api2/Product/Category/Rest/Admin/V1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Api2/Product/Category/Rest/Admin/V1.php
+++ b/app/code/core/Mage/Catalog/Model/Api2/Product/Category/Rest/Admin/V1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Api2/Product/Category/Rest/Customer/V1.php
+++ b/app/code/core/Mage/Catalog/Model/Api2/Product/Category/Rest/Customer/V1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Api2/Product/Category/Rest/Customer/V1.php
+++ b/app/code/core/Mage/Catalog/Model/Api2/Product/Category/Rest/Customer/V1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Api2/Product/Category/Rest/Customer/V1.php
+++ b/app/code/core/Mage/Catalog/Model/Api2/Product/Category/Rest/Customer/V1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Api2/Product/Category/Rest/Guest/V1.php
+++ b/app/code/core/Mage/Catalog/Model/Api2/Product/Category/Rest/Guest/V1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Api2/Product/Category/Rest/Guest/V1.php
+++ b/app/code/core/Mage/Catalog/Model/Api2/Product/Category/Rest/Guest/V1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Api2/Product/Category/Rest/Guest/V1.php
+++ b/app/code/core/Mage/Catalog/Model/Api2/Product/Category/Rest/Guest/V1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Api2/Product/Image.php
+++ b/app/code/core/Mage/Catalog/Model/Api2/Product/Image.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Api2/Product/Image.php
+++ b/app/code/core/Mage/Catalog/Model/Api2/Product/Image.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Api2/Product/Image.php
+++ b/app/code/core/Mage/Catalog/Model/Api2/Product/Image.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Api2/Product/Image/Rest.php
+++ b/app/code/core/Mage/Catalog/Model/Api2/Product/Image/Rest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Api2/Product/Image/Rest.php
+++ b/app/code/core/Mage/Catalog/Model/Api2/Product/Image/Rest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Api2/Product/Image/Rest.php
+++ b/app/code/core/Mage/Catalog/Model/Api2/Product/Image/Rest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Api2/Product/Image/Rest/Admin/V1.php
+++ b/app/code/core/Mage/Catalog/Model/Api2/Product/Image/Rest/Admin/V1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Api2/Product/Image/Rest/Admin/V1.php
+++ b/app/code/core/Mage/Catalog/Model/Api2/Product/Image/Rest/Admin/V1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Api2/Product/Image/Rest/Admin/V1.php
+++ b/app/code/core/Mage/Catalog/Model/Api2/Product/Image/Rest/Admin/V1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Api2/Product/Image/Rest/Customer/V1.php
+++ b/app/code/core/Mage/Catalog/Model/Api2/Product/Image/Rest/Customer/V1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Api2/Product/Image/Rest/Customer/V1.php
+++ b/app/code/core/Mage/Catalog/Model/Api2/Product/Image/Rest/Customer/V1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Api2/Product/Image/Rest/Customer/V1.php
+++ b/app/code/core/Mage/Catalog/Model/Api2/Product/Image/Rest/Customer/V1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Api2/Product/Image/Rest/Guest/V1.php
+++ b/app/code/core/Mage/Catalog/Model/Api2/Product/Image/Rest/Guest/V1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Api2/Product/Image/Rest/Guest/V1.php
+++ b/app/code/core/Mage/Catalog/Model/Api2/Product/Image/Rest/Guest/V1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Api2/Product/Image/Rest/Guest/V1.php
+++ b/app/code/core/Mage/Catalog/Model/Api2/Product/Image/Rest/Guest/V1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Api2/Product/Image/Validator/Image.php
+++ b/app/code/core/Mage/Catalog/Model/Api2/Product/Image/Validator/Image.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Api2/Product/Image/Validator/Image.php
+++ b/app/code/core/Mage/Catalog/Model/Api2/Product/Image/Validator/Image.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Api2/Product/Image/Validator/Image.php
+++ b/app/code/core/Mage/Catalog/Model/Api2/Product/Image/Validator/Image.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Api2/Product/Rest.php
+++ b/app/code/core/Mage/Catalog/Model/Api2/Product/Rest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Api2/Product/Rest.php
+++ b/app/code/core/Mage/Catalog/Model/Api2/Product/Rest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Api2/Product/Rest.php
+++ b/app/code/core/Mage/Catalog/Model/Api2/Product/Rest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Api2/Product/Rest/Admin/V1.php
+++ b/app/code/core/Mage/Catalog/Model/Api2/Product/Rest/Admin/V1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Api2/Product/Rest/Admin/V1.php
+++ b/app/code/core/Mage/Catalog/Model/Api2/Product/Rest/Admin/V1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Api2/Product/Rest/Admin/V1.php
+++ b/app/code/core/Mage/Catalog/Model/Api2/Product/Rest/Admin/V1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Api2/Product/Rest/Customer/V1.php
+++ b/app/code/core/Mage/Catalog/Model/Api2/Product/Rest/Customer/V1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Api2/Product/Rest/Customer/V1.php
+++ b/app/code/core/Mage/Catalog/Model/Api2/Product/Rest/Customer/V1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Api2/Product/Rest/Customer/V1.php
+++ b/app/code/core/Mage/Catalog/Model/Api2/Product/Rest/Customer/V1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Api2/Product/Rest/Guest/V1.php
+++ b/app/code/core/Mage/Catalog/Model/Api2/Product/Rest/Guest/V1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Api2/Product/Rest/Guest/V1.php
+++ b/app/code/core/Mage/Catalog/Model/Api2/Product/Rest/Guest/V1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Api2/Product/Rest/Guest/V1.php
+++ b/app/code/core/Mage/Catalog/Model/Api2/Product/Rest/Guest/V1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Api2/Product/Validator/Product.php
+++ b/app/code/core/Mage/Catalog/Model/Api2/Product/Validator/Product.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Api2/Product/Validator/Product.php
+++ b/app/code/core/Mage/Catalog/Model/Api2/Product/Validator/Product.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Api2/Product/Validator/Product.php
+++ b/app/code/core/Mage/Catalog/Model/Api2/Product/Validator/Product.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Api2/Product/Website.php
+++ b/app/code/core/Mage/Catalog/Model/Api2/Product/Website.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Api2/Product/Website.php
+++ b/app/code/core/Mage/Catalog/Model/Api2/Product/Website.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Api2/Product/Website.php
+++ b/app/code/core/Mage/Catalog/Model/Api2/Product/Website.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Api2/Product/Website/Rest.php
+++ b/app/code/core/Mage/Catalog/Model/Api2/Product/Website/Rest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Api2/Product/Website/Rest.php
+++ b/app/code/core/Mage/Catalog/Model/Api2/Product/Website/Rest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Api2/Product/Website/Rest.php
+++ b/app/code/core/Mage/Catalog/Model/Api2/Product/Website/Rest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Api2/Product/Website/Rest/Admin/V1.php
+++ b/app/code/core/Mage/Catalog/Model/Api2/Product/Website/Rest/Admin/V1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Api2/Product/Website/Rest/Admin/V1.php
+++ b/app/code/core/Mage/Catalog/Model/Api2/Product/Website/Rest/Admin/V1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Api2/Product/Website/Rest/Admin/V1.php
+++ b/app/code/core/Mage/Catalog/Model/Api2/Product/Website/Rest/Admin/V1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Api2/Product/Website/Validator/Admin/Website.php
+++ b/app/code/core/Mage/Catalog/Model/Api2/Product/Website/Validator/Admin/Website.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Api2/Product/Website/Validator/Admin/Website.php
+++ b/app/code/core/Mage/Catalog/Model/Api2/Product/Website/Validator/Admin/Website.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Api2/Product/Website/Validator/Admin/Website.php
+++ b/app/code/core/Mage/Catalog/Model/Api2/Product/Website/Validator/Admin/Website.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Attribute/Backend/Customlayoutupdate.php
+++ b/app/code/core/Mage/Catalog/Model/Attribute/Backend/Customlayoutupdate.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Attribute/Backend/Customlayoutupdate.php
+++ b/app/code/core/Mage/Catalog/Model/Attribute/Backend/Customlayoutupdate.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Attribute/Backend/Customlayoutupdate.php
+++ b/app/code/core/Mage/Catalog/Model/Attribute/Backend/Customlayoutupdate.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Attribute/Backend/Urlkey/Abstract.php
+++ b/app/code/core/Mage/Catalog/Model/Attribute/Backend/Urlkey/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Attribute/Backend/Urlkey/Abstract.php
+++ b/app/code/core/Mage/Catalog/Model/Attribute/Backend/Urlkey/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Attribute/Backend/Urlkey/Abstract.php
+++ b/app/code/core/Mage/Catalog/Model/Attribute/Backend/Urlkey/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Category.php
+++ b/app/code/core/Mage/Catalog/Model/Category.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Category.php
+++ b/app/code/core/Mage/Catalog/Model/Category.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Category.php
+++ b/app/code/core/Mage/Catalog/Model/Category.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Category/Api.php
+++ b/app/code/core/Mage/Catalog/Model/Category/Api.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Category/Api.php
+++ b/app/code/core/Mage/Catalog/Model/Category/Api.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Category/Api.php
+++ b/app/code/core/Mage/Catalog/Model/Category/Api.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Category/Api/V2.php
+++ b/app/code/core/Mage/Catalog/Model/Category/Api/V2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Category/Api/V2.php
+++ b/app/code/core/Mage/Catalog/Model/Category/Api/V2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Category/Api/V2.php
+++ b/app/code/core/Mage/Catalog/Model/Category/Api/V2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Category/Attribute/Api.php
+++ b/app/code/core/Mage/Catalog/Model/Category/Attribute/Api.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Category/Attribute/Api.php
+++ b/app/code/core/Mage/Catalog/Model/Category/Attribute/Api.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Category/Attribute/Api.php
+++ b/app/code/core/Mage/Catalog/Model/Category/Attribute/Api.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Category/Attribute/Api/V2.php
+++ b/app/code/core/Mage/Catalog/Model/Category/Attribute/Api/V2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Category/Attribute/Api/V2.php
+++ b/app/code/core/Mage/Catalog/Model/Category/Attribute/Api/V2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Category/Attribute/Api/V2.php
+++ b/app/code/core/Mage/Catalog/Model/Category/Attribute/Api/V2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Category/Attribute/Backend/Image.php
+++ b/app/code/core/Mage/Catalog/Model/Category/Attribute/Backend/Image.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Category/Attribute/Backend/Image.php
+++ b/app/code/core/Mage/Catalog/Model/Category/Attribute/Backend/Image.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Category/Attribute/Backend/Image.php
+++ b/app/code/core/Mage/Catalog/Model/Category/Attribute/Backend/Image.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Category/Attribute/Backend/Sortby.php
+++ b/app/code/core/Mage/Catalog/Model/Category/Attribute/Backend/Sortby.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Category/Attribute/Backend/Sortby.php
+++ b/app/code/core/Mage/Catalog/Model/Category/Attribute/Backend/Sortby.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Category/Attribute/Backend/Sortby.php
+++ b/app/code/core/Mage/Catalog/Model/Category/Attribute/Backend/Sortby.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Category/Attribute/Backend/Urlkey.php
+++ b/app/code/core/Mage/Catalog/Model/Category/Attribute/Backend/Urlkey.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Category/Attribute/Backend/Urlkey.php
+++ b/app/code/core/Mage/Catalog/Model/Category/Attribute/Backend/Urlkey.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Category/Attribute/Backend/Urlkey.php
+++ b/app/code/core/Mage/Catalog/Model/Category/Attribute/Backend/Urlkey.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Category/Attribute/Source/Layout.php
+++ b/app/code/core/Mage/Catalog/Model/Category/Attribute/Source/Layout.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Category/Attribute/Source/Layout.php
+++ b/app/code/core/Mage/Catalog/Model/Category/Attribute/Source/Layout.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Category/Attribute/Source/Layout.php
+++ b/app/code/core/Mage/Catalog/Model/Category/Attribute/Source/Layout.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Category/Attribute/Source/Mode.php
+++ b/app/code/core/Mage/Catalog/Model/Category/Attribute/Source/Mode.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Category/Attribute/Source/Mode.php
+++ b/app/code/core/Mage/Catalog/Model/Category/Attribute/Source/Mode.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Category/Attribute/Source/Mode.php
+++ b/app/code/core/Mage/Catalog/Model/Category/Attribute/Source/Mode.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Category/Attribute/Source/Page.php
+++ b/app/code/core/Mage/Catalog/Model/Category/Attribute/Source/Page.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Category/Attribute/Source/Page.php
+++ b/app/code/core/Mage/Catalog/Model/Category/Attribute/Source/Page.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Category/Attribute/Source/Page.php
+++ b/app/code/core/Mage/Catalog/Model/Category/Attribute/Source/Page.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Category/Attribute/Source/Sortby.php
+++ b/app/code/core/Mage/Catalog/Model/Category/Attribute/Source/Sortby.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Category/Attribute/Source/Sortby.php
+++ b/app/code/core/Mage/Catalog/Model/Category/Attribute/Source/Sortby.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Category/Attribute/Source/Sortby.php
+++ b/app/code/core/Mage/Catalog/Model/Category/Attribute/Source/Sortby.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Category/Indexer/Flat.php
+++ b/app/code/core/Mage/Catalog/Model/Category/Indexer/Flat.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Category/Indexer/Flat.php
+++ b/app/code/core/Mage/Catalog/Model/Category/Indexer/Flat.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Category/Indexer/Flat.php
+++ b/app/code/core/Mage/Catalog/Model/Category/Indexer/Flat.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Category/Indexer/Product.php
+++ b/app/code/core/Mage/Catalog/Model/Category/Indexer/Product.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Category/Indexer/Product.php
+++ b/app/code/core/Mage/Catalog/Model/Category/Indexer/Product.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Category/Indexer/Product.php
+++ b/app/code/core/Mage/Catalog/Model/Category/Indexer/Product.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Category/Url.php
+++ b/app/code/core/Mage/Catalog/Model/Category/Url.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Category/Url.php
+++ b/app/code/core/Mage/Catalog/Model/Category/Url.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Category/Url.php
+++ b/app/code/core/Mage/Catalog/Model/Category/Url.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Config.php
+++ b/app/code/core/Mage/Catalog/Model/Config.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Config.php
+++ b/app/code/core/Mage/Catalog/Model/Config.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Config.php
+++ b/app/code/core/Mage/Catalog/Model/Config.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Convert.php
+++ b/app/code/core/Mage/Catalog/Model/Convert.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Convert.php
+++ b/app/code/core/Mage/Catalog/Model/Convert.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Convert.php
+++ b/app/code/core/Mage/Catalog/Model/Convert.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Convert/Adapter/Catalog.php
+++ b/app/code/core/Mage/Catalog/Model/Convert/Adapter/Catalog.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Convert/Adapter/Catalog.php
+++ b/app/code/core/Mage/Catalog/Model/Convert/Adapter/Catalog.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Convert/Adapter/Catalog.php
+++ b/app/code/core/Mage/Catalog/Model/Convert/Adapter/Catalog.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Convert/Adapter/Product.php
+++ b/app/code/core/Mage/Catalog/Model/Convert/Adapter/Product.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Convert/Adapter/Product.php
+++ b/app/code/core/Mage/Catalog/Model/Convert/Adapter/Product.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Convert/Adapter/Product.php
+++ b/app/code/core/Mage/Catalog/Model/Convert/Adapter/Product.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Convert/Parser/Product.php
+++ b/app/code/core/Mage/Catalog/Model/Convert/Parser/Product.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Convert/Parser/Product.php
+++ b/app/code/core/Mage/Catalog/Model/Convert/Parser/Product.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Convert/Parser/Product.php
+++ b/app/code/core/Mage/Catalog/Model/Convert/Parser/Product.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Design.php
+++ b/app/code/core/Mage/Catalog/Model/Design.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Design.php
+++ b/app/code/core/Mage/Catalog/Model/Design.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Design.php
+++ b/app/code/core/Mage/Catalog/Model/Design.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Entity/Attribute.php
+++ b/app/code/core/Mage/Catalog/Model/Entity/Attribute.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Entity/Attribute.php
+++ b/app/code/core/Mage/Catalog/Model/Entity/Attribute.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Entity/Attribute.php
+++ b/app/code/core/Mage/Catalog/Model/Entity/Attribute.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Entity/Product/Attribute/Design/Options/Container.php
+++ b/app/code/core/Mage/Catalog/Model/Entity/Product/Attribute/Design/Options/Container.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Entity/Product/Attribute/Design/Options/Container.php
+++ b/app/code/core/Mage/Catalog/Model/Entity/Product/Attribute/Design/Options/Container.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Entity/Product/Attribute/Design/Options/Container.php
+++ b/app/code/core/Mage/Catalog/Model/Entity/Product/Attribute/Design/Options/Container.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Entity/Product/Attribute/Frontend/Image.php
+++ b/app/code/core/Mage/Catalog/Model/Entity/Product/Attribute/Frontend/Image.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Entity/Product/Attribute/Frontend/Image.php
+++ b/app/code/core/Mage/Catalog/Model/Entity/Product/Attribute/Frontend/Image.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Entity/Product/Attribute/Frontend/Image.php
+++ b/app/code/core/Mage/Catalog/Model/Entity/Product/Attribute/Frontend/Image.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Factory.php
+++ b/app/code/core/Mage/Catalog/Model/Factory.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Factory.php
+++ b/app/code/core/Mage/Catalog/Model/Factory.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Factory.php
+++ b/app/code/core/Mage/Catalog/Model/Factory.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Index.php
+++ b/app/code/core/Mage/Catalog/Model/Index.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Index.php
+++ b/app/code/core/Mage/Catalog/Model/Index.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Index.php
+++ b/app/code/core/Mage/Catalog/Model/Index.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Indexer/Url.php
+++ b/app/code/core/Mage/Catalog/Model/Indexer/Url.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Indexer/Url.php
+++ b/app/code/core/Mage/Catalog/Model/Indexer/Url.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Indexer/Url.php
+++ b/app/code/core/Mage/Catalog/Model/Indexer/Url.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Layer.php
+++ b/app/code/core/Mage/Catalog/Model/Layer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Layer.php
+++ b/app/code/core/Mage/Catalog/Model/Layer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Layer.php
+++ b/app/code/core/Mage/Catalog/Model/Layer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Layer/Filter/Abstract.php
+++ b/app/code/core/Mage/Catalog/Model/Layer/Filter/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Layer/Filter/Abstract.php
+++ b/app/code/core/Mage/Catalog/Model/Layer/Filter/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Layer/Filter/Abstract.php
+++ b/app/code/core/Mage/Catalog/Model/Layer/Filter/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Layer/Filter/Attribute.php
+++ b/app/code/core/Mage/Catalog/Model/Layer/Filter/Attribute.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Layer/Filter/Attribute.php
+++ b/app/code/core/Mage/Catalog/Model/Layer/Filter/Attribute.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Layer/Filter/Attribute.php
+++ b/app/code/core/Mage/Catalog/Model/Layer/Filter/Attribute.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Layer/Filter/Category.php
+++ b/app/code/core/Mage/Catalog/Model/Layer/Filter/Category.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Layer/Filter/Category.php
+++ b/app/code/core/Mage/Catalog/Model/Layer/Filter/Category.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Layer/Filter/Category.php
+++ b/app/code/core/Mage/Catalog/Model/Layer/Filter/Category.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Layer/Filter/Decimal.php
+++ b/app/code/core/Mage/Catalog/Model/Layer/Filter/Decimal.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Layer/Filter/Decimal.php
+++ b/app/code/core/Mage/Catalog/Model/Layer/Filter/Decimal.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Layer/Filter/Decimal.php
+++ b/app/code/core/Mage/Catalog/Model/Layer/Filter/Decimal.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Layer/Filter/Item.php
+++ b/app/code/core/Mage/Catalog/Model/Layer/Filter/Item.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Layer/Filter/Item.php
+++ b/app/code/core/Mage/Catalog/Model/Layer/Filter/Item.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Layer/Filter/Item.php
+++ b/app/code/core/Mage/Catalog/Model/Layer/Filter/Item.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Layer/Filter/Price.php
+++ b/app/code/core/Mage/Catalog/Model/Layer/Filter/Price.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Layer/Filter/Price.php
+++ b/app/code/core/Mage/Catalog/Model/Layer/Filter/Price.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Layer/Filter/Price.php
+++ b/app/code/core/Mage/Catalog/Model/Layer/Filter/Price.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Layer/Filter/Price/Algorithm.php
+++ b/app/code/core/Mage/Catalog/Model/Layer/Filter/Price/Algorithm.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Layer/Filter/Price/Algorithm.php
+++ b/app/code/core/Mage/Catalog/Model/Layer/Filter/Price/Algorithm.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Layer/Filter/Price/Algorithm.php
+++ b/app/code/core/Mage/Catalog/Model/Layer/Filter/Price/Algorithm.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Layer/State.php
+++ b/app/code/core/Mage/Catalog/Model/Layer/State.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Layer/State.php
+++ b/app/code/core/Mage/Catalog/Model/Layer/State.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Layer/State.php
+++ b/app/code/core/Mage/Catalog/Model/Layer/State.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Observer.php
+++ b/app/code/core/Mage/Catalog/Model/Observer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Observer.php
+++ b/app/code/core/Mage/Catalog/Model/Observer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Observer.php
+++ b/app/code/core/Mage/Catalog/Model/Observer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product.php
+++ b/app/code/core/Mage/Catalog/Model/Product.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product.php
+++ b/app/code/core/Mage/Catalog/Model/Product.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Product.php
+++ b/app/code/core/Mage/Catalog/Model/Product.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Action.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Action.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Action.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Action.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Product/Action.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Action.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Api.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Api.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Api.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Api.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Product/Api.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Api.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Api/V2.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Api/V2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Api/V2.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Api/V2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Product/Api/V2.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Api/V2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Api.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Api.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Api.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Api.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Api.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Api.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Api/V2.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Api/V2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Api/V2.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Api/V2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Api/V2.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Api/V2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Backend/Boolean.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Backend/Boolean.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Backend/Boolean.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Backend/Boolean.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Backend/Boolean.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Backend/Boolean.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Backend/Groupprice.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Backend/Groupprice.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Backend/Groupprice.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Backend/Groupprice.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Backend/Groupprice.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Backend/Groupprice.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Backend/Groupprice/Abstract.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Backend/Groupprice/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Backend/Groupprice/Abstract.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Backend/Groupprice/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Backend/Groupprice/Abstract.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Backend/Groupprice/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Backend/Media.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Backend/Media.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Backend/Media.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Backend/Media.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Backend/Media.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Backend/Media.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Backend/Msrp.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Backend/Msrp.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Backend/Msrp.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Backend/Msrp.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Backend/Msrp.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Backend/Msrp.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Backend/Price.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Backend/Price.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Backend/Price.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Backend/Price.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Backend/Price.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Backend/Price.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Backend/Recurring.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Backend/Recurring.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Backend/Recurring.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Backend/Recurring.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Backend/Recurring.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Backend/Recurring.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Backend/Sku.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Backend/Sku.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Backend/Sku.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Backend/Sku.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Backend/Sku.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Backend/Sku.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Backend/Startdate.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Backend/Startdate.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Backend/Startdate.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Backend/Startdate.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Backend/Startdate.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Backend/Startdate.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Backend/Startdate/Specialprice.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Backend/Startdate/Specialprice.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Backend/Startdate/Specialprice.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Backend/Startdate/Specialprice.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Backend/Startdate/Specialprice.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Backend/Startdate/Specialprice.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Backend/Tierprice.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Backend/Tierprice.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Backend/Tierprice.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Backend/Tierprice.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Backend/Tierprice.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Backend/Tierprice.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Backend/Urlkey.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Backend/Urlkey.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Backend/Urlkey.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Backend/Urlkey.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Backend/Urlkey.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Backend/Urlkey.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Frontend/Image.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Frontend/Image.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Frontend/Image.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Frontend/Image.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Frontend/Image.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Frontend/Image.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Group.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Group.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Group.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Group.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Group.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Group.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Media/Api.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Media/Api.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Media/Api.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Media/Api.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Media/Api.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Media/Api.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Media/Api/V2.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Media/Api/V2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Media/Api/V2.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Media/Api/V2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Media/Api/V2.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Media/Api/V2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Set/Api.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Set/Api.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Set/Api.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Set/Api.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Set/Api.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Set/Api.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Set/Api/V2.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Set/Api/V2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Set/Api/V2.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Set/Api/V2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Set/Api/V2.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Set/Api/V2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Source/Boolean.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Source/Boolean.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Source/Boolean.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Source/Boolean.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Source/Boolean.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Source/Boolean.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Source/Countryofmanufacture.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Source/Countryofmanufacture.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Source/Countryofmanufacture.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Source/Countryofmanufacture.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Source/Countryofmanufacture.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Source/Countryofmanufacture.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Source/Inputtype.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Source/Inputtype.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Source/Inputtype.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Source/Inputtype.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Source/Inputtype.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Source/Inputtype.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Source/Layout.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Source/Layout.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Source/Layout.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Source/Layout.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Source/Layout.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Source/Layout.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Source/Msrp/Type.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Source/Msrp/Type.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Source/Msrp/Type.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Source/Msrp/Type.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Source/Msrp/Type.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Source/Msrp/Type.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Source/Msrp/Type/Enabled.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Source/Msrp/Type/Enabled.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Source/Msrp/Type/Enabled.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Source/Msrp/Type/Enabled.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Source/Msrp/Type/Enabled.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Source/Msrp/Type/Enabled.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Source/Msrp/Type/Price.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Source/Msrp/Type/Price.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Source/Msrp/Type/Price.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Source/Msrp/Type/Price.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Source/Msrp/Type/Price.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Source/Msrp/Type/Price.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Tierprice/Api.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Tierprice/Api.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Tierprice/Api.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Tierprice/Api.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Tierprice/Api.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Tierprice/Api.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Tierprice/Api/V2.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Tierprice/Api/V2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Tierprice/Api/V2.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Tierprice/Api/V2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Tierprice/Api/V2.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Tierprice/Api/V2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Compare/Item.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Compare/Item.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Compare/Item.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Compare/Item.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Product/Compare/Item.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Compare/Item.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Compare/List.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Compare/List.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Compare/List.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Compare/List.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Product/Compare/List.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Compare/List.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Condition.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Condition.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Condition.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Condition.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Product/Condition.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Condition.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Condition/Interface.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Condition/Interface.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Condition/Interface.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Condition/Interface.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Product/Condition/Interface.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Condition/Interface.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Configuration/Item/Interface.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Configuration/Item/Interface.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Configuration/Item/Interface.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Configuration/Item/Interface.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Product/Configuration/Item/Interface.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Configuration/Item/Interface.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Configuration/Item/Option.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Configuration/Item/Option.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Configuration/Item/Option.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Configuration/Item/Option.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Product/Configuration/Item/Option.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Configuration/Item/Option.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Configuration/Item/Option/Interface.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Configuration/Item/Option/Interface.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Configuration/Item/Option/Interface.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Configuration/Item/Option/Interface.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Product/Configuration/Item/Option/Interface.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Configuration/Item/Option/Interface.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Flat/Flag.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Flat/Flag.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Flat/Flag.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Flat/Flag.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Product/Flat/Flag.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Flat/Flag.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Flat/Indexer.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Flat/Indexer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Flat/Indexer.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Flat/Indexer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Product/Flat/Indexer.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Flat/Indexer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Flat/Observer.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Flat/Observer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Flat/Observer.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Flat/Observer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Product/Flat/Observer.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Flat/Observer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Image.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Image.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Image.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Image.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Product/Image.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Image.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Indexer/Eav.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Indexer/Eav.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Indexer/Eav.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Indexer/Eav.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Product/Indexer/Eav.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Indexer/Eav.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Indexer/Flat.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Indexer/Flat.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Indexer/Flat.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Indexer/Flat.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Product/Indexer/Flat.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Indexer/Flat.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Indexer/Price.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Indexer/Price.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Indexer/Price.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Indexer/Price.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Product/Indexer/Price.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Indexer/Price.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Link.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Link.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Link.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Link.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Product/Link.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Link.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Link/Api.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Link/Api.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Link/Api.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Link/Api.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Product/Link/Api.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Link/Api.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Link/Api/V2.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Link/Api/V2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Link/Api/V2.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Link/Api/V2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Product/Link/Api/V2.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Link/Api/V2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Media/Config.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Media/Config.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Media/Config.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Media/Config.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Product/Media/Config.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Media/Config.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Option.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Option.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Option.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Option.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Product/Option.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Option.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Option/Api.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Option/Api.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Option/Api.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Option/Api.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Product/Option/Api.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Option/Api.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Option/Api/V2.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Option/Api/V2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Option/Api/V2.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Option/Api/V2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Product/Option/Api/V2.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Option/Api/V2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Option/Observer.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Option/Observer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Option/Observer.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Option/Observer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Product/Option/Observer.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Option/Observer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Option/Type/Date.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Option/Type/Date.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Option/Type/Date.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Option/Type/Date.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Product/Option/Type/Date.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Option/Type/Date.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Option/Type/Default.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Option/Type/Default.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Option/Type/Default.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Option/Type/Default.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Product/Option/Type/Default.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Option/Type/Default.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Option/Type/File.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Option/Type/File.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Option/Type/File.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Option/Type/File.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Product/Option/Type/File.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Option/Type/File.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Option/Type/Select.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Option/Type/Select.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Option/Type/Select.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Option/Type/Select.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Product/Option/Type/Select.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Option/Type/Select.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Option/Type/Text.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Option/Type/Text.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Option/Type/Text.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Option/Type/Text.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Product/Option/Type/Text.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Option/Type/Text.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Option/Value.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Option/Value.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Option/Value.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Option/Value.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Product/Option/Value.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Option/Value.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Option/Value/Api.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Option/Value/Api.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Option/Value/Api.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Option/Value/Api.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Product/Option/Value/Api.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Option/Value/Api.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Option/Value/Api/V2.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Option/Value/Api/V2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Option/Value/Api/V2.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Option/Value/Api/V2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Product/Option/Value/Api/V2.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Option/Value/Api/V2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Status.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Status.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Status.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Status.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Product/Status.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Status.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Type.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Type.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Type.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Type.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Product/Type.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Type.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Type/Abstract.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Type/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Type/Abstract.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Type/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Product/Type/Abstract.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Type/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Type/Api.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Type/Api.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Type/Api.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Type/Api.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Product/Type/Api.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Type/Api.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Type/Api/V2.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Type/Api/V2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Type/Api/V2.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Type/Api/V2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Product/Type/Api/V2.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Type/Api/V2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Type/Configurable.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Type/Configurable.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Type/Configurable.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Type/Configurable.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Product/Type/Configurable.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Type/Configurable.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Type/Configurable/Attribute.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Type/Configurable/Attribute.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Type/Configurable/Attribute.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Type/Configurable/Attribute.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Product/Type/Configurable/Attribute.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Type/Configurable/Attribute.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Type/Configurable/Price.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Type/Configurable/Price.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Type/Configurable/Price.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Type/Configurable/Price.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Product/Type/Configurable/Price.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Type/Configurable/Price.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Type/Grouped.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Type/Grouped.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Type/Grouped.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Type/Grouped.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Product/Type/Grouped.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Type/Grouped.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Type/Grouped/Price.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Type/Grouped/Price.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Type/Grouped/Price.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Type/Grouped/Price.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Product/Type/Grouped/Price.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Type/Grouped/Price.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Type/Price.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Type/Price.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Type/Price.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Type/Price.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Product/Type/Price.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Type/Price.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Type/Simple.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Type/Simple.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Type/Simple.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Type/Simple.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Product/Type/Simple.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Type/Simple.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Type/Virtual.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Type/Virtual.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Type/Virtual.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Type/Virtual.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Product/Type/Virtual.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Type/Virtual.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Url.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Url.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Url.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Url.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Product/Url.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Url.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Visibility.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Visibility.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Visibility.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Visibility.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Product/Visibility.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Visibility.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Website.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Website.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Product/Website.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Website.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Product/Website.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Website.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Abstract.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Abstract.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Abstract.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Attribute.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Attribute.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Attribute.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Attribute.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Attribute.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Attribute.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Category.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Category.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Category.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Category.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Category.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Category.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Category/Attribute/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Category/Attribute/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Category/Attribute/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Category/Attribute/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Category/Attribute/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Category/Attribute/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Category/Attribute/Frontend/Image.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Category/Attribute/Frontend/Image.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Category/Attribute/Frontend/Image.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Category/Attribute/Frontend/Image.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Category/Attribute/Frontend/Image.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Category/Attribute/Frontend/Image.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Category/Attribute/Source/Layout.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Category/Attribute/Source/Layout.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Category/Attribute/Source/Layout.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Category/Attribute/Source/Layout.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Category/Attribute/Source/Layout.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Category/Attribute/Source/Layout.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Category/Attribute/Source/Mode.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Category/Attribute/Source/Mode.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Category/Attribute/Source/Mode.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Category/Attribute/Source/Mode.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Category/Attribute/Source/Mode.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Category/Attribute/Source/Mode.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Category/Attribute/Source/Page.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Category/Attribute/Source/Page.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Category/Attribute/Source/Page.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Category/Attribute/Source/Page.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Category/Attribute/Source/Page.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Category/Attribute/Source/Page.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Category/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Category/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Category/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Category/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Category/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Category/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Category/Flat.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Category/Flat.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Category/Flat.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Category/Flat.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Category/Flat.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Category/Flat.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Category/Flat/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Category/Flat/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Category/Flat/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Category/Flat/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Category/Flat/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Category/Flat/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Category/Indexer/Product.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Category/Indexer/Product.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Category/Indexer/Product.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Category/Indexer/Product.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Category/Indexer/Product.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Category/Indexer/Product.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Category/Tree.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Category/Tree.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Category/Tree.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Category/Tree.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Category/Tree.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Category/Tree.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Collection/Abstract.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Collection/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Collection/Abstract.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Collection/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Collection/Abstract.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Collection/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Config.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Config.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Config.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Config.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Config.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Config.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Attribute.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Attribute.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Attribute.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Attribute.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Attribute.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Attribute.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Abstract.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Abstract.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Abstract.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Attribute.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Attribute.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Attribute.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Attribute.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Attribute.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Attribute.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Category.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Category.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Category.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Category.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Category.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Category.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Category/Attribute/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Category/Attribute/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Category/Attribute/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Category/Attribute/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Category/Attribute/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Category/Attribute/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Category/Attribute/Frontend/Image.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Category/Attribute/Frontend/Image.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Category/Attribute/Frontend/Image.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Category/Attribute/Frontend/Image.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Category/Attribute/Frontend/Image.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Category/Attribute/Frontend/Image.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Category/Attribute/Source/Layout.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Category/Attribute/Source/Layout.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Category/Attribute/Source/Layout.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Category/Attribute/Source/Layout.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Category/Attribute/Source/Layout.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Category/Attribute/Source/Layout.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Category/Attribute/Source/Mode.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Category/Attribute/Source/Mode.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Category/Attribute/Source/Mode.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Category/Attribute/Source/Mode.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Category/Attribute/Source/Mode.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Category/Attribute/Source/Mode.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Category/Attribute/Source/Page.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Category/Attribute/Source/Page.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Category/Attribute/Source/Page.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Category/Attribute/Source/Page.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Category/Attribute/Source/Page.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Category/Attribute/Source/Page.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Category/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Category/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Category/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Category/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Category/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Category/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Category/Flat.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Category/Flat.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Category/Flat.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Category/Flat.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Category/Flat.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Category/Flat.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Category/Flat/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Category/Flat/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Category/Flat/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Category/Flat/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Category/Flat/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Category/Flat/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Category/Indexer/Product.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Category/Indexer/Product.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Category/Indexer/Product.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Category/Indexer/Product.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Category/Indexer/Product.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Category/Indexer/Product.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Category/Tree.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Category/Tree.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Category/Tree.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Category/Tree.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Category/Tree.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Category/Tree.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Collection/Abstract.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Collection/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Collection/Abstract.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Collection/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Collection/Abstract.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Collection/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Config.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Config.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Config.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Config.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Config.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Config.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Layer/Filter/Attribute.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Layer/Filter/Attribute.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Layer/Filter/Attribute.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Layer/Filter/Attribute.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Layer/Filter/Attribute.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Layer/Filter/Attribute.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Layer/Filter/Decimal.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Layer/Filter/Decimal.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Layer/Filter/Decimal.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Layer/Filter/Decimal.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Layer/Filter/Decimal.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Layer/Filter/Decimal.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Layer/Filter/Price.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Layer/Filter/Price.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Layer/Filter/Price.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Layer/Filter/Price.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Layer/Filter/Price.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Layer/Filter/Price.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Action.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Action.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Action.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Action.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Action.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Action.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Attribute/Backend/Image.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Attribute/Backend/Image.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Attribute/Backend/Image.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Attribute/Backend/Image.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Attribute/Backend/Image.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Attribute/Backend/Image.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Attribute/Backend/Media.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Attribute/Backend/Media.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Attribute/Backend/Media.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Attribute/Backend/Media.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Attribute/Backend/Media.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Attribute/Backend/Media.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Attribute/Backend/Tierprice.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Attribute/Backend/Tierprice.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Attribute/Backend/Tierprice.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Attribute/Backend/Tierprice.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Attribute/Backend/Tierprice.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Attribute/Backend/Tierprice.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Attribute/Backend/Urlkey.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Attribute/Backend/Urlkey.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Attribute/Backend/Urlkey.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Attribute/Backend/Urlkey.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Attribute/Backend/Urlkey.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Attribute/Backend/Urlkey.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Attribute/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Attribute/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Attribute/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Attribute/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Attribute/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Attribute/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Attribute/Frontend/Image.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Attribute/Frontend/Image.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Attribute/Frontend/Image.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Attribute/Frontend/Image.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Attribute/Frontend/Image.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Attribute/Frontend/Image.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Attribute/Frontend/Tierprice.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Attribute/Frontend/Tierprice.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Attribute/Frontend/Tierprice.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Attribute/Frontend/Tierprice.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Attribute/Frontend/Tierprice.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Attribute/Frontend/Tierprice.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Compare/Item.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Compare/Item.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Compare/Item.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Compare/Item.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Compare/Item.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Compare/Item.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Compare/Item/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Compare/Item/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Compare/Item/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Compare/Item/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Compare/Item/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Compare/Item/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Flat.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Flat.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Flat.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Flat.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Flat.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Flat.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Flat/Indexer.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Flat/Indexer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Flat/Indexer.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Flat/Indexer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Flat/Indexer.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Flat/Indexer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Indexer/Abstract.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Indexer/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Indexer/Abstract.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Indexer/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Indexer/Abstract.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Indexer/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Indexer/Eav.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Indexer/Eav.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Indexer/Eav.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Indexer/Eav.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Indexer/Eav.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Indexer/Eav.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Indexer/Eav/Abstract.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Indexer/Eav/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Indexer/Eav/Abstract.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Indexer/Eav/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Indexer/Eav/Abstract.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Indexer/Eav/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Indexer/Eav/Decimal.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Indexer/Eav/Decimal.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Indexer/Eav/Decimal.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Indexer/Eav/Decimal.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Indexer/Eav/Decimal.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Indexer/Eav/Decimal.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Indexer/Eav/Source.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Indexer/Eav/Source.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Indexer/Eav/Source.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Indexer/Eav/Source.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Indexer/Eav/Source.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Indexer/Eav/Source.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Indexer/Price.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Indexer/Price.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Indexer/Price.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Indexer/Price.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Indexer/Price.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Indexer/Price.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Indexer/Price/Configurable.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Indexer/Price/Configurable.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Indexer/Price/Configurable.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Indexer/Price/Configurable.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Indexer/Price/Configurable.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Indexer/Price/Configurable.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Indexer/Price/Default.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Indexer/Price/Default.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Indexer/Price/Default.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Indexer/Price/Default.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Indexer/Price/Default.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Indexer/Price/Default.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Indexer/Price/Grouped.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Indexer/Price/Grouped.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Indexer/Price/Grouped.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Indexer/Price/Grouped.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Indexer/Price/Grouped.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Indexer/Price/Grouped.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Indexer/Price/Interface.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Indexer/Price/Interface.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Indexer/Price/Interface.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Indexer/Price/Interface.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Indexer/Price/Interface.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Indexer/Price/Interface.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Link.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Link.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Link.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Link.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Link.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Link.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Link/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Link/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Link/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Link/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Link/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Link/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Link/Product/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Link/Product/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Link/Product/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Link/Product/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Link/Product/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Link/Product/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Option.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Option.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Option.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Option.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Option.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Option.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Option/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Option/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Option/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Option/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Option/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Option/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Option/Value.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Option/Value.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Option/Value.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Option/Value.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Option/Value.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Option/Value.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Option/Value/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Option/Value/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Option/Value/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Option/Value/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Option/Value/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Option/Value/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Relation.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Relation.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Relation.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Relation.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Relation.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Relation.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Status.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Status.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Status.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Status.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Status.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Status.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Type/Configurable.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Type/Configurable.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Type/Configurable.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Type/Configurable.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Type/Configurable.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Type/Configurable.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Type/Configurable/Attribute.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Type/Configurable/Attribute.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Type/Configurable/Attribute.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Type/Configurable/Attribute.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Type/Configurable/Attribute.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Type/Configurable/Attribute.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Type/Configurable/Attribute/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Type/Configurable/Attribute/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Type/Configurable/Attribute/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Type/Configurable/Attribute/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Type/Configurable/Attribute/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Type/Configurable/Attribute/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Type/Configurable/Product/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Type/Configurable/Product/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Type/Configurable/Product/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Type/Configurable/Product/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Type/Configurable/Product/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Type/Configurable/Product/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Website.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Website.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Website.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Website.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Website.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Product/Website.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Sendfriend.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Sendfriend.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Sendfriend.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Sendfriend.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Sendfriend.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Sendfriend.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Sendfriend/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Sendfriend/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Sendfriend/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Sendfriend/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Sendfriend/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Sendfriend/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Setup.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Setup.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Setup.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Setup.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Setup.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Setup.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Url.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Url.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Url.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Url.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Url.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Mysql4/Url.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Helper/Mysql4.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Helper/Mysql4.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Helper/Mysql4.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Helper/Mysql4.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Helper/Mysql4.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Helper/Mysql4.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Layer/Filter/Attribute.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Layer/Filter/Attribute.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Layer/Filter/Attribute.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Layer/Filter/Attribute.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Layer/Filter/Attribute.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Layer/Filter/Attribute.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Layer/Filter/Decimal.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Layer/Filter/Decimal.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Layer/Filter/Decimal.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Layer/Filter/Decimal.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Layer/Filter/Decimal.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Layer/Filter/Decimal.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Layer/Filter/Price.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Layer/Filter/Price.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Layer/Filter/Price.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Layer/Filter/Price.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Layer/Filter/Price.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Layer/Filter/Price.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Product.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Product.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Product.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Action.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Action.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Action.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Action.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Action.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Action.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Attribute/Backend/Groupprice.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Attribute/Backend/Groupprice.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Attribute/Backend/Groupprice.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Attribute/Backend/Groupprice.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Attribute/Backend/Groupprice.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Attribute/Backend/Groupprice.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Attribute/Backend/Groupprice/Abstract.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Attribute/Backend/Groupprice/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Attribute/Backend/Groupprice/Abstract.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Attribute/Backend/Groupprice/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Attribute/Backend/Groupprice/Abstract.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Attribute/Backend/Groupprice/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Attribute/Backend/Image.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Attribute/Backend/Image.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Attribute/Backend/Image.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Attribute/Backend/Image.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Attribute/Backend/Image.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Attribute/Backend/Image.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Attribute/Backend/Media.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Attribute/Backend/Media.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Attribute/Backend/Media.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Attribute/Backend/Media.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Attribute/Backend/Media.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Attribute/Backend/Media.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Attribute/Backend/Tierprice.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Attribute/Backend/Tierprice.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Attribute/Backend/Tierprice.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Attribute/Backend/Tierprice.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Attribute/Backend/Tierprice.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Attribute/Backend/Tierprice.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Attribute/Backend/Urlkey.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Attribute/Backend/Urlkey.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Attribute/Backend/Urlkey.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Attribute/Backend/Urlkey.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Attribute/Backend/Urlkey.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Attribute/Backend/Urlkey.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Attribute/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Attribute/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Attribute/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Attribute/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Attribute/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Attribute/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Attribute/Frontend/Image.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Attribute/Frontend/Image.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Attribute/Frontend/Image.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Attribute/Frontend/Image.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Attribute/Frontend/Image.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Attribute/Frontend/Image.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Attribute/Frontend/Tierprice.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Attribute/Frontend/Tierprice.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Attribute/Frontend/Tierprice.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Attribute/Frontend/Tierprice.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Attribute/Frontend/Tierprice.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Attribute/Frontend/Tierprice.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Compare/Item.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Compare/Item.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Compare/Item.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Compare/Item.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Compare/Item.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Compare/Item.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Compare/Item/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Compare/Item/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Compare/Item/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Compare/Item/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Compare/Item/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Compare/Item/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Flat.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Flat.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Flat.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Flat.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Flat.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Flat.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Flat/Indexer.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Flat/Indexer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Flat/Indexer.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Flat/Indexer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Flat/Indexer.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Flat/Indexer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Indexer/Abstract.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Indexer/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Indexer/Abstract.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Indexer/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Indexer/Abstract.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Indexer/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Indexer/Eav.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Indexer/Eav.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Indexer/Eav.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Indexer/Eav.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Indexer/Eav.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Indexer/Eav.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Indexer/Eav/Abstract.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Indexer/Eav/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Indexer/Eav/Abstract.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Indexer/Eav/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Indexer/Eav/Abstract.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Indexer/Eav/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Indexer/Eav/Decimal.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Indexer/Eav/Decimal.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Indexer/Eav/Decimal.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Indexer/Eav/Decimal.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Indexer/Eav/Decimal.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Indexer/Eav/Decimal.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Indexer/Eav/Source.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Indexer/Eav/Source.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Indexer/Eav/Source.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Indexer/Eav/Source.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Indexer/Eav/Source.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Indexer/Eav/Source.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Indexer/Price.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Indexer/Price.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Indexer/Price.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Indexer/Price.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Indexer/Price.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Indexer/Price.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Indexer/Price/Configurable.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Indexer/Price/Configurable.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Indexer/Price/Configurable.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Indexer/Price/Configurable.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Indexer/Price/Configurable.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Indexer/Price/Configurable.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Indexer/Price/Default.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Indexer/Price/Default.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Indexer/Price/Default.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Indexer/Price/Default.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Indexer/Price/Default.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Indexer/Price/Default.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Indexer/Price/Grouped.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Indexer/Price/Grouped.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Indexer/Price/Grouped.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Indexer/Price/Grouped.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Indexer/Price/Grouped.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Indexer/Price/Grouped.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Indexer/Price/Interface.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Indexer/Price/Interface.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Indexer/Price/Interface.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Indexer/Price/Interface.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Indexer/Price/Interface.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Indexer/Price/Interface.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Link.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Link.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Link.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Link.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Link.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Link.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Link/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Link/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Link/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Link/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Link/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Link/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Link/Product/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Link/Product/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Link/Product/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Link/Product/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Link/Product/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Link/Product/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Option.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Option.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Option.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Option.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Option.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Option.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Option/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Option/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Option/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Option/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Option/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Option/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Option/Value.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Option/Value.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Option/Value.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Option/Value.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Option/Value.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Option/Value.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Option/Value/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Option/Value/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Option/Value/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Option/Value/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Option/Value/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Option/Value/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Relation.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Relation.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Relation.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Relation.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Relation.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Relation.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Status.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Status.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Status.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Status.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Status.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Status.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Type/Configurable.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Type/Configurable.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Type/Configurable.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Type/Configurable.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Type/Configurable.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Type/Configurable.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Type/Configurable/Attribute.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Type/Configurable/Attribute.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Type/Configurable/Attribute.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Type/Configurable/Attribute.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Type/Configurable/Attribute.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Type/Configurable/Attribute.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Type/Configurable/Attribute/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Type/Configurable/Attribute/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Type/Configurable/Attribute/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Type/Configurable/Attribute/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Type/Configurable/Attribute/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Type/Configurable/Attribute/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Type/Configurable/Product/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Type/Configurable/Product/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Type/Configurable/Product/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Type/Configurable/Product/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Type/Configurable/Product/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Type/Configurable/Product/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Website.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Website.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Website.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Website.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Website.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Website.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Setup.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Setup.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Setup.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Setup.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Setup.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Setup.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Url.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Url.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Resource/Url.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Url.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Resource/Url.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Url.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Session.php
+++ b/app/code/core/Mage/Catalog/Model/Session.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Session.php
+++ b/app/code/core/Mage/Catalog/Model/Session.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Session.php
+++ b/app/code/core/Mage/Catalog/Model/Session.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/System/Config/Backend/Catalog/Category/Flat.php
+++ b/app/code/core/Mage/Catalog/Model/System/Config/Backend/Catalog/Category/Flat.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/System/Config/Backend/Catalog/Category/Flat.php
+++ b/app/code/core/Mage/Catalog/Model/System/Config/Backend/Catalog/Category/Flat.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/System/Config/Backend/Catalog/Category/Flat.php
+++ b/app/code/core/Mage/Catalog/Model/System/Config/Backend/Catalog/Category/Flat.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/System/Config/Backend/Catalog/Product/Flat.php
+++ b/app/code/core/Mage/Catalog/Model/System/Config/Backend/Catalog/Product/Flat.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/System/Config/Backend/Catalog/Product/Flat.php
+++ b/app/code/core/Mage/Catalog/Model/System/Config/Backend/Catalog/Product/Flat.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/System/Config/Backend/Catalog/Product/Flat.php
+++ b/app/code/core/Mage/Catalog/Model/System/Config/Backend/Catalog/Product/Flat.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/System/Config/Backend/Catalog/Url/Rewrite/Suffix.php
+++ b/app/code/core/Mage/Catalog/Model/System/Config/Backend/Catalog/Url/Rewrite/Suffix.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/System/Config/Backend/Catalog/Url/Rewrite/Suffix.php
+++ b/app/code/core/Mage/Catalog/Model/System/Config/Backend/Catalog/Url/Rewrite/Suffix.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/System/Config/Backend/Catalog/Url/Rewrite/Suffix.php
+++ b/app/code/core/Mage/Catalog/Model/System/Config/Backend/Catalog/Url/Rewrite/Suffix.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Template/Filter.php
+++ b/app/code/core/Mage/Catalog/Model/Template/Filter.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Template/Filter.php
+++ b/app/code/core/Mage/Catalog/Model/Template/Filter.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Template/Filter.php
+++ b/app/code/core/Mage/Catalog/Model/Template/Filter.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Url.php
+++ b/app/code/core/Mage/Catalog/Model/Url.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/Model/Url.php
+++ b/app/code/core/Mage/Catalog/Model/Url.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/Model/Url.php
+++ b/app/code/core/Mage/Catalog/Model/Url.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/controllers/CategoryController.php
+++ b/app/code/core/Mage/Catalog/controllers/CategoryController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/controllers/CategoryController.php
+++ b/app/code/core/Mage/Catalog/controllers/CategoryController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/controllers/CategoryController.php
+++ b/app/code/core/Mage/Catalog/controllers/CategoryController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/controllers/IndexController.php
+++ b/app/code/core/Mage/Catalog/controllers/IndexController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/controllers/IndexController.php
+++ b/app/code/core/Mage/Catalog/controllers/IndexController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/controllers/IndexController.php
+++ b/app/code/core/Mage/Catalog/controllers/IndexController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/controllers/Product/CompareController.php
+++ b/app/code/core/Mage/Catalog/controllers/Product/CompareController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/controllers/Product/CompareController.php
+++ b/app/code/core/Mage/Catalog/controllers/Product/CompareController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/controllers/Product/CompareController.php
+++ b/app/code/core/Mage/Catalog/controllers/Product/CompareController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/controllers/ProductController.php
+++ b/app/code/core/Mage/Catalog/controllers/ProductController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/controllers/ProductController.php
+++ b/app/code/core/Mage/Catalog/controllers/ProductController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/controllers/ProductController.php
+++ b/app/code/core/Mage/Catalog/controllers/ProductController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/controllers/Seo/SitemapController.php
+++ b/app/code/core/Mage/Catalog/controllers/Seo/SitemapController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/controllers/Seo/SitemapController.php
+++ b/app/code/core/Mage/Catalog/controllers/Seo/SitemapController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/controllers/Seo/SitemapController.php
+++ b/app/code/core/Mage/Catalog/controllers/Seo/SitemapController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/data/catalog_setup/data-install-1.6.0.0.php
+++ b/app/code/core/Mage/Catalog/data/catalog_setup/data-install-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/data/catalog_setup/data-install-1.6.0.0.php
+++ b/app/code/core/Mage/Catalog/data/catalog_setup/data-install-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/data/catalog_setup/data-install-1.6.0.0.php
+++ b/app/code/core/Mage/Catalog/data/catalog_setup/data-install-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/data/catalog_setup/data-upgrade-1.6.0.0.12-1.6.0.0.13.php
+++ b/app/code/core/Mage/Catalog/data/catalog_setup/data-upgrade-1.6.0.0.12-1.6.0.0.13.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/data/catalog_setup/data-upgrade-1.6.0.0.12-1.6.0.0.13.php
+++ b/app/code/core/Mage/Catalog/data/catalog_setup/data-upgrade-1.6.0.0.12-1.6.0.0.13.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/data/catalog_setup/data-upgrade-1.6.0.0.12-1.6.0.0.13.php
+++ b/app/code/core/Mage/Catalog/data/catalog_setup/data-upgrade-1.6.0.0.12-1.6.0.0.13.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/data/catalog_setup/data-upgrade-1.6.0.0.13-1.6.0.0.14.php
+++ b/app/code/core/Mage/Catalog/data/catalog_setup/data-upgrade-1.6.0.0.13-1.6.0.0.14.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/data/catalog_setup/data-upgrade-1.6.0.0.13-1.6.0.0.14.php
+++ b/app/code/core/Mage/Catalog/data/catalog_setup/data-upgrade-1.6.0.0.13-1.6.0.0.14.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/data/catalog_setup/data-upgrade-1.6.0.0.13-1.6.0.0.14.php
+++ b/app/code/core/Mage/Catalog/data/catalog_setup/data-upgrade-1.6.0.0.13-1.6.0.0.14.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/data/catalog_setup/data-upgrade-1.6.0.0.19.1.3-1.6.0.0.19.1.4.php
+++ b/app/code/core/Mage/Catalog/data/catalog_setup/data-upgrade-1.6.0.0.19.1.3-1.6.0.0.19.1.4.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/data/catalog_setup/data-upgrade-1.6.0.0.19.1.3-1.6.0.0.19.1.4.php
+++ b/app/code/core/Mage/Catalog/data/catalog_setup/data-upgrade-1.6.0.0.19.1.3-1.6.0.0.19.1.4.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/data/catalog_setup/data-upgrade-1.6.0.0.19.1.3-1.6.0.0.19.1.4.php
+++ b/app/code/core/Mage/Catalog/data/catalog_setup/data-upgrade-1.6.0.0.19.1.3-1.6.0.0.19.1.4.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/data/catalog_setup/data-upgrade-1.6.0.0.4-1.6.0.0.5.php
+++ b/app/code/core/Mage/Catalog/data/catalog_setup/data-upgrade-1.6.0.0.4-1.6.0.0.5.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/data/catalog_setup/data-upgrade-1.6.0.0.4-1.6.0.0.5.php
+++ b/app/code/core/Mage/Catalog/data/catalog_setup/data-upgrade-1.6.0.0.4-1.6.0.0.5.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/data/catalog_setup/data-upgrade-1.6.0.0.4-1.6.0.0.5.php
+++ b/app/code/core/Mage/Catalog/data/catalog_setup/data-upgrade-1.6.0.0.4-1.6.0.0.5.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/data/catalog_setup/data-upgrade-1.6.0.0.8-1.6.0.0.9.php
+++ b/app/code/core/Mage/Catalog/data/catalog_setup/data-upgrade-1.6.0.0.8-1.6.0.0.9.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/data/catalog_setup/data-upgrade-1.6.0.0.8-1.6.0.0.9.php
+++ b/app/code/core/Mage/Catalog/data/catalog_setup/data-upgrade-1.6.0.0.8-1.6.0.0.9.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/data/catalog_setup/data-upgrade-1.6.0.0.8-1.6.0.0.9.php
+++ b/app/code/core/Mage/Catalog/data/catalog_setup/data-upgrade-1.6.0.0.8-1.6.0.0.9.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/etc/adminhtml.xml
+++ b/app/code/core/Mage/Catalog/etc/adminhtml.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/etc/adminhtml.xml
+++ b/app/code/core/Mage/Catalog/etc/adminhtml.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/etc/adminhtml.xml
+++ b/app/code/core/Mage/Catalog/etc/adminhtml.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/etc/api.xml
+++ b/app/code/core/Mage/Catalog/etc/api.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/etc/api.xml
+++ b/app/code/core/Mage/Catalog/etc/api.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/etc/api.xml
+++ b/app/code/core/Mage/Catalog/etc/api.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/etc/api2.xml
+++ b/app/code/core/Mage/Catalog/etc/api2.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/etc/api2.xml
+++ b/app/code/core/Mage/Catalog/etc/api2.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/etc/api2.xml
+++ b/app/code/core/Mage/Catalog/etc/api2.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/etc/config.xml
+++ b/app/code/core/Mage/Catalog/etc/config.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/etc/config.xml
+++ b/app/code/core/Mage/Catalog/etc/config.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/etc/config.xml
+++ b/app/code/core/Mage/Catalog/etc/config.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/etc/convert.xml
+++ b/app/code/core/Mage/Catalog/etc/convert.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/etc/convert.xml
+++ b/app/code/core/Mage/Catalog/etc/convert.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/etc/convert.xml
+++ b/app/code/core/Mage/Catalog/etc/convert.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/etc/system.xml
+++ b/app/code/core/Mage/Catalog/etc/system.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/etc/system.xml
+++ b/app/code/core/Mage/Catalog/etc/system.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/etc/system.xml
+++ b/app/code/core/Mage/Catalog/etc/system.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/etc/widget.xml
+++ b/app/code/core/Mage/Catalog/etc/widget.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/etc/widget.xml
+++ b/app/code/core/Mage/Catalog/etc/widget.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/etc/widget.xml
+++ b/app/code/core/Mage/Catalog/etc/widget.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/install-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/install-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/install-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-data-upgrade-0.7.57-0.7.58.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-data-upgrade-0.7.57-0.7.58.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-data-upgrade-0.7.57-0.7.58.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-data-upgrade-0.7.57-0.7.58.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-data-upgrade-0.7.57-0.7.58.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-data-upgrade-0.7.57-0.7.58.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-data-upgrade-0.7.63-0.7.64.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-data-upgrade-0.7.63-0.7.64.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-data-upgrade-0.7.63-0.7.64.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-data-upgrade-0.7.63-0.7.64.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-data-upgrade-0.7.63-0.7.64.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-data-upgrade-0.7.63-0.7.64.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-data-upgrade-1.4.0.0.28-1.4.0.0.29.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-data-upgrade-1.4.0.0.28-1.4.0.0.29.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-data-upgrade-1.4.0.0.28-1.4.0.0.29.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-data-upgrade-1.4.0.0.28-1.4.0.0.29.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-data-upgrade-1.4.0.0.28-1.4.0.0.29.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-data-upgrade-1.4.0.0.28-1.4.0.0.29.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-data-upgrade-1.4.0.0.42-1.4.0.0.43.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-data-upgrade-1.4.0.0.42-1.4.0.0.43.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-data-upgrade-1.4.0.0.42-1.4.0.0.43.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-data-upgrade-1.4.0.0.42-1.4.0.0.43.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-data-upgrade-1.4.0.0.42-1.4.0.0.43.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-data-upgrade-1.4.0.0.42-1.4.0.0.43.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-install-0.7.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-install-0.7.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-install-0.7.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-install-1.4.0.0.0.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-install-1.4.0.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-install-1.4.0.0.0.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-install-1.4.0.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-install-1.4.0.0.0.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-install-1.4.0.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.6.40-0.7.0.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.6.40-0.7.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.6.40-0.7.0.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.6.40-0.7.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.6.40-0.7.0.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.6.40-0.7.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.0-0.7.1.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.0-0.7.1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.0-0.7.1.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.0-0.7.1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.0-0.7.1.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.0-0.7.1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.1-0.7.2.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.1-0.7.2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.1-0.7.2.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.1-0.7.2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.1-0.7.2.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.1-0.7.2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.11-0.7.12.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.11-0.7.12.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.11-0.7.12.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.11-0.7.12.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.11-0.7.12.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.11-0.7.12.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.12-0.7.13.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.12-0.7.13.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.12-0.7.13.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.12-0.7.13.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.12-0.7.13.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.12-0.7.13.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.13-0.7.14.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.13-0.7.14.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.13-0.7.14.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.13-0.7.14.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.13-0.7.14.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.13-0.7.14.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.14-0.7.15.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.14-0.7.15.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.14-0.7.15.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.14-0.7.15.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.14-0.7.15.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.14-0.7.15.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.15-0.7.16.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.15-0.7.16.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.15-0.7.16.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.15-0.7.16.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.15-0.7.16.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.15-0.7.16.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.16-0.7.17.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.16-0.7.17.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.16-0.7.17.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.16-0.7.17.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.16-0.7.17.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.16-0.7.17.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.17-0.7.18.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.17-0.7.18.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.17-0.7.18.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.17-0.7.18.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.17-0.7.18.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.17-0.7.18.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.18-0.7.19.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.18-0.7.19.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.18-0.7.19.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.18-0.7.19.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.18-0.7.19.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.18-0.7.19.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.19-0.7.20.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.19-0.7.20.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.19-0.7.20.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.19-0.7.20.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.19-0.7.20.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.19-0.7.20.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.2-0.7.3.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.2-0.7.3.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.2-0.7.3.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.2-0.7.3.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.2-0.7.3.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.2-0.7.3.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.20-0.7.21.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.20-0.7.21.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.20-0.7.21.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.20-0.7.21.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.20-0.7.21.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.20-0.7.21.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.21-0.7.22.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.21-0.7.22.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.21-0.7.22.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.21-0.7.22.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.21-0.7.22.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.21-0.7.22.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.22-0.7.23.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.22-0.7.23.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.22-0.7.23.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.22-0.7.23.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.22-0.7.23.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.22-0.7.23.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.23-0.7.24.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.23-0.7.24.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.23-0.7.24.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.23-0.7.24.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.23-0.7.24.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.23-0.7.24.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.24-0.7.25.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.24-0.7.25.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.24-0.7.25.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.24-0.7.25.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.24-0.7.25.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.24-0.7.25.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.25-0.7.26.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.25-0.7.26.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.25-0.7.26.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.25-0.7.26.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.25-0.7.26.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.25-0.7.26.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.26-0.7.27.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.26-0.7.27.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.26-0.7.27.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.26-0.7.27.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.26-0.7.27.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.26-0.7.27.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.27-0.7.28.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.27-0.7.28.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.27-0.7.28.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.27-0.7.28.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.27-0.7.28.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.27-0.7.28.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.28-0.7.29.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.28-0.7.29.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.28-0.7.29.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.28-0.7.29.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.28-0.7.29.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.28-0.7.29.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.29-0.7.30.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.29-0.7.30.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.29-0.7.30.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.29-0.7.30.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.29-0.7.30.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.29-0.7.30.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.30-0.7.31.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.30-0.7.31.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.30-0.7.31.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.30-0.7.31.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.30-0.7.31.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.30-0.7.31.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.31-0.7.32.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.31-0.7.32.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.31-0.7.32.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.31-0.7.32.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.31-0.7.32.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.31-0.7.32.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.32-0.7.33.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.32-0.7.33.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.32-0.7.33.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.32-0.7.33.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.32-0.7.33.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.32-0.7.33.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.33-0.7.34.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.33-0.7.34.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.33-0.7.34.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.33-0.7.34.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.33-0.7.34.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.33-0.7.34.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.34-0.7.35.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.34-0.7.35.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.34-0.7.35.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.34-0.7.35.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.34-0.7.35.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.34-0.7.35.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.35-0.7.36.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.35-0.7.36.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.35-0.7.36.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.35-0.7.36.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.35-0.7.36.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.35-0.7.36.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.36-0.7.37.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.36-0.7.37.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.36-0.7.37.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.36-0.7.37.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.36-0.7.37.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.36-0.7.37.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.37-0.7.38.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.37-0.7.38.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.37-0.7.38.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.37-0.7.38.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.37-0.7.38.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.37-0.7.38.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.38-0.7.39.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.38-0.7.39.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.38-0.7.39.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.38-0.7.39.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.38-0.7.39.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.38-0.7.39.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.39-0.7.40.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.39-0.7.40.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.39-0.7.40.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.39-0.7.40.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.39-0.7.40.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.39-0.7.40.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.4-0.7.5.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.4-0.7.5.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.4-0.7.5.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.4-0.7.5.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.4-0.7.5.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.4-0.7.5.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.40-0.7.41.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.40-0.7.41.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.40-0.7.41.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.40-0.7.41.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.40-0.7.41.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.40-0.7.41.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.41-0.7.42.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.41-0.7.42.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.41-0.7.42.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.41-0.7.42.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.41-0.7.42.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.41-0.7.42.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.43-0.7.44.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.43-0.7.44.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.43-0.7.44.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.43-0.7.44.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.43-0.7.44.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.43-0.7.44.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.44-0.7.45.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.44-0.7.45.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.44-0.7.45.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.44-0.7.45.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.44-0.7.45.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.44-0.7.45.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.45-0.7.46.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.45-0.7.46.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.45-0.7.46.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.45-0.7.46.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.45-0.7.46.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.45-0.7.46.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.46-0.7.47.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.46-0.7.47.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.46-0.7.47.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.46-0.7.47.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.46-0.7.47.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.46-0.7.47.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.47-0.7.48.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.47-0.7.48.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.47-0.7.48.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.47-0.7.48.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.47-0.7.48.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.47-0.7.48.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.48-0.7.49.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.48-0.7.49.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.48-0.7.49.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.48-0.7.49.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.48-0.7.49.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.48-0.7.49.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.49-0.7.50.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.49-0.7.50.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.49-0.7.50.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.49-0.7.50.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.49-0.7.50.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.49-0.7.50.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.5-0.7.6.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.5-0.7.6.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.5-0.7.6.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.5-0.7.6.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.5-0.7.6.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.5-0.7.6.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.50-0.7.51.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.50-0.7.51.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.50-0.7.51.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.50-0.7.51.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.50-0.7.51.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.50-0.7.51.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.51-0.7.52.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.51-0.7.52.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.51-0.7.52.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.51-0.7.52.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.51-0.7.52.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.51-0.7.52.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.52-0.7.53.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.52-0.7.53.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.52-0.7.53.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.52-0.7.53.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.52-0.7.53.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.52-0.7.53.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.53-0.7.54.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.53-0.7.54.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.53-0.7.54.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.53-0.7.54.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.53-0.7.54.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.53-0.7.54.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.54-0.7.55.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.54-0.7.55.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.54-0.7.55.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.54-0.7.55.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.54-0.7.55.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.54-0.7.55.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.55-0.7.56.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.55-0.7.56.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.55-0.7.56.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.55-0.7.56.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.55-0.7.56.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.55-0.7.56.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.56-0.7.57.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.56-0.7.57.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.56-0.7.57.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.56-0.7.57.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.56-0.7.57.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.56-0.7.57.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.57-0.7.58.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.57-0.7.58.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.57-0.7.58.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.57-0.7.58.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.57-0.7.58.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.57-0.7.58.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.58-0.7.59.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.58-0.7.59.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.58-0.7.59.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.58-0.7.59.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.58-0.7.59.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.58-0.7.59.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.59-0.7.60.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.59-0.7.60.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.59-0.7.60.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.59-0.7.60.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.59-0.7.60.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.59-0.7.60.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.6-0.7.7.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.6-0.7.7.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.6-0.7.7.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.6-0.7.7.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.6-0.7.7.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.6-0.7.7.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.60-0.7.61.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.60-0.7.61.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.60-0.7.61.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.60-0.7.61.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.60-0.7.61.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.60-0.7.61.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.61-0.7.62.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.61-0.7.62.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.61-0.7.62.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.61-0.7.62.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.61-0.7.62.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.61-0.7.62.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.62-0.7.63.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.62-0.7.63.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.62-0.7.63.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.62-0.7.63.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.62-0.7.63.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.62-0.7.63.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.63-0.7.64.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.63-0.7.64.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.63-0.7.64.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.63-0.7.64.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.63-0.7.64.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.63-0.7.64.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.64-0.7.65.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.64-0.7.65.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.64-0.7.65.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.64-0.7.65.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.64-0.7.65.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.64-0.7.65.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.65-0.7.66.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.65-0.7.66.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.65-0.7.66.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.65-0.7.66.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.65-0.7.66.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.65-0.7.66.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.66-0.7.67.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.66-0.7.67.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.66-0.7.67.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.66-0.7.67.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.66-0.7.67.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.66-0.7.67.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.67-0.7.68.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.67-0.7.68.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.67-0.7.68.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.67-0.7.68.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.67-0.7.68.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.67-0.7.68.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.68-0.7.69.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.68-0.7.69.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.68-0.7.69.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.68-0.7.69.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.68-0.7.69.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.68-0.7.69.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.69-0.7.70.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.69-0.7.70.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.69-0.7.70.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.69-0.7.70.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.69-0.7.70.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.69-0.7.70.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.7-0.7.8.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.7-0.7.8.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.7-0.7.8.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.7-0.7.8.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.7-0.7.8.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.7-0.7.8.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.70-0.7.71.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.70-0.7.71.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.70-0.7.71.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.70-0.7.71.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.70-0.7.71.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.70-0.7.71.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.71-0.7.72.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.71-0.7.72.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.71-0.7.72.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.71-0.7.72.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.71-0.7.72.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.71-0.7.72.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.72-0.7.73.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.72-0.7.73.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.72-0.7.73.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.72-0.7.73.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.72-0.7.73.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.72-0.7.73.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.73-1.4.0.0.0.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.73-1.4.0.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.73-1.4.0.0.0.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.73-1.4.0.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.73-1.4.0.0.0.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.73-1.4.0.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.8-0.7.9.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.8-0.7.9.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.8-0.7.9.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.8-0.7.9.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.8-0.7.9.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-0.7.8-0.7.9.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.0-1.4.0.0.1.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.0-1.4.0.0.1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.0-1.4.0.0.1.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.0-1.4.0.0.1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.0-1.4.0.0.1.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.0-1.4.0.0.1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.1-1.4.0.0.2.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.1-1.4.0.0.2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.1-1.4.0.0.2.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.1-1.4.0.0.2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.1-1.4.0.0.2.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.1-1.4.0.0.2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.10-1.4.0.0.11.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.10-1.4.0.0.11.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.10-1.4.0.0.11.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.10-1.4.0.0.11.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.10-1.4.0.0.11.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.10-1.4.0.0.11.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.11-1.4.0.0.12.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.11-1.4.0.0.12.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.11-1.4.0.0.12.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.11-1.4.0.0.12.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.11-1.4.0.0.12.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.11-1.4.0.0.12.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.12-1.4.0.0.13.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.12-1.4.0.0.13.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.12-1.4.0.0.13.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.12-1.4.0.0.13.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.12-1.4.0.0.13.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.12-1.4.0.0.13.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.13-1.4.0.0.14.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.13-1.4.0.0.14.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.13-1.4.0.0.14.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.13-1.4.0.0.14.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.13-1.4.0.0.14.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.13-1.4.0.0.14.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.14-1.4.0.0.15.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.14-1.4.0.0.15.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.14-1.4.0.0.15.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.14-1.4.0.0.15.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.14-1.4.0.0.15.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.14-1.4.0.0.15.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.15-1.4.0.0.16.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.15-1.4.0.0.16.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.15-1.4.0.0.16.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.15-1.4.0.0.16.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.15-1.4.0.0.16.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.15-1.4.0.0.16.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.16-1.4.0.0.17.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.16-1.4.0.0.17.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.16-1.4.0.0.17.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.16-1.4.0.0.17.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.16-1.4.0.0.17.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.16-1.4.0.0.17.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.17-1.4.0.0.18.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.17-1.4.0.0.18.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.17-1.4.0.0.18.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.17-1.4.0.0.18.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.17-1.4.0.0.18.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.17-1.4.0.0.18.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.18-1.4.0.0.19.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.18-1.4.0.0.19.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.18-1.4.0.0.19.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.18-1.4.0.0.19.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.18-1.4.0.0.19.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.18-1.4.0.0.19.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.19-1.4.0.0.20.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.19-1.4.0.0.20.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.19-1.4.0.0.20.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.19-1.4.0.0.20.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.19-1.4.0.0.20.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.19-1.4.0.0.20.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.2-1.4.0.0.3.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.2-1.4.0.0.3.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.2-1.4.0.0.3.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.2-1.4.0.0.3.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.2-1.4.0.0.3.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.2-1.4.0.0.3.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.20-1.4.0.0.21.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.20-1.4.0.0.21.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.20-1.4.0.0.21.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.20-1.4.0.0.21.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.20-1.4.0.0.21.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.20-1.4.0.0.21.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.21-1.4.0.0.22.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.21-1.4.0.0.22.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.21-1.4.0.0.22.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.21-1.4.0.0.22.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.21-1.4.0.0.22.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.21-1.4.0.0.22.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.22-1.4.0.0.23.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.22-1.4.0.0.23.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.22-1.4.0.0.23.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.22-1.4.0.0.23.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.22-1.4.0.0.23.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.22-1.4.0.0.23.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.23-1.4.0.0.24.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.23-1.4.0.0.24.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.23-1.4.0.0.24.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.23-1.4.0.0.24.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.23-1.4.0.0.24.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.23-1.4.0.0.24.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.24-1.4.0.0.25.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.24-1.4.0.0.25.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.24-1.4.0.0.25.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.24-1.4.0.0.25.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.24-1.4.0.0.25.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.24-1.4.0.0.25.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.25-1.4.0.0.26.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.25-1.4.0.0.26.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.25-1.4.0.0.26.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.25-1.4.0.0.26.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.25-1.4.0.0.26.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.25-1.4.0.0.26.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.26-1.4.0.0.27.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.26-1.4.0.0.27.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.26-1.4.0.0.27.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.26-1.4.0.0.27.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.26-1.4.0.0.27.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.26-1.4.0.0.27.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.27-1.4.0.0.28.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.27-1.4.0.0.28.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.27-1.4.0.0.28.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.27-1.4.0.0.28.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.27-1.4.0.0.28.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.27-1.4.0.0.28.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.28-1.4.0.0.29.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.28-1.4.0.0.29.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.28-1.4.0.0.29.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.28-1.4.0.0.29.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.28-1.4.0.0.29.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.28-1.4.0.0.29.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.3-1.4.0.0.4.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.3-1.4.0.0.4.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.3-1.4.0.0.4.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.3-1.4.0.0.4.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.3-1.4.0.0.4.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.3-1.4.0.0.4.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.30-1.4.0.0.31.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.30-1.4.0.0.31.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.30-1.4.0.0.31.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.30-1.4.0.0.31.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.30-1.4.0.0.31.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.30-1.4.0.0.31.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.31-1.4.0.0.32.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.31-1.4.0.0.32.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.31-1.4.0.0.32.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.31-1.4.0.0.32.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.31-1.4.0.0.32.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.31-1.4.0.0.32.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.32-1.4.0.0.33.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.32-1.4.0.0.33.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.32-1.4.0.0.33.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.32-1.4.0.0.33.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.32-1.4.0.0.33.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.32-1.4.0.0.33.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.33-1.4.0.0.34.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.33-1.4.0.0.34.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.33-1.4.0.0.34.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.33-1.4.0.0.34.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.33-1.4.0.0.34.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.33-1.4.0.0.34.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.34-1.4.0.0.35.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.34-1.4.0.0.35.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.34-1.4.0.0.35.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.34-1.4.0.0.35.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.34-1.4.0.0.35.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.34-1.4.0.0.35.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.35-1.4.0.0.36.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.35-1.4.0.0.36.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.35-1.4.0.0.36.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.35-1.4.0.0.36.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.35-1.4.0.0.36.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.35-1.4.0.0.36.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.36-1.4.0.0.37.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.36-1.4.0.0.37.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.36-1.4.0.0.37.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.36-1.4.0.0.37.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.36-1.4.0.0.37.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.36-1.4.0.0.37.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.37-1.4.0.0.38.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.37-1.4.0.0.38.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.37-1.4.0.0.38.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.37-1.4.0.0.38.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.37-1.4.0.0.38.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.37-1.4.0.0.38.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.38-1.4.0.0.39.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.38-1.4.0.0.39.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.38-1.4.0.0.39.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.38-1.4.0.0.39.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.38-1.4.0.0.39.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.38-1.4.0.0.39.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.39-1.4.0.0.40.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.39-1.4.0.0.40.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.39-1.4.0.0.40.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.39-1.4.0.0.40.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.39-1.4.0.0.40.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.39-1.4.0.0.40.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.4-1.4.0.0.5.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.4-1.4.0.0.5.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.4-1.4.0.0.5.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.4-1.4.0.0.5.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.4-1.4.0.0.5.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.4-1.4.0.0.5.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.40-1.4.0.0.41.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.40-1.4.0.0.41.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.40-1.4.0.0.41.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.40-1.4.0.0.41.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.40-1.4.0.0.41.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.40-1.4.0.0.41.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.41-1.4.0.0.42.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.41-1.4.0.0.42.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.41-1.4.0.0.42.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.41-1.4.0.0.42.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.41-1.4.0.0.42.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.41-1.4.0.0.42.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.43-1.4.0.0.44.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.43-1.4.0.0.44.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.43-1.4.0.0.44.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.43-1.4.0.0.44.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.43-1.4.0.0.44.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.43-1.4.0.0.44.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.5-1.4.0.0.6.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.5-1.4.0.0.6.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.5-1.4.0.0.6.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.5-1.4.0.0.6.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.5-1.4.0.0.6.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.5-1.4.0.0.6.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.6-1.4.0.0.7.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.6-1.4.0.0.7.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.6-1.4.0.0.7.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.6-1.4.0.0.7.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.6-1.4.0.0.7.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.6-1.4.0.0.7.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.7-1.4.0.0.8.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.7-1.4.0.0.8.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.7-1.4.0.0.8.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.7-1.4.0.0.8.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.7-1.4.0.0.8.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.7-1.4.0.0.8.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.8-1.4.0.0.9.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.8-1.4.0.0.9.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.8-1.4.0.0.9.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.8-1.4.0.0.9.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.8-1.4.0.0.9.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.8-1.4.0.0.9.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.9-1.4.0.0.10.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.9-1.4.0.0.10.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.9-1.4.0.0.10.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.9-1.4.0.0.10.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.9-1.4.0.0.10.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.9-1.4.0.0.10.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.6.0.0.8-1.6.0.0.9.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.6.0.0.8-1.6.0.0.9.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.6.0.0.8-1.6.0.0.9.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.6.0.0.8-1.6.0.0.9.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.6.0.0.8-1.6.0.0.9.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.6.0.0.8-1.6.0.0.9.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0-1.6.0.0.1.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0-1.6.0.0.1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0-1.6.0.0.1.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0-1.6.0.0.1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0-1.6.0.0.1.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0-1.6.0.0.1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.1-1.6.0.0.2.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.1-1.6.0.0.2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.1-1.6.0.0.2.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.1-1.6.0.0.2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.1-1.6.0.0.2.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.1-1.6.0.0.2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.10-1.6.0.0.11.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.10-1.6.0.0.11.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.10-1.6.0.0.11.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.10-1.6.0.0.11.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.10-1.6.0.0.11.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.10-1.6.0.0.11.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.11-1.6.0.0.12.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.11-1.6.0.0.12.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.11-1.6.0.0.12.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.11-1.6.0.0.12.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.11-1.6.0.0.12.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.11-1.6.0.0.12.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.14-1.6.0.0.15.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.14-1.6.0.0.15.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.14-1.6.0.0.15.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.14-1.6.0.0.15.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.14-1.6.0.0.15.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.14-1.6.0.0.15.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.15-1.6.0.0.18.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.15-1.6.0.0.18.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.15-1.6.0.0.18.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.15-1.6.0.0.18.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.15-1.6.0.0.18.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.15-1.6.0.0.18.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.18-1.6.0.0.19.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.18-1.6.0.0.19.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.18-1.6.0.0.19.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.18-1.6.0.0.19.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.18-1.6.0.0.19.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.18-1.6.0.0.19.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.19.1.1-1.6.0.0.19.1.2.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.19.1.1-1.6.0.0.19.1.2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.19.1.1-1.6.0.0.19.1.2.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.19.1.1-1.6.0.0.19.1.2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.19.1.1-1.6.0.0.19.1.2.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.19.1.1-1.6.0.0.19.1.2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.19.1.2-1.6.0.0.19.1.3.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.19.1.2-1.6.0.0.19.1.3.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.19.1.2-1.6.0.0.19.1.3.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.19.1.2-1.6.0.0.19.1.3.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.19.1.2-1.6.0.0.19.1.3.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.19.1.2-1.6.0.0.19.1.3.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.19.1.4-1.6.0.0.19.1.5.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.19.1.4-1.6.0.0.19.1.5.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.19.1.4-1.6.0.0.19.1.5.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.19.1.4-1.6.0.0.19.1.5.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.19.1.4-1.6.0.0.19.1.5.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.19.1.4-1.6.0.0.19.1.5.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.19.1.5-1.6.0.0.19.1.6.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.19.1.5-1.6.0.0.19.1.6.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.19.1.5-1.6.0.0.19.1.6.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.19.1.5-1.6.0.0.19.1.6.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.19.1.5-1.6.0.0.19.1.6.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.19.1.5-1.6.0.0.19.1.6.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.2-1.6.0.0.3.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.2-1.6.0.0.3.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.2-1.6.0.0.3.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.2-1.6.0.0.3.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.2-1.6.0.0.3.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.2-1.6.0.0.3.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.3-1.6.0.0.4.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.3-1.6.0.0.4.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.3-1.6.0.0.4.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.3-1.6.0.0.4.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.3-1.6.0.0.4.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.3-1.6.0.0.4.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.4-1.6.0.0.5.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.4-1.6.0.0.5.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.4-1.6.0.0.5.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.4-1.6.0.0.5.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.4-1.6.0.0.5.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.4-1.6.0.0.5.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.5-1.6.0.0.6.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.5-1.6.0.0.6.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.5-1.6.0.0.6.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.5-1.6.0.0.6.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.5-1.6.0.0.6.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.5-1.6.0.0.6.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.6-1.6.0.0.7.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.6-1.6.0.0.7.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.6-1.6.0.0.7.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.6-1.6.0.0.7.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.6-1.6.0.0.7.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.6-1.6.0.0.7.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.7-1.6.0.0.8.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.7-1.6.0.0.8.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.7-1.6.0.0.8.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.7-1.6.0.0.8.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.7-1.6.0.0.8.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.7-1.6.0.0.8.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.9-1.6.0.0.10.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.9-1.6.0.0.10.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.9-1.6.0.0.10.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.9-1.6.0.0.10.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.9-1.6.0.0.10.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.9-1.6.0.0.10.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/code/core/Mage/CatalogIndex/Model/Aggregation.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Aggregation.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogIndex/Model/Aggregation.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Aggregation.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/Model/Aggregation.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Aggregation.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/Model/Attribute.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Attribute.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogIndex/Model/Attribute.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Attribute.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/Model/Attribute.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Attribute.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/Model/Catalog/Index/Flag.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Catalog/Index/Flag.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogIndex/Model/Catalog/Index/Flag.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Catalog/Index/Flag.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/Model/Catalog/Index/Flag.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Catalog/Index/Flag.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/Model/Catalog/Index/Kill/Flag.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Catalog/Index/Kill/Flag.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogIndex/Model/Catalog/Index/Kill/Flag.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Catalog/Index/Kill/Flag.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/Model/Catalog/Index/Kill/Flag.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Catalog/Index/Kill/Flag.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/Model/Data/Abstract.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Data/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogIndex/Model/Data/Abstract.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Data/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/Model/Data/Abstract.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Data/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/Model/Data/Configurable.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Data/Configurable.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogIndex/Model/Data/Configurable.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Data/Configurable.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/Model/Data/Configurable.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Data/Configurable.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/Model/Data/Grouped.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Data/Grouped.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogIndex/Model/Data/Grouped.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Data/Grouped.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/Model/Data/Grouped.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Data/Grouped.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/Model/Data/Simple.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Data/Simple.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogIndex/Model/Data/Simple.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Data/Simple.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/Model/Data/Simple.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Data/Simple.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/Model/Data/Virtual.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Data/Virtual.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogIndex/Model/Data/Virtual.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Data/Virtual.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/Model/Data/Virtual.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Data/Virtual.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/Model/Indexer.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Indexer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogIndex/Model/Indexer.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Indexer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/Model/Indexer.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Indexer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/Model/Indexer/Abstract.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Indexer/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogIndex/Model/Indexer/Abstract.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Indexer/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/Model/Indexer/Abstract.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Indexer/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/Model/Indexer/Eav.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Indexer/Eav.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogIndex/Model/Indexer/Eav.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Indexer/Eav.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/Model/Indexer/Eav.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Indexer/Eav.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/Model/Indexer/Interface.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Indexer/Interface.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogIndex/Model/Indexer/Interface.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Indexer/Interface.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/Model/Indexer/Interface.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Indexer/Interface.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/Model/Indexer/Minimalprice.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Indexer/Minimalprice.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogIndex/Model/Indexer/Minimalprice.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Indexer/Minimalprice.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/Model/Indexer/Minimalprice.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Indexer/Minimalprice.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/Model/Indexer/Price.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Indexer/Price.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogIndex/Model/Indexer/Price.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Indexer/Price.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/Model/Indexer/Price.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Indexer/Price.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/Model/Indexer/Tierprice.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Indexer/Tierprice.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogIndex/Model/Indexer/Tierprice.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Indexer/Tierprice.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/Model/Indexer/Tierprice.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Indexer/Tierprice.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/Model/Mysql4/Abstract.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Mysql4/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogIndex/Model/Mysql4/Abstract.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Mysql4/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/Model/Mysql4/Abstract.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Mysql4/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/Model/Mysql4/Aggregation.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Mysql4/Aggregation.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogIndex/Model/Mysql4/Aggregation.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Mysql4/Aggregation.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/Model/Mysql4/Aggregation.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Mysql4/Aggregation.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/Model/Mysql4/Attribute.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Mysql4/Attribute.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogIndex/Model/Mysql4/Attribute.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Mysql4/Attribute.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/Model/Mysql4/Attribute.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Mysql4/Attribute.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/Model/Mysql4/Data/Abstract.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Mysql4/Data/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogIndex/Model/Mysql4/Data/Abstract.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Mysql4/Data/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/Model/Mysql4/Data/Abstract.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Mysql4/Data/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/Model/Mysql4/Data/Configurable.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Mysql4/Data/Configurable.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogIndex/Model/Mysql4/Data/Configurable.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Mysql4/Data/Configurable.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/Model/Mysql4/Data/Configurable.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Mysql4/Data/Configurable.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/Model/Mysql4/Data/Grouped.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Mysql4/Data/Grouped.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogIndex/Model/Mysql4/Data/Grouped.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Mysql4/Data/Grouped.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/Model/Mysql4/Data/Grouped.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Mysql4/Data/Grouped.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/Model/Mysql4/Indexer.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Mysql4/Indexer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogIndex/Model/Mysql4/Indexer.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Mysql4/Indexer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/Model/Mysql4/Indexer.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Mysql4/Indexer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/Model/Mysql4/Indexer/Abstract.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Mysql4/Indexer/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogIndex/Model/Mysql4/Indexer/Abstract.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Mysql4/Indexer/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/Model/Mysql4/Indexer/Abstract.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Mysql4/Indexer/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/Model/Mysql4/Indexer/Eav.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Mysql4/Indexer/Eav.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogIndex/Model/Mysql4/Indexer/Eav.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Mysql4/Indexer/Eav.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/Model/Mysql4/Indexer/Eav.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Mysql4/Indexer/Eav.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/Model/Mysql4/Indexer/Minimalprice.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Mysql4/Indexer/Minimalprice.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogIndex/Model/Mysql4/Indexer/Minimalprice.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Mysql4/Indexer/Minimalprice.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/Model/Mysql4/Indexer/Minimalprice.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Mysql4/Indexer/Minimalprice.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/Model/Mysql4/Indexer/Price.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Mysql4/Indexer/Price.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogIndex/Model/Mysql4/Indexer/Price.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Mysql4/Indexer/Price.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/Model/Mysql4/Indexer/Price.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Mysql4/Indexer/Price.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/Model/Mysql4/Price.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Mysql4/Price.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogIndex/Model/Mysql4/Price.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Mysql4/Price.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/Model/Mysql4/Price.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Mysql4/Price.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/Model/Mysql4/Retreiver.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Mysql4/Retreiver.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogIndex/Model/Mysql4/Retreiver.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Mysql4/Retreiver.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/Model/Mysql4/Retreiver.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Mysql4/Retreiver.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/Model/Mysql4/Setup.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Mysql4/Setup.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogIndex/Model/Mysql4/Setup.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Mysql4/Setup.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/Model/Mysql4/Setup.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Mysql4/Setup.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/Model/Observer.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Observer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogIndex/Model/Observer.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Observer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/Model/Observer.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Observer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/Model/Price.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Price.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogIndex/Model/Price.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Price.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/Model/Price.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Price.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/Model/Resource/Abstract.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Resource/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogIndex/Model/Resource/Abstract.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Resource/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/Model/Resource/Abstract.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Resource/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/Model/Resource/Aggregation.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Resource/Aggregation.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogIndex/Model/Resource/Aggregation.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Resource/Aggregation.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/Model/Resource/Aggregation.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Resource/Aggregation.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/Model/Resource/Attribute.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Resource/Attribute.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogIndex/Model/Resource/Attribute.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Resource/Attribute.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/Model/Resource/Attribute.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Resource/Attribute.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/Model/Resource/Data/Abstract.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Resource/Data/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogIndex/Model/Resource/Data/Abstract.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Resource/Data/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/Model/Resource/Data/Abstract.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Resource/Data/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/Model/Resource/Data/Configurable.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Resource/Data/Configurable.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogIndex/Model/Resource/Data/Configurable.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Resource/Data/Configurable.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/Model/Resource/Data/Configurable.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Resource/Data/Configurable.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/Model/Resource/Data/Grouped.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Resource/Data/Grouped.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogIndex/Model/Resource/Data/Grouped.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Resource/Data/Grouped.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/Model/Resource/Data/Grouped.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Resource/Data/Grouped.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/Model/Resource/Indexer.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Resource/Indexer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogIndex/Model/Resource/Indexer.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Resource/Indexer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/Model/Resource/Indexer.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Resource/Indexer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/Model/Resource/Indexer/Abstract.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Resource/Indexer/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogIndex/Model/Resource/Indexer/Abstract.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Resource/Indexer/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/Model/Resource/Indexer/Abstract.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Resource/Indexer/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/Model/Resource/Indexer/Eav.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Resource/Indexer/Eav.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogIndex/Model/Resource/Indexer/Eav.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Resource/Indexer/Eav.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/Model/Resource/Indexer/Eav.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Resource/Indexer/Eav.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/Model/Resource/Indexer/Minimalprice.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Resource/Indexer/Minimalprice.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogIndex/Model/Resource/Indexer/Minimalprice.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Resource/Indexer/Minimalprice.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/Model/Resource/Indexer/Minimalprice.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Resource/Indexer/Minimalprice.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/Model/Resource/Indexer/Price.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Resource/Indexer/Price.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogIndex/Model/Resource/Indexer/Price.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Resource/Indexer/Price.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/Model/Resource/Indexer/Price.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Resource/Indexer/Price.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/Model/Resource/Price.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Resource/Price.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogIndex/Model/Resource/Price.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Resource/Price.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/Model/Resource/Price.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Resource/Price.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/Model/Resource/Retreiver.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Resource/Retreiver.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogIndex/Model/Resource/Retreiver.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Resource/Retreiver.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/Model/Resource/Retreiver.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Resource/Retreiver.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/Model/Resource/Setup.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Resource/Setup.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogIndex/Model/Resource/Setup.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Resource/Setup.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/Model/Resource/Setup.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Resource/Setup.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/Model/Retreiver.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Retreiver.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogIndex/Model/Retreiver.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Retreiver.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/Model/Retreiver.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Retreiver.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/etc/config.xml
+++ b/app/code/core/Mage/CatalogIndex/etc/config.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/etc/config.xml
+++ b/app/code/core/Mage/CatalogIndex/etc/config.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/etc/config.xml
+++ b/app/code/core/Mage/CatalogIndex/etc/config.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogIndex/sql/catalogindex_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/CatalogIndex/sql/catalogindex_setup/install-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogIndex/sql/catalogindex_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/CatalogIndex/sql/catalogindex_setup/install-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/sql/catalogindex_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/CatalogIndex/sql/catalogindex_setup/install-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/sql/catalogindex_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/CatalogIndex/sql/catalogindex_setup/mysql4-install-0.7.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogIndex/sql/catalogindex_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/CatalogIndex/sql/catalogindex_setup/mysql4-install-0.7.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/sql/catalogindex_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/CatalogIndex/sql/catalogindex_setup/mysql4-install-0.7.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/sql/catalogindex_setup/mysql4-upgrade-0.7.0-0.7.1.php
+++ b/app/code/core/Mage/CatalogIndex/sql/catalogindex_setup/mysql4-upgrade-0.7.0-0.7.1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogIndex/sql/catalogindex_setup/mysql4-upgrade-0.7.0-0.7.1.php
+++ b/app/code/core/Mage/CatalogIndex/sql/catalogindex_setup/mysql4-upgrade-0.7.0-0.7.1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/sql/catalogindex_setup/mysql4-upgrade-0.7.0-0.7.1.php
+++ b/app/code/core/Mage/CatalogIndex/sql/catalogindex_setup/mysql4-upgrade-0.7.0-0.7.1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/sql/catalogindex_setup/mysql4-upgrade-0.7.1-0.7.2.php
+++ b/app/code/core/Mage/CatalogIndex/sql/catalogindex_setup/mysql4-upgrade-0.7.1-0.7.2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogIndex/sql/catalogindex_setup/mysql4-upgrade-0.7.1-0.7.2.php
+++ b/app/code/core/Mage/CatalogIndex/sql/catalogindex_setup/mysql4-upgrade-0.7.1-0.7.2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/sql/catalogindex_setup/mysql4-upgrade-0.7.1-0.7.2.php
+++ b/app/code/core/Mage/CatalogIndex/sql/catalogindex_setup/mysql4-upgrade-0.7.1-0.7.2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/sql/catalogindex_setup/mysql4-upgrade-0.7.2-0.7.3.php
+++ b/app/code/core/Mage/CatalogIndex/sql/catalogindex_setup/mysql4-upgrade-0.7.2-0.7.3.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogIndex/sql/catalogindex_setup/mysql4-upgrade-0.7.2-0.7.3.php
+++ b/app/code/core/Mage/CatalogIndex/sql/catalogindex_setup/mysql4-upgrade-0.7.2-0.7.3.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/sql/catalogindex_setup/mysql4-upgrade-0.7.2-0.7.3.php
+++ b/app/code/core/Mage/CatalogIndex/sql/catalogindex_setup/mysql4-upgrade-0.7.2-0.7.3.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/sql/catalogindex_setup/mysql4-upgrade-0.7.3-0.7.4.php
+++ b/app/code/core/Mage/CatalogIndex/sql/catalogindex_setup/mysql4-upgrade-0.7.3-0.7.4.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogIndex/sql/catalogindex_setup/mysql4-upgrade-0.7.3-0.7.4.php
+++ b/app/code/core/Mage/CatalogIndex/sql/catalogindex_setup/mysql4-upgrade-0.7.3-0.7.4.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/sql/catalogindex_setup/mysql4-upgrade-0.7.3-0.7.4.php
+++ b/app/code/core/Mage/CatalogIndex/sql/catalogindex_setup/mysql4-upgrade-0.7.3-0.7.4.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/sql/catalogindex_setup/mysql4-upgrade-0.7.4-0.7.5.php
+++ b/app/code/core/Mage/CatalogIndex/sql/catalogindex_setup/mysql4-upgrade-0.7.4-0.7.5.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogIndex/sql/catalogindex_setup/mysql4-upgrade-0.7.4-0.7.5.php
+++ b/app/code/core/Mage/CatalogIndex/sql/catalogindex_setup/mysql4-upgrade-0.7.4-0.7.5.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/sql/catalogindex_setup/mysql4-upgrade-0.7.4-0.7.5.php
+++ b/app/code/core/Mage/CatalogIndex/sql/catalogindex_setup/mysql4-upgrade-0.7.4-0.7.5.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/sql/catalogindex_setup/mysql4-upgrade-0.7.5-0.7.6.php
+++ b/app/code/core/Mage/CatalogIndex/sql/catalogindex_setup/mysql4-upgrade-0.7.5-0.7.6.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogIndex/sql/catalogindex_setup/mysql4-upgrade-0.7.5-0.7.6.php
+++ b/app/code/core/Mage/CatalogIndex/sql/catalogindex_setup/mysql4-upgrade-0.7.5-0.7.6.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/sql/catalogindex_setup/mysql4-upgrade-0.7.5-0.7.6.php
+++ b/app/code/core/Mage/CatalogIndex/sql/catalogindex_setup/mysql4-upgrade-0.7.5-0.7.6.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/sql/catalogindex_setup/mysql4-upgrade-0.7.6-0.7.7.php
+++ b/app/code/core/Mage/CatalogIndex/sql/catalogindex_setup/mysql4-upgrade-0.7.6-0.7.7.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogIndex/sql/catalogindex_setup/mysql4-upgrade-0.7.6-0.7.7.php
+++ b/app/code/core/Mage/CatalogIndex/sql/catalogindex_setup/mysql4-upgrade-0.7.6-0.7.7.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/sql/catalogindex_setup/mysql4-upgrade-0.7.6-0.7.7.php
+++ b/app/code/core/Mage/CatalogIndex/sql/catalogindex_setup/mysql4-upgrade-0.7.6-0.7.7.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/sql/catalogindex_setup/mysql4-upgrade-0.7.7-0.7.8.php
+++ b/app/code/core/Mage/CatalogIndex/sql/catalogindex_setup/mysql4-upgrade-0.7.7-0.7.8.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogIndex/sql/catalogindex_setup/mysql4-upgrade-0.7.7-0.7.8.php
+++ b/app/code/core/Mage/CatalogIndex/sql/catalogindex_setup/mysql4-upgrade-0.7.7-0.7.8.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/sql/catalogindex_setup/mysql4-upgrade-0.7.7-0.7.8.php
+++ b/app/code/core/Mage/CatalogIndex/sql/catalogindex_setup/mysql4-upgrade-0.7.7-0.7.8.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/sql/catalogindex_setup/mysql4-upgrade-0.7.8-0.7.9.php
+++ b/app/code/core/Mage/CatalogIndex/sql/catalogindex_setup/mysql4-upgrade-0.7.8-0.7.9.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogIndex/sql/catalogindex_setup/mysql4-upgrade-0.7.8-0.7.9.php
+++ b/app/code/core/Mage/CatalogIndex/sql/catalogindex_setup/mysql4-upgrade-0.7.8-0.7.9.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/sql/catalogindex_setup/mysql4-upgrade-0.7.8-0.7.9.php
+++ b/app/code/core/Mage/CatalogIndex/sql/catalogindex_setup/mysql4-upgrade-0.7.8-0.7.9.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/sql/catalogindex_setup/mysql4-upgrade-0.7.9-0.7.10.php
+++ b/app/code/core/Mage/CatalogIndex/sql/catalogindex_setup/mysql4-upgrade-0.7.9-0.7.10.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogIndex/sql/catalogindex_setup/mysql4-upgrade-0.7.9-0.7.10.php
+++ b/app/code/core/Mage/CatalogIndex/sql/catalogindex_setup/mysql4-upgrade-0.7.9-0.7.10.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/sql/catalogindex_setup/mysql4-upgrade-0.7.9-0.7.10.php
+++ b/app/code/core/Mage/CatalogIndex/sql/catalogindex_setup/mysql4-upgrade-0.7.9-0.7.10.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/sql/catalogindex_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/CatalogIndex/sql/catalogindex_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogIndex/sql/catalogindex_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/CatalogIndex/sql/catalogindex_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogIndex/sql/catalogindex_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/CatalogIndex/sql/catalogindex_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/code/core/Mage/CatalogInventory/Block/Adminhtml/Form/Field/Customergroup.php
+++ b/app/code/core/Mage/CatalogInventory/Block/Adminhtml/Form/Field/Customergroup.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogInventory/Block/Adminhtml/Form/Field/Customergroup.php
+++ b/app/code/core/Mage/CatalogInventory/Block/Adminhtml/Form/Field/Customergroup.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/Block/Adminhtml/Form/Field/Customergroup.php
+++ b/app/code/core/Mage/CatalogInventory/Block/Adminhtml/Form/Field/Customergroup.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/Block/Adminhtml/Form/Field/Minsaleqty.php
+++ b/app/code/core/Mage/CatalogInventory/Block/Adminhtml/Form/Field/Minsaleqty.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogInventory/Block/Adminhtml/Form/Field/Minsaleqty.php
+++ b/app/code/core/Mage/CatalogInventory/Block/Adminhtml/Form/Field/Minsaleqty.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/Block/Adminhtml/Form/Field/Minsaleqty.php
+++ b/app/code/core/Mage/CatalogInventory/Block/Adminhtml/Form/Field/Minsaleqty.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/Block/Qtyincrements.php
+++ b/app/code/core/Mage/CatalogInventory/Block/Qtyincrements.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogInventory/Block/Qtyincrements.php
+++ b/app/code/core/Mage/CatalogInventory/Block/Qtyincrements.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/Block/Qtyincrements.php
+++ b/app/code/core/Mage/CatalogInventory/Block/Qtyincrements.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/Block/Stockqty/Abstract.php
+++ b/app/code/core/Mage/CatalogInventory/Block/Stockqty/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogInventory/Block/Stockqty/Abstract.php
+++ b/app/code/core/Mage/CatalogInventory/Block/Stockqty/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/Block/Stockqty/Abstract.php
+++ b/app/code/core/Mage/CatalogInventory/Block/Stockqty/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/Block/Stockqty/Composite.php
+++ b/app/code/core/Mage/CatalogInventory/Block/Stockqty/Composite.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogInventory/Block/Stockqty/Composite.php
+++ b/app/code/core/Mage/CatalogInventory/Block/Stockqty/Composite.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/Block/Stockqty/Composite.php
+++ b/app/code/core/Mage/CatalogInventory/Block/Stockqty/Composite.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/Block/Stockqty/Default.php
+++ b/app/code/core/Mage/CatalogInventory/Block/Stockqty/Default.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogInventory/Block/Stockqty/Default.php
+++ b/app/code/core/Mage/CatalogInventory/Block/Stockqty/Default.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/Block/Stockqty/Default.php
+++ b/app/code/core/Mage/CatalogInventory/Block/Stockqty/Default.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/Block/Stockqty/Type/Configurable.php
+++ b/app/code/core/Mage/CatalogInventory/Block/Stockqty/Type/Configurable.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogInventory/Block/Stockqty/Type/Configurable.php
+++ b/app/code/core/Mage/CatalogInventory/Block/Stockqty/Type/Configurable.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/Block/Stockqty/Type/Configurable.php
+++ b/app/code/core/Mage/CatalogInventory/Block/Stockqty/Type/Configurable.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/Block/Stockqty/Type/Grouped.php
+++ b/app/code/core/Mage/CatalogInventory/Block/Stockqty/Type/Grouped.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogInventory/Block/Stockqty/Type/Grouped.php
+++ b/app/code/core/Mage/CatalogInventory/Block/Stockqty/Type/Grouped.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/Block/Stockqty/Type/Grouped.php
+++ b/app/code/core/Mage/CatalogInventory/Block/Stockqty/Type/Grouped.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/Helper/Data.php
+++ b/app/code/core/Mage/CatalogInventory/Helper/Data.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogInventory/Helper/Data.php
+++ b/app/code/core/Mage/CatalogInventory/Helper/Data.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/Helper/Data.php
+++ b/app/code/core/Mage/CatalogInventory/Helper/Data.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/Helper/Minsaleqty.php
+++ b/app/code/core/Mage/CatalogInventory/Helper/Minsaleqty.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogInventory/Helper/Minsaleqty.php
+++ b/app/code/core/Mage/CatalogInventory/Helper/Minsaleqty.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/Helper/Minsaleqty.php
+++ b/app/code/core/Mage/CatalogInventory/Helper/Minsaleqty.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/Model/Api2/Stock/Item.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Api2/Stock/Item.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogInventory/Model/Api2/Stock/Item.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Api2/Stock/Item.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/Model/Api2/Stock/Item.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Api2/Stock/Item.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/Model/Api2/Stock/Item/Rest.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Api2/Stock/Item/Rest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogInventory/Model/Api2/Stock/Item/Rest.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Api2/Stock/Item/Rest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/Model/Api2/Stock/Item/Rest.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Api2/Stock/Item/Rest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/Model/Api2/Stock/Item/Rest/Admin/V1.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Api2/Stock/Item/Rest/Admin/V1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogInventory/Model/Api2/Stock/Item/Rest/Admin/V1.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Api2/Stock/Item/Rest/Admin/V1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/Model/Api2/Stock/Item/Rest/Admin/V1.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Api2/Stock/Item/Rest/Admin/V1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/Model/Api2/Stock/Item/Validator/Item.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Api2/Stock/Item/Validator/Item.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogInventory/Model/Api2/Stock/Item/Validator/Item.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Api2/Stock/Item/Validator/Item.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/Model/Api2/Stock/Item/Validator/Item.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Api2/Stock/Item/Validator/Item.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/Model/Indexer/Stock.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Indexer/Stock.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogInventory/Model/Indexer/Stock.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Indexer/Stock.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/Model/Indexer/Stock.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Indexer/Stock.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/Model/Mysql4/Indexer/Stock.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Mysql4/Indexer/Stock.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogInventory/Model/Mysql4/Indexer/Stock.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Mysql4/Indexer/Stock.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/Model/Mysql4/Indexer/Stock.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Mysql4/Indexer/Stock.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/Model/Mysql4/Indexer/Stock/Configurable.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Mysql4/Indexer/Stock/Configurable.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogInventory/Model/Mysql4/Indexer/Stock/Configurable.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Mysql4/Indexer/Stock/Configurable.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/Model/Mysql4/Indexer/Stock/Configurable.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Mysql4/Indexer/Stock/Configurable.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/Model/Mysql4/Indexer/Stock/Default.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Mysql4/Indexer/Stock/Default.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogInventory/Model/Mysql4/Indexer/Stock/Default.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Mysql4/Indexer/Stock/Default.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/Model/Mysql4/Indexer/Stock/Default.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Mysql4/Indexer/Stock/Default.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/Model/Mysql4/Indexer/Stock/Grouped.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Mysql4/Indexer/Stock/Grouped.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogInventory/Model/Mysql4/Indexer/Stock/Grouped.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Mysql4/Indexer/Stock/Grouped.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/Model/Mysql4/Indexer/Stock/Grouped.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Mysql4/Indexer/Stock/Grouped.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/Model/Mysql4/Indexer/Stock/Interface.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Mysql4/Indexer/Stock/Interface.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogInventory/Model/Mysql4/Indexer/Stock/Interface.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Mysql4/Indexer/Stock/Interface.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/Model/Mysql4/Indexer/Stock/Interface.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Mysql4/Indexer/Stock/Interface.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/Model/Mysql4/Stock.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Mysql4/Stock.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogInventory/Model/Mysql4/Stock.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Mysql4/Stock.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/Model/Mysql4/Stock.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Mysql4/Stock.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/Model/Mysql4/Stock/Item.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Mysql4/Stock/Item.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogInventory/Model/Mysql4/Stock/Item.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Mysql4/Stock/Item.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/Model/Mysql4/Stock/Item.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Mysql4/Stock/Item.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/Model/Mysql4/Stock/Item/Collection.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Mysql4/Stock/Item/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogInventory/Model/Mysql4/Stock/Item/Collection.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Mysql4/Stock/Item/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/Model/Mysql4/Stock/Item/Collection.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Mysql4/Stock/Item/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/Model/Mysql4/Stock/Status.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Mysql4/Stock/Status.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogInventory/Model/Mysql4/Stock/Status.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Mysql4/Stock/Status.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/Model/Mysql4/Stock/Status.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Mysql4/Stock/Status.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/Model/Observer.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Observer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogInventory/Model/Observer.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Observer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/Model/Observer.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Observer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/Model/Resource/Indexer/Stock.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Resource/Indexer/Stock.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogInventory/Model/Resource/Indexer/Stock.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Resource/Indexer/Stock.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/Model/Resource/Indexer/Stock.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Resource/Indexer/Stock.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/Model/Resource/Indexer/Stock/Configurable.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Resource/Indexer/Stock/Configurable.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogInventory/Model/Resource/Indexer/Stock/Configurable.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Resource/Indexer/Stock/Configurable.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/Model/Resource/Indexer/Stock/Configurable.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Resource/Indexer/Stock/Configurable.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/Model/Resource/Indexer/Stock/Default.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Resource/Indexer/Stock/Default.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogInventory/Model/Resource/Indexer/Stock/Default.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Resource/Indexer/Stock/Default.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/Model/Resource/Indexer/Stock/Default.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Resource/Indexer/Stock/Default.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/Model/Resource/Indexer/Stock/Grouped.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Resource/Indexer/Stock/Grouped.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogInventory/Model/Resource/Indexer/Stock/Grouped.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Resource/Indexer/Stock/Grouped.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/Model/Resource/Indexer/Stock/Grouped.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Resource/Indexer/Stock/Grouped.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/Model/Resource/Indexer/Stock/Interface.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Resource/Indexer/Stock/Interface.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogInventory/Model/Resource/Indexer/Stock/Interface.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Resource/Indexer/Stock/Interface.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/Model/Resource/Indexer/Stock/Interface.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Resource/Indexer/Stock/Interface.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/Model/Resource/Stock.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Resource/Stock.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogInventory/Model/Resource/Stock.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Resource/Stock.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/Model/Resource/Stock.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Resource/Stock.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/Model/Resource/Stock/Item.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Resource/Stock/Item.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogInventory/Model/Resource/Stock/Item.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Resource/Stock/Item.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/Model/Resource/Stock/Item.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Resource/Stock/Item.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/Model/Resource/Stock/Item/Collection.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Resource/Stock/Item/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogInventory/Model/Resource/Stock/Item/Collection.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Resource/Stock/Item/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/Model/Resource/Stock/Item/Collection.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Resource/Stock/Item/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/Model/Resource/Stock/Status.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Resource/Stock/Status.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogInventory/Model/Resource/Stock/Status.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Resource/Stock/Status.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/Model/Resource/Stock/Status.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Resource/Stock/Status.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/Model/Source/Backorders.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Source/Backorders.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogInventory/Model/Source/Backorders.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Source/Backorders.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/Model/Source/Backorders.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Source/Backorders.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/Model/Source/Stock.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Source/Stock.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogInventory/Model/Source/Stock.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Source/Stock.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/Model/Source/Stock.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Source/Stock.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/Model/Stock.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Stock.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogInventory/Model/Stock.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Stock.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/Model/Stock.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Stock.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/Model/Stock/Item.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Stock/Item.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogInventory/Model/Stock/Item.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Stock/Item.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/Model/Stock/Item.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Stock/Item.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/Model/Stock/Item/Api.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Stock/Item/Api.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogInventory/Model/Stock/Item/Api.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Stock/Item/Api.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/Model/Stock/Item/Api.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Stock/Item/Api.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/Model/Stock/Item/Api/V2.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Stock/Item/Api/V2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogInventory/Model/Stock/Item/Api/V2.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Stock/Item/Api/V2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/Model/Stock/Item/Api/V2.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Stock/Item/Api/V2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/Model/Stock/Status.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Stock/Status.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogInventory/Model/Stock/Status.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Stock/Status.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/Model/Stock/Status.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Stock/Status.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/Model/System/Config/Backend/Minqty.php
+++ b/app/code/core/Mage/CatalogInventory/Model/System/Config/Backend/Minqty.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogInventory/Model/System/Config/Backend/Minqty.php
+++ b/app/code/core/Mage/CatalogInventory/Model/System/Config/Backend/Minqty.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/Model/System/Config/Backend/Minqty.php
+++ b/app/code/core/Mage/CatalogInventory/Model/System/Config/Backend/Minqty.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/Model/System/Config/Backend/Minsaleqty.php
+++ b/app/code/core/Mage/CatalogInventory/Model/System/Config/Backend/Minsaleqty.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogInventory/Model/System/Config/Backend/Minsaleqty.php
+++ b/app/code/core/Mage/CatalogInventory/Model/System/Config/Backend/Minsaleqty.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/Model/System/Config/Backend/Minsaleqty.php
+++ b/app/code/core/Mage/CatalogInventory/Model/System/Config/Backend/Minsaleqty.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/Model/System/Config/Backend/Qtyincrements.php
+++ b/app/code/core/Mage/CatalogInventory/Model/System/Config/Backend/Qtyincrements.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogInventory/Model/System/Config/Backend/Qtyincrements.php
+++ b/app/code/core/Mage/CatalogInventory/Model/System/Config/Backend/Qtyincrements.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/Model/System/Config/Backend/Qtyincrements.php
+++ b/app/code/core/Mage/CatalogInventory/Model/System/Config/Backend/Qtyincrements.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/etc/adminhtml.xml
+++ b/app/code/core/Mage/CatalogInventory/etc/adminhtml.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/etc/adminhtml.xml
+++ b/app/code/core/Mage/CatalogInventory/etc/adminhtml.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/etc/adminhtml.xml
+++ b/app/code/core/Mage/CatalogInventory/etc/adminhtml.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogInventory/etc/api.xml
+++ b/app/code/core/Mage/CatalogInventory/etc/api.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/etc/api.xml
+++ b/app/code/core/Mage/CatalogInventory/etc/api.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/etc/api.xml
+++ b/app/code/core/Mage/CatalogInventory/etc/api.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogInventory/etc/api2.xml
+++ b/app/code/core/Mage/CatalogInventory/etc/api2.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/etc/api2.xml
+++ b/app/code/core/Mage/CatalogInventory/etc/api2.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/etc/api2.xml
+++ b/app/code/core/Mage/CatalogInventory/etc/api2.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogInventory/etc/config.xml
+++ b/app/code/core/Mage/CatalogInventory/etc/config.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/etc/config.xml
+++ b/app/code/core/Mage/CatalogInventory/etc/config.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/etc/config.xml
+++ b/app/code/core/Mage/CatalogInventory/etc/config.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogInventory/etc/system.xml
+++ b/app/code/core/Mage/CatalogInventory/etc/system.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/etc/system.xml
+++ b/app/code/core/Mage/CatalogInventory/etc/system.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/etc/system.xml
+++ b/app/code/core/Mage/CatalogInventory/etc/system.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogInventory/sql/cataloginventory_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/CatalogInventory/sql/cataloginventory_setup/install-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogInventory/sql/cataloginventory_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/CatalogInventory/sql/cataloginventory_setup/install-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/sql/cataloginventory_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/CatalogInventory/sql/cataloginventory_setup/install-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/sql/cataloginventory_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/CatalogInventory/sql/cataloginventory_setup/mysql4-install-0.7.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogInventory/sql/cataloginventory_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/CatalogInventory/sql/cataloginventory_setup/mysql4-install-0.7.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/sql/cataloginventory_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/CatalogInventory/sql/cataloginventory_setup/mysql4-install-0.7.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/sql/cataloginventory_setup/mysql4-upgrade-0.7.0-0.7.1.php
+++ b/app/code/core/Mage/CatalogInventory/sql/cataloginventory_setup/mysql4-upgrade-0.7.0-0.7.1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogInventory/sql/cataloginventory_setup/mysql4-upgrade-0.7.0-0.7.1.php
+++ b/app/code/core/Mage/CatalogInventory/sql/cataloginventory_setup/mysql4-upgrade-0.7.0-0.7.1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/sql/cataloginventory_setup/mysql4-upgrade-0.7.0-0.7.1.php
+++ b/app/code/core/Mage/CatalogInventory/sql/cataloginventory_setup/mysql4-upgrade-0.7.0-0.7.1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/sql/cataloginventory_setup/mysql4-upgrade-0.7.1-0.7.2.php
+++ b/app/code/core/Mage/CatalogInventory/sql/cataloginventory_setup/mysql4-upgrade-0.7.1-0.7.2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogInventory/sql/cataloginventory_setup/mysql4-upgrade-0.7.1-0.7.2.php
+++ b/app/code/core/Mage/CatalogInventory/sql/cataloginventory_setup/mysql4-upgrade-0.7.1-0.7.2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/sql/cataloginventory_setup/mysql4-upgrade-0.7.1-0.7.2.php
+++ b/app/code/core/Mage/CatalogInventory/sql/cataloginventory_setup/mysql4-upgrade-0.7.1-0.7.2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/sql/cataloginventory_setup/mysql4-upgrade-0.7.2-0.7.3.php
+++ b/app/code/core/Mage/CatalogInventory/sql/cataloginventory_setup/mysql4-upgrade-0.7.2-0.7.3.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogInventory/sql/cataloginventory_setup/mysql4-upgrade-0.7.2-0.7.3.php
+++ b/app/code/core/Mage/CatalogInventory/sql/cataloginventory_setup/mysql4-upgrade-0.7.2-0.7.3.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/sql/cataloginventory_setup/mysql4-upgrade-0.7.2-0.7.3.php
+++ b/app/code/core/Mage/CatalogInventory/sql/cataloginventory_setup/mysql4-upgrade-0.7.2-0.7.3.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/sql/cataloginventory_setup/mysql4-upgrade-0.7.3-0.7.4.php
+++ b/app/code/core/Mage/CatalogInventory/sql/cataloginventory_setup/mysql4-upgrade-0.7.3-0.7.4.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogInventory/sql/cataloginventory_setup/mysql4-upgrade-0.7.3-0.7.4.php
+++ b/app/code/core/Mage/CatalogInventory/sql/cataloginventory_setup/mysql4-upgrade-0.7.3-0.7.4.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/sql/cataloginventory_setup/mysql4-upgrade-0.7.3-0.7.4.php
+++ b/app/code/core/Mage/CatalogInventory/sql/cataloginventory_setup/mysql4-upgrade-0.7.3-0.7.4.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/sql/cataloginventory_setup/mysql4-upgrade-0.7.4-0.7.5.php
+++ b/app/code/core/Mage/CatalogInventory/sql/cataloginventory_setup/mysql4-upgrade-0.7.4-0.7.5.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogInventory/sql/cataloginventory_setup/mysql4-upgrade-0.7.4-0.7.5.php
+++ b/app/code/core/Mage/CatalogInventory/sql/cataloginventory_setup/mysql4-upgrade-0.7.4-0.7.5.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/sql/cataloginventory_setup/mysql4-upgrade-0.7.4-0.7.5.php
+++ b/app/code/core/Mage/CatalogInventory/sql/cataloginventory_setup/mysql4-upgrade-0.7.4-0.7.5.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/sql/cataloginventory_setup/mysql4-upgrade-0.7.5-0.7.6.php
+++ b/app/code/core/Mage/CatalogInventory/sql/cataloginventory_setup/mysql4-upgrade-0.7.5-0.7.6.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogInventory/sql/cataloginventory_setup/mysql4-upgrade-0.7.5-0.7.6.php
+++ b/app/code/core/Mage/CatalogInventory/sql/cataloginventory_setup/mysql4-upgrade-0.7.5-0.7.6.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/sql/cataloginventory_setup/mysql4-upgrade-0.7.5-0.7.6.php
+++ b/app/code/core/Mage/CatalogInventory/sql/cataloginventory_setup/mysql4-upgrade-0.7.5-0.7.6.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/sql/cataloginventory_setup/mysql4-upgrade-0.7.6-0.7.7.php
+++ b/app/code/core/Mage/CatalogInventory/sql/cataloginventory_setup/mysql4-upgrade-0.7.6-0.7.7.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogInventory/sql/cataloginventory_setup/mysql4-upgrade-0.7.6-0.7.7.php
+++ b/app/code/core/Mage/CatalogInventory/sql/cataloginventory_setup/mysql4-upgrade-0.7.6-0.7.7.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/sql/cataloginventory_setup/mysql4-upgrade-0.7.6-0.7.7.php
+++ b/app/code/core/Mage/CatalogInventory/sql/cataloginventory_setup/mysql4-upgrade-0.7.6-0.7.7.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/sql/cataloginventory_setup/mysql4-upgrade-0.7.7-0.7.8.php
+++ b/app/code/core/Mage/CatalogInventory/sql/cataloginventory_setup/mysql4-upgrade-0.7.7-0.7.8.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogInventory/sql/cataloginventory_setup/mysql4-upgrade-0.7.7-0.7.8.php
+++ b/app/code/core/Mage/CatalogInventory/sql/cataloginventory_setup/mysql4-upgrade-0.7.7-0.7.8.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/sql/cataloginventory_setup/mysql4-upgrade-0.7.7-0.7.8.php
+++ b/app/code/core/Mage/CatalogInventory/sql/cataloginventory_setup/mysql4-upgrade-0.7.7-0.7.8.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/sql/cataloginventory_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/CatalogInventory/sql/cataloginventory_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogInventory/sql/cataloginventory_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/CatalogInventory/sql/cataloginventory_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/sql/cataloginventory_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/CatalogInventory/sql/cataloginventory_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/sql/cataloginventory_setup/mysql4-upgrade-1.6.0.0-1.6.0.0.1.php
+++ b/app/code/core/Mage/CatalogInventory/sql/cataloginventory_setup/mysql4-upgrade-1.6.0.0-1.6.0.0.1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogInventory/sql/cataloginventory_setup/mysql4-upgrade-1.6.0.0-1.6.0.0.1.php
+++ b/app/code/core/Mage/CatalogInventory/sql/cataloginventory_setup/mysql4-upgrade-1.6.0.0-1.6.0.0.1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/sql/cataloginventory_setup/mysql4-upgrade-1.6.0.0-1.6.0.0.1.php
+++ b/app/code/core/Mage/CatalogInventory/sql/cataloginventory_setup/mysql4-upgrade-1.6.0.0-1.6.0.0.1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/sql/cataloginventory_setup/upgrade-1.6.0.0.1-1.6.0.0.2.php
+++ b/app/code/core/Mage/CatalogInventory/sql/cataloginventory_setup/upgrade-1.6.0.0.1-1.6.0.0.2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogInventory/sql/cataloginventory_setup/upgrade-1.6.0.0.1-1.6.0.0.2.php
+++ b/app/code/core/Mage/CatalogInventory/sql/cataloginventory_setup/upgrade-1.6.0.0.1-1.6.0.0.2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogInventory/sql/cataloginventory_setup/upgrade-1.6.0.0.1-1.6.0.0.2.php
+++ b/app/code/core/Mage/CatalogInventory/sql/cataloginventory_setup/upgrade-1.6.0.0.1-1.6.0.0.2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/code/core/Mage/CatalogRule/Helper/Data.php
+++ b/app/code/core/Mage/CatalogRule/Helper/Data.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogRule

--- a/app/code/core/Mage/CatalogRule/Helper/Data.php
+++ b/app/code/core/Mage/CatalogRule/Helper/Data.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogRule/Helper/Data.php
+++ b/app/code/core/Mage/CatalogRule/Helper/Data.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogRule

--- a/app/code/core/Mage/CatalogRule/Model/Action/Index/Refresh.php
+++ b/app/code/core/Mage/CatalogRule/Model/Action/Index/Refresh.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogRule

--- a/app/code/core/Mage/CatalogRule/Model/Action/Index/Refresh.php
+++ b/app/code/core/Mage/CatalogRule/Model/Action/Index/Refresh.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogRule/Model/Action/Index/Refresh.php
+++ b/app/code/core/Mage/CatalogRule/Model/Action/Index/Refresh.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogRule

--- a/app/code/core/Mage/CatalogRule/Model/Action/Index/Refresh/Row.php
+++ b/app/code/core/Mage/CatalogRule/Model/Action/Index/Refresh/Row.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogRule

--- a/app/code/core/Mage/CatalogRule/Model/Action/Index/Refresh/Row.php
+++ b/app/code/core/Mage/CatalogRule/Model/Action/Index/Refresh/Row.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogRule/Model/Action/Index/Refresh/Row.php
+++ b/app/code/core/Mage/CatalogRule/Model/Action/Index/Refresh/Row.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogRule

--- a/app/code/core/Mage/CatalogRule/Model/Flag.php
+++ b/app/code/core/Mage/CatalogRule/Model/Flag.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogRule

--- a/app/code/core/Mage/CatalogRule/Model/Flag.php
+++ b/app/code/core/Mage/CatalogRule/Model/Flag.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogRule/Model/Flag.php
+++ b/app/code/core/Mage/CatalogRule/Model/Flag.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogRule

--- a/app/code/core/Mage/CatalogRule/Model/Mysql4/Rule.php
+++ b/app/code/core/Mage/CatalogRule/Model/Mysql4/Rule.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogRule

--- a/app/code/core/Mage/CatalogRule/Model/Mysql4/Rule.php
+++ b/app/code/core/Mage/CatalogRule/Model/Mysql4/Rule.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogRule/Model/Mysql4/Rule.php
+++ b/app/code/core/Mage/CatalogRule/Model/Mysql4/Rule.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogRule

--- a/app/code/core/Mage/CatalogRule/Model/Mysql4/Rule/Collection.php
+++ b/app/code/core/Mage/CatalogRule/Model/Mysql4/Rule/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogRule

--- a/app/code/core/Mage/CatalogRule/Model/Mysql4/Rule/Collection.php
+++ b/app/code/core/Mage/CatalogRule/Model/Mysql4/Rule/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogRule/Model/Mysql4/Rule/Collection.php
+++ b/app/code/core/Mage/CatalogRule/Model/Mysql4/Rule/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogRule

--- a/app/code/core/Mage/CatalogRule/Model/Mysql4/Rule/Product/Price.php
+++ b/app/code/core/Mage/CatalogRule/Model/Mysql4/Rule/Product/Price.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogRule

--- a/app/code/core/Mage/CatalogRule/Model/Mysql4/Rule/Product/Price.php
+++ b/app/code/core/Mage/CatalogRule/Model/Mysql4/Rule/Product/Price.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogRule/Model/Mysql4/Rule/Product/Price.php
+++ b/app/code/core/Mage/CatalogRule/Model/Mysql4/Rule/Product/Price.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogRule

--- a/app/code/core/Mage/CatalogRule/Model/Mysql4/Rule/Product/Price/Collection.php
+++ b/app/code/core/Mage/CatalogRule/Model/Mysql4/Rule/Product/Price/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogRule

--- a/app/code/core/Mage/CatalogRule/Model/Mysql4/Rule/Product/Price/Collection.php
+++ b/app/code/core/Mage/CatalogRule/Model/Mysql4/Rule/Product/Price/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogRule/Model/Mysql4/Rule/Product/Price/Collection.php
+++ b/app/code/core/Mage/CatalogRule/Model/Mysql4/Rule/Product/Price/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogRule

--- a/app/code/core/Mage/CatalogRule/Model/Observer.php
+++ b/app/code/core/Mage/CatalogRule/Model/Observer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogRule

--- a/app/code/core/Mage/CatalogRule/Model/Observer.php
+++ b/app/code/core/Mage/CatalogRule/Model/Observer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogRule/Model/Observer.php
+++ b/app/code/core/Mage/CatalogRule/Model/Observer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogRule

--- a/app/code/core/Mage/CatalogRule/Model/Resource/Rule.php
+++ b/app/code/core/Mage/CatalogRule/Model/Resource/Rule.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogRule

--- a/app/code/core/Mage/CatalogRule/Model/Resource/Rule.php
+++ b/app/code/core/Mage/CatalogRule/Model/Resource/Rule.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogRule/Model/Resource/Rule.php
+++ b/app/code/core/Mage/CatalogRule/Model/Resource/Rule.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogRule

--- a/app/code/core/Mage/CatalogRule/Model/Resource/Rule/Collection.php
+++ b/app/code/core/Mage/CatalogRule/Model/Resource/Rule/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogRule

--- a/app/code/core/Mage/CatalogRule/Model/Resource/Rule/Collection.php
+++ b/app/code/core/Mage/CatalogRule/Model/Resource/Rule/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogRule/Model/Resource/Rule/Collection.php
+++ b/app/code/core/Mage/CatalogRule/Model/Resource/Rule/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogRule

--- a/app/code/core/Mage/CatalogRule/Model/Resource/Rule/Product/Price.php
+++ b/app/code/core/Mage/CatalogRule/Model/Resource/Rule/Product/Price.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogRule

--- a/app/code/core/Mage/CatalogRule/Model/Resource/Rule/Product/Price.php
+++ b/app/code/core/Mage/CatalogRule/Model/Resource/Rule/Product/Price.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogRule/Model/Resource/Rule/Product/Price.php
+++ b/app/code/core/Mage/CatalogRule/Model/Resource/Rule/Product/Price.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogRule

--- a/app/code/core/Mage/CatalogRule/Model/Resource/Rule/Product/Price/Collection.php
+++ b/app/code/core/Mage/CatalogRule/Model/Resource/Rule/Product/Price/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogRule

--- a/app/code/core/Mage/CatalogRule/Model/Resource/Rule/Product/Price/Collection.php
+++ b/app/code/core/Mage/CatalogRule/Model/Resource/Rule/Product/Price/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogRule/Model/Resource/Rule/Product/Price/Collection.php
+++ b/app/code/core/Mage/CatalogRule/Model/Resource/Rule/Product/Price/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogRule

--- a/app/code/core/Mage/CatalogRule/Model/Rule.php
+++ b/app/code/core/Mage/CatalogRule/Model/Rule.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogRule

--- a/app/code/core/Mage/CatalogRule/Model/Rule.php
+++ b/app/code/core/Mage/CatalogRule/Model/Rule.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogRule/Model/Rule.php
+++ b/app/code/core/Mage/CatalogRule/Model/Rule.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogRule

--- a/app/code/core/Mage/CatalogRule/Model/Rule/Action/Collection.php
+++ b/app/code/core/Mage/CatalogRule/Model/Rule/Action/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogRule

--- a/app/code/core/Mage/CatalogRule/Model/Rule/Action/Collection.php
+++ b/app/code/core/Mage/CatalogRule/Model/Rule/Action/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogRule/Model/Rule/Action/Collection.php
+++ b/app/code/core/Mage/CatalogRule/Model/Rule/Action/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogRule

--- a/app/code/core/Mage/CatalogRule/Model/Rule/Action/Product.php
+++ b/app/code/core/Mage/CatalogRule/Model/Rule/Action/Product.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogRule

--- a/app/code/core/Mage/CatalogRule/Model/Rule/Action/Product.php
+++ b/app/code/core/Mage/CatalogRule/Model/Rule/Action/Product.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogRule/Model/Rule/Action/Product.php
+++ b/app/code/core/Mage/CatalogRule/Model/Rule/Action/Product.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogRule

--- a/app/code/core/Mage/CatalogRule/Model/Rule/Condition/Combine.php
+++ b/app/code/core/Mage/CatalogRule/Model/Rule/Condition/Combine.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogRule

--- a/app/code/core/Mage/CatalogRule/Model/Rule/Condition/Combine.php
+++ b/app/code/core/Mage/CatalogRule/Model/Rule/Condition/Combine.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogRule/Model/Rule/Condition/Combine.php
+++ b/app/code/core/Mage/CatalogRule/Model/Rule/Condition/Combine.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogRule

--- a/app/code/core/Mage/CatalogRule/Model/Rule/Condition/Product.php
+++ b/app/code/core/Mage/CatalogRule/Model/Rule/Condition/Product.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogRule

--- a/app/code/core/Mage/CatalogRule/Model/Rule/Condition/Product.php
+++ b/app/code/core/Mage/CatalogRule/Model/Rule/Condition/Product.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogRule/Model/Rule/Condition/Product.php
+++ b/app/code/core/Mage/CatalogRule/Model/Rule/Condition/Product.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogRule

--- a/app/code/core/Mage/CatalogRule/Model/Rule/Product/Price.php
+++ b/app/code/core/Mage/CatalogRule/Model/Rule/Product/Price.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogRule

--- a/app/code/core/Mage/CatalogRule/Model/Rule/Product/Price.php
+++ b/app/code/core/Mage/CatalogRule/Model/Rule/Product/Price.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogRule/Model/Rule/Product/Price.php
+++ b/app/code/core/Mage/CatalogRule/Model/Rule/Product/Price.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogRule

--- a/app/code/core/Mage/CatalogRule/etc/adminhtml.xml
+++ b/app/code/core/Mage/CatalogRule/etc/adminhtml.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogRule

--- a/app/code/core/Mage/CatalogRule/etc/adminhtml.xml
+++ b/app/code/core/Mage/CatalogRule/etc/adminhtml.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogRule

--- a/app/code/core/Mage/CatalogRule/etc/adminhtml.xml
+++ b/app/code/core/Mage/CatalogRule/etc/adminhtml.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogRule/etc/config.xml
+++ b/app/code/core/Mage/CatalogRule/etc/config.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogRule

--- a/app/code/core/Mage/CatalogRule/etc/config.xml
+++ b/app/code/core/Mage/CatalogRule/etc/config.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogRule

--- a/app/code/core/Mage/CatalogRule/etc/config.xml
+++ b/app/code/core/Mage/CatalogRule/etc/config.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/install-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogRule

--- a/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/install-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/install-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogRule

--- a/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/mysql4-install-0.7.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogRule

--- a/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/mysql4-install-0.7.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/mysql4-install-0.7.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogRule

--- a/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/mysql4-upgrade-0.7.0-0.7.1.php
+++ b/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/mysql4-upgrade-0.7.0-0.7.1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogRule

--- a/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/mysql4-upgrade-0.7.0-0.7.1.php
+++ b/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/mysql4-upgrade-0.7.0-0.7.1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/mysql4-upgrade-0.7.0-0.7.1.php
+++ b/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/mysql4-upgrade-0.7.0-0.7.1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogRule

--- a/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/mysql4-upgrade-0.7.1-0.7.2.php
+++ b/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/mysql4-upgrade-0.7.1-0.7.2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogRule

--- a/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/mysql4-upgrade-0.7.1-0.7.2.php
+++ b/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/mysql4-upgrade-0.7.1-0.7.2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/mysql4-upgrade-0.7.1-0.7.2.php
+++ b/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/mysql4-upgrade-0.7.1-0.7.2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogRule

--- a/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/mysql4-upgrade-0.7.2-0.7.3.php
+++ b/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/mysql4-upgrade-0.7.2-0.7.3.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogRule

--- a/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/mysql4-upgrade-0.7.2-0.7.3.php
+++ b/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/mysql4-upgrade-0.7.2-0.7.3.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/mysql4-upgrade-0.7.2-0.7.3.php
+++ b/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/mysql4-upgrade-0.7.2-0.7.3.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogRule

--- a/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/mysql4-upgrade-0.7.3-0.7.4.php
+++ b/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/mysql4-upgrade-0.7.3-0.7.4.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogRule

--- a/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/mysql4-upgrade-0.7.3-0.7.4.php
+++ b/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/mysql4-upgrade-0.7.3-0.7.4.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/mysql4-upgrade-0.7.3-0.7.4.php
+++ b/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/mysql4-upgrade-0.7.3-0.7.4.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogRule

--- a/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/mysql4-upgrade-0.7.4-0.7.5.php
+++ b/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/mysql4-upgrade-0.7.4-0.7.5.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogRule

--- a/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/mysql4-upgrade-0.7.4-0.7.5.php
+++ b/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/mysql4-upgrade-0.7.4-0.7.5.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/mysql4-upgrade-0.7.4-0.7.5.php
+++ b/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/mysql4-upgrade-0.7.4-0.7.5.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogRule

--- a/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/mysql4-upgrade-0.7.5-0.7.6.php
+++ b/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/mysql4-upgrade-0.7.5-0.7.6.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogRule

--- a/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/mysql4-upgrade-0.7.5-0.7.6.php
+++ b/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/mysql4-upgrade-0.7.5-0.7.6.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/mysql4-upgrade-0.7.5-0.7.6.php
+++ b/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/mysql4-upgrade-0.7.5-0.7.6.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogRule

--- a/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/mysql4-upgrade-0.7.6-0.7.7.php
+++ b/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/mysql4-upgrade-0.7.6-0.7.7.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogRule

--- a/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/mysql4-upgrade-0.7.6-0.7.7.php
+++ b/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/mysql4-upgrade-0.7.6-0.7.7.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/mysql4-upgrade-0.7.6-0.7.7.php
+++ b/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/mysql4-upgrade-0.7.6-0.7.7.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogRule

--- a/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/mysql4-upgrade-0.7.7-0.7.8.php
+++ b/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/mysql4-upgrade-0.7.7-0.7.8.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogRule

--- a/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/mysql4-upgrade-0.7.7-0.7.8.php
+++ b/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/mysql4-upgrade-0.7.7-0.7.8.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/mysql4-upgrade-0.7.7-0.7.8.php
+++ b/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/mysql4-upgrade-0.7.7-0.7.8.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogRule

--- a/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/mysql4-upgrade-0.7.8-0.7.9.php
+++ b/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/mysql4-upgrade-0.7.8-0.7.9.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogRule

--- a/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/mysql4-upgrade-0.7.8-0.7.9.php
+++ b/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/mysql4-upgrade-0.7.8-0.7.9.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/mysql4-upgrade-0.7.8-0.7.9.php
+++ b/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/mysql4-upgrade-0.7.8-0.7.9.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogRule

--- a/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/mysql4-upgrade-0.7.9-0.7.10.php
+++ b/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/mysql4-upgrade-0.7.9-0.7.10.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogRule

--- a/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/mysql4-upgrade-0.7.9-0.7.10.php
+++ b/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/mysql4-upgrade-0.7.9-0.7.10.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/mysql4-upgrade-0.7.9-0.7.10.php
+++ b/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/mysql4-upgrade-0.7.9-0.7.10.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogRule

--- a/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogRule

--- a/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogRule

--- a/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/upgrade-1.6.0.0-1.6.0.1.php
+++ b/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/upgrade-1.6.0.0-1.6.0.1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogRule

--- a/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/upgrade-1.6.0.0-1.6.0.1.php
+++ b/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/upgrade-1.6.0.0-1.6.0.1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/upgrade-1.6.0.0-1.6.0.1.php
+++ b/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/upgrade-1.6.0.0-1.6.0.1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogRule

--- a/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/upgrade-1.6.0.1-1.6.0.2.php
+++ b/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/upgrade-1.6.0.1-1.6.0.2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogRule

--- a/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/upgrade-1.6.0.1-1.6.0.2.php
+++ b/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/upgrade-1.6.0.1-1.6.0.2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/upgrade-1.6.0.1-1.6.0.2.php
+++ b/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/upgrade-1.6.0.1-1.6.0.2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogRule

--- a/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/upgrade-1.6.0.2-1.6.0.3.php
+++ b/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/upgrade-1.6.0.2-1.6.0.3.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogRule

--- a/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/upgrade-1.6.0.2-1.6.0.3.php
+++ b/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/upgrade-1.6.0.2-1.6.0.3.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/upgrade-1.6.0.2-1.6.0.3.php
+++ b/app/code/core/Mage/CatalogRule/sql/catalogrule_setup/upgrade-1.6.0.2-1.6.0.3.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogRule

--- a/app/code/core/Mage/CatalogSearch/Block/Advanced/Form.php
+++ b/app/code/core/Mage/CatalogSearch/Block/Advanced/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogSearch/Block/Advanced/Form.php
+++ b/app/code/core/Mage/CatalogSearch/Block/Advanced/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/Block/Advanced/Form.php
+++ b/app/code/core/Mage/CatalogSearch/Block/Advanced/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/Block/Advanced/Result.php
+++ b/app/code/core/Mage/CatalogSearch/Block/Advanced/Result.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogSearch/Block/Advanced/Result.php
+++ b/app/code/core/Mage/CatalogSearch/Block/Advanced/Result.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/Block/Advanced/Result.php
+++ b/app/code/core/Mage/CatalogSearch/Block/Advanced/Result.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/Block/Autocomplete.php
+++ b/app/code/core/Mage/CatalogSearch/Block/Autocomplete.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogSearch/Block/Autocomplete.php
+++ b/app/code/core/Mage/CatalogSearch/Block/Autocomplete.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/Block/Autocomplete.php
+++ b/app/code/core/Mage/CatalogSearch/Block/Autocomplete.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/Block/Layer.php
+++ b/app/code/core/Mage/CatalogSearch/Block/Layer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogSearch/Block/Layer.php
+++ b/app/code/core/Mage/CatalogSearch/Block/Layer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/Block/Layer.php
+++ b/app/code/core/Mage/CatalogSearch/Block/Layer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/Block/Layer/Filter/Attribute.php
+++ b/app/code/core/Mage/CatalogSearch/Block/Layer/Filter/Attribute.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogSearch/Block/Layer/Filter/Attribute.php
+++ b/app/code/core/Mage/CatalogSearch/Block/Layer/Filter/Attribute.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/Block/Layer/Filter/Attribute.php
+++ b/app/code/core/Mage/CatalogSearch/Block/Layer/Filter/Attribute.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/Block/Result.php
+++ b/app/code/core/Mage/CatalogSearch/Block/Result.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogSearch/Block/Result.php
+++ b/app/code/core/Mage/CatalogSearch/Block/Result.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/Block/Result.php
+++ b/app/code/core/Mage/CatalogSearch/Block/Result.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/Block/Term.php
+++ b/app/code/core/Mage/CatalogSearch/Block/Term.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogSearch/Block/Term.php
+++ b/app/code/core/Mage/CatalogSearch/Block/Term.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/Block/Term.php
+++ b/app/code/core/Mage/CatalogSearch/Block/Term.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/Helper/Data.php
+++ b/app/code/core/Mage/CatalogSearch/Helper/Data.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogSearch/Helper/Data.php
+++ b/app/code/core/Mage/CatalogSearch/Helper/Data.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/Helper/Data.php
+++ b/app/code/core/Mage/CatalogSearch/Helper/Data.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/Model/Advanced.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Advanced.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogSearch/Model/Advanced.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Advanced.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/Model/Advanced.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Advanced.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/Model/Fulltext.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Fulltext.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogSearch/Model/Fulltext.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Fulltext.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/Model/Fulltext.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Fulltext.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/Model/Fulltext/Observer.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Fulltext/Observer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogSearch/Model/Fulltext/Observer.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Fulltext/Observer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/Model/Fulltext/Observer.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Fulltext/Observer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/Model/Indexer/Fulltext.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Indexer/Fulltext.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogSearch/Model/Indexer/Fulltext.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Indexer/Fulltext.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/Model/Indexer/Fulltext.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Indexer/Fulltext.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/Model/Layer.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Layer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogSearch/Model/Layer.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Layer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/Model/Layer.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Layer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/Model/Layer/Filter/Attribute.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Layer/Filter/Attribute.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogSearch/Model/Layer/Filter/Attribute.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Layer/Filter/Attribute.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/Model/Layer/Filter/Attribute.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Layer/Filter/Attribute.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/Model/Mysql4/Advanced.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Mysql4/Advanced.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogSearch/Model/Mysql4/Advanced.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Mysql4/Advanced.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/Model/Mysql4/Advanced.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Mysql4/Advanced.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/Model/Mysql4/Advanced/Collection.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Mysql4/Advanced/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogSearch/Model/Mysql4/Advanced/Collection.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Mysql4/Advanced/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/Model/Mysql4/Advanced/Collection.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Mysql4/Advanced/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/Model/Mysql4/Fulltext.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Mysql4/Fulltext.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogSearch/Model/Mysql4/Fulltext.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Mysql4/Fulltext.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/Model/Mysql4/Fulltext.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Mysql4/Fulltext.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/Model/Mysql4/Fulltext/Collection.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Mysql4/Fulltext/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogSearch/Model/Mysql4/Fulltext/Collection.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Mysql4/Fulltext/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/Model/Mysql4/Fulltext/Collection.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Mysql4/Fulltext/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/Model/Mysql4/Fulltext/Engine.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Mysql4/Fulltext/Engine.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogSearch/Model/Mysql4/Fulltext/Engine.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Mysql4/Fulltext/Engine.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/Model/Mysql4/Fulltext/Engine.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Mysql4/Fulltext/Engine.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/Model/Mysql4/Indexer/Fulltext.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Mysql4/Indexer/Fulltext.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogSearch/Model/Mysql4/Indexer/Fulltext.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Mysql4/Indexer/Fulltext.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/Model/Mysql4/Indexer/Fulltext.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Mysql4/Indexer/Fulltext.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/Model/Mysql4/Query.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Mysql4/Query.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogSearch/Model/Mysql4/Query.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Mysql4/Query.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/Model/Mysql4/Query.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Mysql4/Query.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/Model/Mysql4/Query/Collection.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Mysql4/Query/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogSearch/Model/Mysql4/Query/Collection.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Mysql4/Query/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/Model/Mysql4/Query/Collection.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Mysql4/Query/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/Model/Mysql4/Search/Collection.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Mysql4/Search/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogSearch/Model/Mysql4/Search/Collection.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Mysql4/Search/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/Model/Mysql4/Search/Collection.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Mysql4/Search/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/Model/Query.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Query.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogSearch/Model/Query.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Query.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/Model/Query.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Query.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/Model/Resource/Advanced.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Resource/Advanced.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogSearch/Model/Resource/Advanced.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Resource/Advanced.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/Model/Resource/Advanced.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Resource/Advanced.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/Model/Resource/Advanced/Collection.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Resource/Advanced/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogSearch/Model/Resource/Advanced/Collection.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Resource/Advanced/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/Model/Resource/Advanced/Collection.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Resource/Advanced/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/Model/Resource/Fulltext.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Resource/Fulltext.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogSearch/Model/Resource/Fulltext.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Resource/Fulltext.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/Model/Resource/Fulltext.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Resource/Fulltext.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/Model/Resource/Fulltext/Collection.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Resource/Fulltext/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogSearch/Model/Resource/Fulltext/Collection.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Resource/Fulltext/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/Model/Resource/Fulltext/Collection.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Resource/Fulltext/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/Model/Resource/Fulltext/Engine.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Resource/Fulltext/Engine.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogSearch/Model/Resource/Fulltext/Engine.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Resource/Fulltext/Engine.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/Model/Resource/Fulltext/Engine.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Resource/Fulltext/Engine.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/Model/Resource/Helper/Mysql4.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Resource/Helper/Mysql4.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogSearch/Model/Resource/Helper/Mysql4.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Resource/Helper/Mysql4.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/Model/Resource/Helper/Mysql4.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Resource/Helper/Mysql4.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/Model/Resource/Indexer/Fulltext.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Resource/Indexer/Fulltext.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogSearch/Model/Resource/Indexer/Fulltext.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Resource/Indexer/Fulltext.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/Model/Resource/Indexer/Fulltext.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Resource/Indexer/Fulltext.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/Model/Resource/Query.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Resource/Query.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogSearch/Model/Resource/Query.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Resource/Query.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/Model/Resource/Query.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Resource/Query.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/Model/Resource/Query/Collection.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Resource/Query/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogSearch/Model/Resource/Query/Collection.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Resource/Query/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/Model/Resource/Query/Collection.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Resource/Query/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/Model/Resource/Search/Collection.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Resource/Search/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogSearch/Model/Resource/Search/Collection.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Resource/Search/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/Model/Resource/Search/Collection.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Resource/Search/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/Model/Session.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Session.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogSearch/Model/Session.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Session.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/Model/Session.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Session.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/Model/System/Config/Backend/Sitemap.php
+++ b/app/code/core/Mage/CatalogSearch/Model/System/Config/Backend/Sitemap.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogSearch/Model/System/Config/Backend/Sitemap.php
+++ b/app/code/core/Mage/CatalogSearch/Model/System/Config/Backend/Sitemap.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/Model/System/Config/Backend/Sitemap.php
+++ b/app/code/core/Mage/CatalogSearch/Model/System/Config/Backend/Sitemap.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/controllers/AdvancedController.php
+++ b/app/code/core/Mage/CatalogSearch/controllers/AdvancedController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogSearch/controllers/AdvancedController.php
+++ b/app/code/core/Mage/CatalogSearch/controllers/AdvancedController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/controllers/AdvancedController.php
+++ b/app/code/core/Mage/CatalogSearch/controllers/AdvancedController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/controllers/AjaxController.php
+++ b/app/code/core/Mage/CatalogSearch/controllers/AjaxController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogSearch/controllers/AjaxController.php
+++ b/app/code/core/Mage/CatalogSearch/controllers/AjaxController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/controllers/AjaxController.php
+++ b/app/code/core/Mage/CatalogSearch/controllers/AjaxController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/controllers/ResultController.php
+++ b/app/code/core/Mage/CatalogSearch/controllers/ResultController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogSearch/controllers/ResultController.php
+++ b/app/code/core/Mage/CatalogSearch/controllers/ResultController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/controllers/ResultController.php
+++ b/app/code/core/Mage/CatalogSearch/controllers/ResultController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/controllers/TermController.php
+++ b/app/code/core/Mage/CatalogSearch/controllers/TermController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogSearch/controllers/TermController.php
+++ b/app/code/core/Mage/CatalogSearch/controllers/TermController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/controllers/TermController.php
+++ b/app/code/core/Mage/CatalogSearch/controllers/TermController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/etc/adminhtml.xml
+++ b/app/code/core/Mage/CatalogSearch/etc/adminhtml.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/etc/adminhtml.xml
+++ b/app/code/core/Mage/CatalogSearch/etc/adminhtml.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/etc/adminhtml.xml
+++ b/app/code/core/Mage/CatalogSearch/etc/adminhtml.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogSearch/etc/config.xml
+++ b/app/code/core/Mage/CatalogSearch/etc/config.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/etc/config.xml
+++ b/app/code/core/Mage/CatalogSearch/etc/config.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/etc/config.xml
+++ b/app/code/core/Mage/CatalogSearch/etc/config.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogSearch/etc/system.xml
+++ b/app/code/core/Mage/CatalogSearch/etc/system.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/etc/system.xml
+++ b/app/code/core/Mage/CatalogSearch/etc/system.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/etc/system.xml
+++ b/app/code/core/Mage/CatalogSearch/etc/system.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogSearch/sql/catalogsearch_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/CatalogSearch/sql/catalogsearch_setup/install-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogSearch/sql/catalogsearch_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/CatalogSearch/sql/catalogsearch_setup/install-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/sql/catalogsearch_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/CatalogSearch/sql/catalogsearch_setup/install-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/sql/catalogsearch_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/CatalogSearch/sql/catalogsearch_setup/mysql4-install-0.7.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogSearch/sql/catalogsearch_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/CatalogSearch/sql/catalogsearch_setup/mysql4-install-0.7.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/sql/catalogsearch_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/CatalogSearch/sql/catalogsearch_setup/mysql4-install-0.7.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/sql/catalogsearch_setup/mysql4-upgrade-0.7.1-0.7.2.php
+++ b/app/code/core/Mage/CatalogSearch/sql/catalogsearch_setup/mysql4-upgrade-0.7.1-0.7.2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogSearch/sql/catalogsearch_setup/mysql4-upgrade-0.7.1-0.7.2.php
+++ b/app/code/core/Mage/CatalogSearch/sql/catalogsearch_setup/mysql4-upgrade-0.7.1-0.7.2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/sql/catalogsearch_setup/mysql4-upgrade-0.7.1-0.7.2.php
+++ b/app/code/core/Mage/CatalogSearch/sql/catalogsearch_setup/mysql4-upgrade-0.7.1-0.7.2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/sql/catalogsearch_setup/mysql4-upgrade-0.7.2-0.7.3.php
+++ b/app/code/core/Mage/CatalogSearch/sql/catalogsearch_setup/mysql4-upgrade-0.7.2-0.7.3.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogSearch/sql/catalogsearch_setup/mysql4-upgrade-0.7.2-0.7.3.php
+++ b/app/code/core/Mage/CatalogSearch/sql/catalogsearch_setup/mysql4-upgrade-0.7.2-0.7.3.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/sql/catalogsearch_setup/mysql4-upgrade-0.7.2-0.7.3.php
+++ b/app/code/core/Mage/CatalogSearch/sql/catalogsearch_setup/mysql4-upgrade-0.7.2-0.7.3.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/sql/catalogsearch_setup/mysql4-upgrade-0.7.3-0.7.4.php
+++ b/app/code/core/Mage/CatalogSearch/sql/catalogsearch_setup/mysql4-upgrade-0.7.3-0.7.4.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogSearch/sql/catalogsearch_setup/mysql4-upgrade-0.7.3-0.7.4.php
+++ b/app/code/core/Mage/CatalogSearch/sql/catalogsearch_setup/mysql4-upgrade-0.7.3-0.7.4.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/sql/catalogsearch_setup/mysql4-upgrade-0.7.3-0.7.4.php
+++ b/app/code/core/Mage/CatalogSearch/sql/catalogsearch_setup/mysql4-upgrade-0.7.3-0.7.4.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/sql/catalogsearch_setup/mysql4-upgrade-0.7.4-0.7.5.php
+++ b/app/code/core/Mage/CatalogSearch/sql/catalogsearch_setup/mysql4-upgrade-0.7.4-0.7.5.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogSearch/sql/catalogsearch_setup/mysql4-upgrade-0.7.4-0.7.5.php
+++ b/app/code/core/Mage/CatalogSearch/sql/catalogsearch_setup/mysql4-upgrade-0.7.4-0.7.5.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/sql/catalogsearch_setup/mysql4-upgrade-0.7.4-0.7.5.php
+++ b/app/code/core/Mage/CatalogSearch/sql/catalogsearch_setup/mysql4-upgrade-0.7.4-0.7.5.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/sql/catalogsearch_setup/mysql4-upgrade-0.7.5-0.7.6.php
+++ b/app/code/core/Mage/CatalogSearch/sql/catalogsearch_setup/mysql4-upgrade-0.7.5-0.7.6.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogSearch/sql/catalogsearch_setup/mysql4-upgrade-0.7.5-0.7.6.php
+++ b/app/code/core/Mage/CatalogSearch/sql/catalogsearch_setup/mysql4-upgrade-0.7.5-0.7.6.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/sql/catalogsearch_setup/mysql4-upgrade-0.7.5-0.7.6.php
+++ b/app/code/core/Mage/CatalogSearch/sql/catalogsearch_setup/mysql4-upgrade-0.7.5-0.7.6.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/sql/catalogsearch_setup/mysql4-upgrade-0.7.6-0.7.7.php
+++ b/app/code/core/Mage/CatalogSearch/sql/catalogsearch_setup/mysql4-upgrade-0.7.6-0.7.7.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogSearch/sql/catalogsearch_setup/mysql4-upgrade-0.7.6-0.7.7.php
+++ b/app/code/core/Mage/CatalogSearch/sql/catalogsearch_setup/mysql4-upgrade-0.7.6-0.7.7.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/sql/catalogsearch_setup/mysql4-upgrade-0.7.6-0.7.7.php
+++ b/app/code/core/Mage/CatalogSearch/sql/catalogsearch_setup/mysql4-upgrade-0.7.6-0.7.7.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/sql/catalogsearch_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/CatalogSearch/sql/catalogsearch_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogSearch/sql/catalogsearch_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/CatalogSearch/sql/catalogsearch_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/sql/catalogsearch_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/CatalogSearch/sql/catalogsearch_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/sql/catalogsearch_setup/upgrade-1.6.0.0-1.8.2.0.php
+++ b/app/code/core/Mage/CatalogSearch/sql/catalogsearch_setup/upgrade-1.6.0.0-1.8.2.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CatalogSearch/sql/catalogsearch_setup/upgrade-1.6.0.0-1.8.2.0.php
+++ b/app/code/core/Mage/CatalogSearch/sql/catalogsearch_setup/upgrade-1.6.0.0-1.8.2.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/CatalogSearch/sql/catalogsearch_setup/upgrade-1.6.0.0-1.8.2.0.php
+++ b/app/code/core/Mage/CatalogSearch/sql/catalogsearch_setup/upgrade-1.6.0.0-1.8.2.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/code/core/Mage/Centinel/Block/Adminhtml/Validation.php
+++ b/app/code/core/Mage/Centinel/Block/Adminhtml/Validation.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Centinel

--- a/app/code/core/Mage/Centinel/Block/Adminhtml/Validation.php
+++ b/app/code/core/Mage/Centinel/Block/Adminhtml/Validation.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Centinel/Block/Adminhtml/Validation.php
+++ b/app/code/core/Mage/Centinel/Block/Adminhtml/Validation.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Centinel

--- a/app/code/core/Mage/Centinel/Block/Adminhtml/Validation/Form.php
+++ b/app/code/core/Mage/Centinel/Block/Adminhtml/Validation/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Centinel

--- a/app/code/core/Mage/Centinel/Block/Adminhtml/Validation/Form.php
+++ b/app/code/core/Mage/Centinel/Block/Adminhtml/Validation/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Centinel/Block/Adminhtml/Validation/Form.php
+++ b/app/code/core/Mage/Centinel/Block/Adminhtml/Validation/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Centinel

--- a/app/code/core/Mage/Centinel/Block/Authentication.php
+++ b/app/code/core/Mage/Centinel/Block/Authentication.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Centinel

--- a/app/code/core/Mage/Centinel/Block/Authentication.php
+++ b/app/code/core/Mage/Centinel/Block/Authentication.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Centinel/Block/Authentication.php
+++ b/app/code/core/Mage/Centinel/Block/Authentication.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Centinel

--- a/app/code/core/Mage/Centinel/Block/Authentication/Complete.php
+++ b/app/code/core/Mage/Centinel/Block/Authentication/Complete.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Centinel

--- a/app/code/core/Mage/Centinel/Block/Authentication/Complete.php
+++ b/app/code/core/Mage/Centinel/Block/Authentication/Complete.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Centinel/Block/Authentication/Complete.php
+++ b/app/code/core/Mage/Centinel/Block/Authentication/Complete.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Centinel

--- a/app/code/core/Mage/Centinel/Block/Authentication/Start.php
+++ b/app/code/core/Mage/Centinel/Block/Authentication/Start.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Centinel

--- a/app/code/core/Mage/Centinel/Block/Authentication/Start.php
+++ b/app/code/core/Mage/Centinel/Block/Authentication/Start.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Centinel/Block/Authentication/Start.php
+++ b/app/code/core/Mage/Centinel/Block/Authentication/Start.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Centinel

--- a/app/code/core/Mage/Centinel/Block/Logo.php
+++ b/app/code/core/Mage/Centinel/Block/Logo.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Centinel

--- a/app/code/core/Mage/Centinel/Block/Logo.php
+++ b/app/code/core/Mage/Centinel/Block/Logo.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Centinel/Block/Logo.php
+++ b/app/code/core/Mage/Centinel/Block/Logo.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Centinel

--- a/app/code/core/Mage/Centinel/Helper/Data.php
+++ b/app/code/core/Mage/Centinel/Helper/Data.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Centinel

--- a/app/code/core/Mage/Centinel/Helper/Data.php
+++ b/app/code/core/Mage/Centinel/Helper/Data.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Centinel/Helper/Data.php
+++ b/app/code/core/Mage/Centinel/Helper/Data.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Centinel

--- a/app/code/core/Mage/Centinel/Model/Api.php
+++ b/app/code/core/Mage/Centinel/Model/Api.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Centinel

--- a/app/code/core/Mage/Centinel/Model/Api.php
+++ b/app/code/core/Mage/Centinel/Model/Api.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Centinel/Model/Api.php
+++ b/app/code/core/Mage/Centinel/Model/Api.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Centinel

--- a/app/code/core/Mage/Centinel/Model/Api/Client.php
+++ b/app/code/core/Mage/Centinel/Model/Api/Client.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Centinel

--- a/app/code/core/Mage/Centinel/Model/Api/Client.php
+++ b/app/code/core/Mage/Centinel/Model/Api/Client.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Centinel/Model/Api/Client.php
+++ b/app/code/core/Mage/Centinel/Model/Api/Client.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Centinel

--- a/app/code/core/Mage/Centinel/Model/Config.php
+++ b/app/code/core/Mage/Centinel/Model/Config.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Centinel

--- a/app/code/core/Mage/Centinel/Model/Config.php
+++ b/app/code/core/Mage/Centinel/Model/Config.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Centinel/Model/Config.php
+++ b/app/code/core/Mage/Centinel/Model/Config.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Centinel

--- a/app/code/core/Mage/Centinel/Model/Observer.php
+++ b/app/code/core/Mage/Centinel/Model/Observer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Centinel

--- a/app/code/core/Mage/Centinel/Model/Observer.php
+++ b/app/code/core/Mage/Centinel/Model/Observer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Centinel/Model/Observer.php
+++ b/app/code/core/Mage/Centinel/Model/Observer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Centinel

--- a/app/code/core/Mage/Centinel/Model/Service.php
+++ b/app/code/core/Mage/Centinel/Model/Service.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Centinel

--- a/app/code/core/Mage/Centinel/Model/Service.php
+++ b/app/code/core/Mage/Centinel/Model/Service.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Centinel/Model/Service.php
+++ b/app/code/core/Mage/Centinel/Model/Service.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Centinel

--- a/app/code/core/Mage/Centinel/Model/Session.php
+++ b/app/code/core/Mage/Centinel/Model/Session.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Centinel

--- a/app/code/core/Mage/Centinel/Model/Session.php
+++ b/app/code/core/Mage/Centinel/Model/Session.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Centinel/Model/Session.php
+++ b/app/code/core/Mage/Centinel/Model/Session.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Centinel

--- a/app/code/core/Mage/Centinel/Model/State/Jcb.php
+++ b/app/code/core/Mage/Centinel/Model/State/Jcb.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Centinel

--- a/app/code/core/Mage/Centinel/Model/State/Jcb.php
+++ b/app/code/core/Mage/Centinel/Model/State/Jcb.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Centinel/Model/State/Jcb.php
+++ b/app/code/core/Mage/Centinel/Model/State/Jcb.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Centinel

--- a/app/code/core/Mage/Centinel/Model/State/Mastercard.php
+++ b/app/code/core/Mage/Centinel/Model/State/Mastercard.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Centinel

--- a/app/code/core/Mage/Centinel/Model/State/Mastercard.php
+++ b/app/code/core/Mage/Centinel/Model/State/Mastercard.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Centinel/Model/State/Mastercard.php
+++ b/app/code/core/Mage/Centinel/Model/State/Mastercard.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Centinel

--- a/app/code/core/Mage/Centinel/Model/State/Visa.php
+++ b/app/code/core/Mage/Centinel/Model/State/Visa.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Centinel

--- a/app/code/core/Mage/Centinel/Model/State/Visa.php
+++ b/app/code/core/Mage/Centinel/Model/State/Visa.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Centinel/Model/State/Visa.php
+++ b/app/code/core/Mage/Centinel/Model/State/Visa.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Centinel

--- a/app/code/core/Mage/Centinel/Model/StateAbstract.php
+++ b/app/code/core/Mage/Centinel/Model/StateAbstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Centinel

--- a/app/code/core/Mage/Centinel/Model/StateAbstract.php
+++ b/app/code/core/Mage/Centinel/Model/StateAbstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Centinel/Model/StateAbstract.php
+++ b/app/code/core/Mage/Centinel/Model/StateAbstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Centinel

--- a/app/code/core/Mage/Centinel/controllers/Adminhtml/Centinel/IndexController.php
+++ b/app/code/core/Mage/Centinel/controllers/Adminhtml/Centinel/IndexController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Centinel

--- a/app/code/core/Mage/Centinel/controllers/Adminhtml/Centinel/IndexController.php
+++ b/app/code/core/Mage/Centinel/controllers/Adminhtml/Centinel/IndexController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Centinel/controllers/Adminhtml/Centinel/IndexController.php
+++ b/app/code/core/Mage/Centinel/controllers/Adminhtml/Centinel/IndexController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Centinel

--- a/app/code/core/Mage/Centinel/controllers/IndexController.php
+++ b/app/code/core/Mage/Centinel/controllers/IndexController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Centinel

--- a/app/code/core/Mage/Centinel/controllers/IndexController.php
+++ b/app/code/core/Mage/Centinel/controllers/IndexController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Centinel/controllers/IndexController.php
+++ b/app/code/core/Mage/Centinel/controllers/IndexController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Centinel

--- a/app/code/core/Mage/Centinel/etc/config.xml
+++ b/app/code/core/Mage/Centinel/etc/config.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Centinel

--- a/app/code/core/Mage/Centinel/etc/config.xml
+++ b/app/code/core/Mage/Centinel/etc/config.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Centinel

--- a/app/code/core/Mage/Centinel/etc/config.xml
+++ b/app/code/core/Mage/Centinel/etc/config.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Centinel/etc/system.xml
+++ b/app/code/core/Mage/Centinel/etc/system.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Centinel

--- a/app/code/core/Mage/Centinel/etc/system.xml
+++ b/app/code/core/Mage/Centinel/etc/system.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Centinel

--- a/app/code/core/Mage/Centinel/etc/system.xml
+++ b/app/code/core/Mage/Centinel/etc/system.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/Block/Agreements.php
+++ b/app/code/core/Mage/Checkout/Block/Agreements.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/Block/Agreements.php
+++ b/app/code/core/Mage/Checkout/Block/Agreements.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Block/Agreements.php
+++ b/app/code/core/Mage/Checkout/Block/Agreements.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Block/Cart.php
+++ b/app/code/core/Mage/Checkout/Block/Cart.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/Block/Cart.php
+++ b/app/code/core/Mage/Checkout/Block/Cart.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Block/Cart.php
+++ b/app/code/core/Mage/Checkout/Block/Cart.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Block/Cart/Abstract.php
+++ b/app/code/core/Mage/Checkout/Block/Cart/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/Block/Cart/Abstract.php
+++ b/app/code/core/Mage/Checkout/Block/Cart/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Block/Cart/Abstract.php
+++ b/app/code/core/Mage/Checkout/Block/Cart/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Block/Cart/Coupon.php
+++ b/app/code/core/Mage/Checkout/Block/Cart/Coupon.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/Block/Cart/Coupon.php
+++ b/app/code/core/Mage/Checkout/Block/Cart/Coupon.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Block/Cart/Coupon.php
+++ b/app/code/core/Mage/Checkout/Block/Cart/Coupon.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Block/Cart/Crosssell.php
+++ b/app/code/core/Mage/Checkout/Block/Cart/Crosssell.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/Block/Cart/Crosssell.php
+++ b/app/code/core/Mage/Checkout/Block/Cart/Crosssell.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Block/Cart/Crosssell.php
+++ b/app/code/core/Mage/Checkout/Block/Cart/Crosssell.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Block/Cart/Item/Configure.php
+++ b/app/code/core/Mage/Checkout/Block/Cart/Item/Configure.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/Block/Cart/Item/Configure.php
+++ b/app/code/core/Mage/Checkout/Block/Cart/Item/Configure.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Block/Cart/Item/Configure.php
+++ b/app/code/core/Mage/Checkout/Block/Cart/Item/Configure.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Block/Cart/Item/Renderer.php
+++ b/app/code/core/Mage/Checkout/Block/Cart/Item/Renderer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/Block/Cart/Item/Renderer.php
+++ b/app/code/core/Mage/Checkout/Block/Cart/Item/Renderer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Block/Cart/Item/Renderer.php
+++ b/app/code/core/Mage/Checkout/Block/Cart/Item/Renderer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Block/Cart/Item/Renderer/Configurable.php
+++ b/app/code/core/Mage/Checkout/Block/Cart/Item/Renderer/Configurable.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/Block/Cart/Item/Renderer/Configurable.php
+++ b/app/code/core/Mage/Checkout/Block/Cart/Item/Renderer/Configurable.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Block/Cart/Item/Renderer/Configurable.php
+++ b/app/code/core/Mage/Checkout/Block/Cart/Item/Renderer/Configurable.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Block/Cart/Item/Renderer/Grouped.php
+++ b/app/code/core/Mage/Checkout/Block/Cart/Item/Renderer/Grouped.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/Block/Cart/Item/Renderer/Grouped.php
+++ b/app/code/core/Mage/Checkout/Block/Cart/Item/Renderer/Grouped.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Block/Cart/Item/Renderer/Grouped.php
+++ b/app/code/core/Mage/Checkout/Block/Cart/Item/Renderer/Grouped.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Block/Cart/Minicart.php
+++ b/app/code/core/Mage/Checkout/Block/Cart/Minicart.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/Block/Cart/Minicart.php
+++ b/app/code/core/Mage/Checkout/Block/Cart/Minicart.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Block/Cart/Minicart.php
+++ b/app/code/core/Mage/Checkout/Block/Cart/Minicart.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Block/Cart/Shipping.php
+++ b/app/code/core/Mage/Checkout/Block/Cart/Shipping.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/Block/Cart/Shipping.php
+++ b/app/code/core/Mage/Checkout/Block/Cart/Shipping.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Block/Cart/Shipping.php
+++ b/app/code/core/Mage/Checkout/Block/Cart/Shipping.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Block/Cart/Sidebar.php
+++ b/app/code/core/Mage/Checkout/Block/Cart/Sidebar.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/Block/Cart/Sidebar.php
+++ b/app/code/core/Mage/Checkout/Block/Cart/Sidebar.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Block/Cart/Sidebar.php
+++ b/app/code/core/Mage/Checkout/Block/Cart/Sidebar.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Block/Cart/Totals.php
+++ b/app/code/core/Mage/Checkout/Block/Cart/Totals.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/Block/Cart/Totals.php
+++ b/app/code/core/Mage/Checkout/Block/Cart/Totals.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Block/Cart/Totals.php
+++ b/app/code/core/Mage/Checkout/Block/Cart/Totals.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Block/Links.php
+++ b/app/code/core/Mage/Checkout/Block/Links.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/Block/Links.php
+++ b/app/code/core/Mage/Checkout/Block/Links.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Block/Links.php
+++ b/app/code/core/Mage/Checkout/Block/Links.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Block/Multishipping/Abstract.php
+++ b/app/code/core/Mage/Checkout/Block/Multishipping/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/Block/Multishipping/Abstract.php
+++ b/app/code/core/Mage/Checkout/Block/Multishipping/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Block/Multishipping/Abstract.php
+++ b/app/code/core/Mage/Checkout/Block/Multishipping/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Block/Multishipping/Address/Select.php
+++ b/app/code/core/Mage/Checkout/Block/Multishipping/Address/Select.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/Block/Multishipping/Address/Select.php
+++ b/app/code/core/Mage/Checkout/Block/Multishipping/Address/Select.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Block/Multishipping/Address/Select.php
+++ b/app/code/core/Mage/Checkout/Block/Multishipping/Address/Select.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Block/Multishipping/Addresses.php
+++ b/app/code/core/Mage/Checkout/Block/Multishipping/Addresses.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/Block/Multishipping/Addresses.php
+++ b/app/code/core/Mage/Checkout/Block/Multishipping/Addresses.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Block/Multishipping/Addresses.php
+++ b/app/code/core/Mage/Checkout/Block/Multishipping/Addresses.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Block/Multishipping/Billing.php
+++ b/app/code/core/Mage/Checkout/Block/Multishipping/Billing.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/Block/Multishipping/Billing.php
+++ b/app/code/core/Mage/Checkout/Block/Multishipping/Billing.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Block/Multishipping/Billing.php
+++ b/app/code/core/Mage/Checkout/Block/Multishipping/Billing.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Block/Multishipping/Billing/Items.php
+++ b/app/code/core/Mage/Checkout/Block/Multishipping/Billing/Items.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/Block/Multishipping/Billing/Items.php
+++ b/app/code/core/Mage/Checkout/Block/Multishipping/Billing/Items.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Block/Multishipping/Billing/Items.php
+++ b/app/code/core/Mage/Checkout/Block/Multishipping/Billing/Items.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Block/Multishipping/Link.php
+++ b/app/code/core/Mage/Checkout/Block/Multishipping/Link.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/Block/Multishipping/Link.php
+++ b/app/code/core/Mage/Checkout/Block/Multishipping/Link.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Block/Multishipping/Link.php
+++ b/app/code/core/Mage/Checkout/Block/Multishipping/Link.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Block/Multishipping/Overview.php
+++ b/app/code/core/Mage/Checkout/Block/Multishipping/Overview.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/Block/Multishipping/Overview.php
+++ b/app/code/core/Mage/Checkout/Block/Multishipping/Overview.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Block/Multishipping/Overview.php
+++ b/app/code/core/Mage/Checkout/Block/Multishipping/Overview.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Block/Multishipping/Payment/Info.php
+++ b/app/code/core/Mage/Checkout/Block/Multishipping/Payment/Info.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/Block/Multishipping/Payment/Info.php
+++ b/app/code/core/Mage/Checkout/Block/Multishipping/Payment/Info.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Block/Multishipping/Payment/Info.php
+++ b/app/code/core/Mage/Checkout/Block/Multishipping/Payment/Info.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Block/Multishipping/Shipping.php
+++ b/app/code/core/Mage/Checkout/Block/Multishipping/Shipping.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/Block/Multishipping/Shipping.php
+++ b/app/code/core/Mage/Checkout/Block/Multishipping/Shipping.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Block/Multishipping/Shipping.php
+++ b/app/code/core/Mage/Checkout/Block/Multishipping/Shipping.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Block/Multishipping/State.php
+++ b/app/code/core/Mage/Checkout/Block/Multishipping/State.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/Block/Multishipping/State.php
+++ b/app/code/core/Mage/Checkout/Block/Multishipping/State.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Block/Multishipping/State.php
+++ b/app/code/core/Mage/Checkout/Block/Multishipping/State.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Block/Multishipping/Success.php
+++ b/app/code/core/Mage/Checkout/Block/Multishipping/Success.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/Block/Multishipping/Success.php
+++ b/app/code/core/Mage/Checkout/Block/Multishipping/Success.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Block/Multishipping/Success.php
+++ b/app/code/core/Mage/Checkout/Block/Multishipping/Success.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Block/Onepage.php
+++ b/app/code/core/Mage/Checkout/Block/Onepage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/Block/Onepage.php
+++ b/app/code/core/Mage/Checkout/Block/Onepage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Block/Onepage.php
+++ b/app/code/core/Mage/Checkout/Block/Onepage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Block/Onepage/Abstract.php
+++ b/app/code/core/Mage/Checkout/Block/Onepage/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/Block/Onepage/Abstract.php
+++ b/app/code/core/Mage/Checkout/Block/Onepage/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Block/Onepage/Abstract.php
+++ b/app/code/core/Mage/Checkout/Block/Onepage/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Block/Onepage/Billing.php
+++ b/app/code/core/Mage/Checkout/Block/Onepage/Billing.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/Block/Onepage/Billing.php
+++ b/app/code/core/Mage/Checkout/Block/Onepage/Billing.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Block/Onepage/Billing.php
+++ b/app/code/core/Mage/Checkout/Block/Onepage/Billing.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Block/Onepage/Failure.php
+++ b/app/code/core/Mage/Checkout/Block/Onepage/Failure.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/Block/Onepage/Failure.php
+++ b/app/code/core/Mage/Checkout/Block/Onepage/Failure.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Block/Onepage/Failure.php
+++ b/app/code/core/Mage/Checkout/Block/Onepage/Failure.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Block/Onepage/Link.php
+++ b/app/code/core/Mage/Checkout/Block/Onepage/Link.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/Block/Onepage/Link.php
+++ b/app/code/core/Mage/Checkout/Block/Onepage/Link.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Block/Onepage/Link.php
+++ b/app/code/core/Mage/Checkout/Block/Onepage/Link.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Block/Onepage/Login.php
+++ b/app/code/core/Mage/Checkout/Block/Onepage/Login.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/Block/Onepage/Login.php
+++ b/app/code/core/Mage/Checkout/Block/Onepage/Login.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Block/Onepage/Login.php
+++ b/app/code/core/Mage/Checkout/Block/Onepage/Login.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Block/Onepage/Payment.php
+++ b/app/code/core/Mage/Checkout/Block/Onepage/Payment.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/Block/Onepage/Payment.php
+++ b/app/code/core/Mage/Checkout/Block/Onepage/Payment.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Block/Onepage/Payment.php
+++ b/app/code/core/Mage/Checkout/Block/Onepage/Payment.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Block/Onepage/Payment/Info.php
+++ b/app/code/core/Mage/Checkout/Block/Onepage/Payment/Info.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/Block/Onepage/Payment/Info.php
+++ b/app/code/core/Mage/Checkout/Block/Onepage/Payment/Info.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Block/Onepage/Payment/Info.php
+++ b/app/code/core/Mage/Checkout/Block/Onepage/Payment/Info.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Block/Onepage/Payment/Methods.php
+++ b/app/code/core/Mage/Checkout/Block/Onepage/Payment/Methods.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/Block/Onepage/Payment/Methods.php
+++ b/app/code/core/Mage/Checkout/Block/Onepage/Payment/Methods.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Block/Onepage/Payment/Methods.php
+++ b/app/code/core/Mage/Checkout/Block/Onepage/Payment/Methods.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Block/Onepage/Progress.php
+++ b/app/code/core/Mage/Checkout/Block/Onepage/Progress.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/Block/Onepage/Progress.php
+++ b/app/code/core/Mage/Checkout/Block/Onepage/Progress.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Block/Onepage/Progress.php
+++ b/app/code/core/Mage/Checkout/Block/Onepage/Progress.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Block/Onepage/Review.php
+++ b/app/code/core/Mage/Checkout/Block/Onepage/Review.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/Block/Onepage/Review.php
+++ b/app/code/core/Mage/Checkout/Block/Onepage/Review.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Block/Onepage/Review.php
+++ b/app/code/core/Mage/Checkout/Block/Onepage/Review.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Block/Onepage/Review/Info.php
+++ b/app/code/core/Mage/Checkout/Block/Onepage/Review/Info.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/Block/Onepage/Review/Info.php
+++ b/app/code/core/Mage/Checkout/Block/Onepage/Review/Info.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Block/Onepage/Review/Info.php
+++ b/app/code/core/Mage/Checkout/Block/Onepage/Review/Info.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Block/Onepage/Shipping.php
+++ b/app/code/core/Mage/Checkout/Block/Onepage/Shipping.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/Block/Onepage/Shipping.php
+++ b/app/code/core/Mage/Checkout/Block/Onepage/Shipping.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Block/Onepage/Shipping.php
+++ b/app/code/core/Mage/Checkout/Block/Onepage/Shipping.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Block/Onepage/Shipping/Method.php
+++ b/app/code/core/Mage/Checkout/Block/Onepage/Shipping/Method.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/Block/Onepage/Shipping/Method.php
+++ b/app/code/core/Mage/Checkout/Block/Onepage/Shipping/Method.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Block/Onepage/Shipping/Method.php
+++ b/app/code/core/Mage/Checkout/Block/Onepage/Shipping/Method.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Block/Onepage/Shipping/Method/Additional.php
+++ b/app/code/core/Mage/Checkout/Block/Onepage/Shipping/Method/Additional.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/Block/Onepage/Shipping/Method/Additional.php
+++ b/app/code/core/Mage/Checkout/Block/Onepage/Shipping/Method/Additional.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Block/Onepage/Shipping/Method/Additional.php
+++ b/app/code/core/Mage/Checkout/Block/Onepage/Shipping/Method/Additional.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Block/Onepage/Shipping/Method/Available.php
+++ b/app/code/core/Mage/Checkout/Block/Onepage/Shipping/Method/Available.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/Block/Onepage/Shipping/Method/Available.php
+++ b/app/code/core/Mage/Checkout/Block/Onepage/Shipping/Method/Available.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Block/Onepage/Shipping/Method/Available.php
+++ b/app/code/core/Mage/Checkout/Block/Onepage/Shipping/Method/Available.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Block/Onepage/Success.php
+++ b/app/code/core/Mage/Checkout/Block/Onepage/Success.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/Block/Onepage/Success.php
+++ b/app/code/core/Mage/Checkout/Block/Onepage/Success.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Block/Onepage/Success.php
+++ b/app/code/core/Mage/Checkout/Block/Onepage/Success.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Block/Success.php
+++ b/app/code/core/Mage/Checkout/Block/Success.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/Block/Success.php
+++ b/app/code/core/Mage/Checkout/Block/Success.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Block/Success.php
+++ b/app/code/core/Mage/Checkout/Block/Success.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Block/Total/Default.php
+++ b/app/code/core/Mage/Checkout/Block/Total/Default.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/Block/Total/Default.php
+++ b/app/code/core/Mage/Checkout/Block/Total/Default.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Block/Total/Default.php
+++ b/app/code/core/Mage/Checkout/Block/Total/Default.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Block/Total/Nominal.php
+++ b/app/code/core/Mage/Checkout/Block/Total/Nominal.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/Block/Total/Nominal.php
+++ b/app/code/core/Mage/Checkout/Block/Total/Nominal.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Block/Total/Nominal.php
+++ b/app/code/core/Mage/Checkout/Block/Total/Nominal.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Block/Total/Tax.php
+++ b/app/code/core/Mage/Checkout/Block/Total/Tax.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/Block/Total/Tax.php
+++ b/app/code/core/Mage/Checkout/Block/Total/Tax.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Block/Total/Tax.php
+++ b/app/code/core/Mage/Checkout/Block/Total/Tax.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Controller/Action.php
+++ b/app/code/core/Mage/Checkout/Controller/Action.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/Controller/Action.php
+++ b/app/code/core/Mage/Checkout/Controller/Action.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Controller/Action.php
+++ b/app/code/core/Mage/Checkout/Controller/Action.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Exception.php
+++ b/app/code/core/Mage/Checkout/Exception.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/Exception.php
+++ b/app/code/core/Mage/Checkout/Exception.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Exception.php
+++ b/app/code/core/Mage/Checkout/Exception.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Helper/Cart.php
+++ b/app/code/core/Mage/Checkout/Helper/Cart.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/Helper/Cart.php
+++ b/app/code/core/Mage/Checkout/Helper/Cart.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Helper/Cart.php
+++ b/app/code/core/Mage/Checkout/Helper/Cart.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Helper/Data.php
+++ b/app/code/core/Mage/Checkout/Helper/Data.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/Helper/Data.php
+++ b/app/code/core/Mage/Checkout/Helper/Data.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Helper/Data.php
+++ b/app/code/core/Mage/Checkout/Helper/Data.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Helper/Url.php
+++ b/app/code/core/Mage/Checkout/Helper/Url.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/Helper/Url.php
+++ b/app/code/core/Mage/Checkout/Helper/Url.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Helper/Url.php
+++ b/app/code/core/Mage/Checkout/Helper/Url.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Model/Agreement.php
+++ b/app/code/core/Mage/Checkout/Model/Agreement.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/Model/Agreement.php
+++ b/app/code/core/Mage/Checkout/Model/Agreement.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Model/Agreement.php
+++ b/app/code/core/Mage/Checkout/Model/Agreement.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Model/Api/Resource.php
+++ b/app/code/core/Mage/Checkout/Model/Api/Resource.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/Model/Api/Resource.php
+++ b/app/code/core/Mage/Checkout/Model/Api/Resource.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Model/Api/Resource.php
+++ b/app/code/core/Mage/Checkout/Model/Api/Resource.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Model/Api/Resource/Customer.php
+++ b/app/code/core/Mage/Checkout/Model/Api/Resource/Customer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/Model/Api/Resource/Customer.php
+++ b/app/code/core/Mage/Checkout/Model/Api/Resource/Customer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Model/Api/Resource/Customer.php
+++ b/app/code/core/Mage/Checkout/Model/Api/Resource/Customer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Model/Api/Resource/Product.php
+++ b/app/code/core/Mage/Checkout/Model/Api/Resource/Product.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/Model/Api/Resource/Product.php
+++ b/app/code/core/Mage/Checkout/Model/Api/Resource/Product.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Model/Api/Resource/Product.php
+++ b/app/code/core/Mage/Checkout/Model/Api/Resource/Product.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Model/Cart.php
+++ b/app/code/core/Mage/Checkout/Model/Cart.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/Model/Cart.php
+++ b/app/code/core/Mage/Checkout/Model/Cart.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Model/Cart.php
+++ b/app/code/core/Mage/Checkout/Model/Cart.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Model/Cart/Api.php
+++ b/app/code/core/Mage/Checkout/Model/Cart/Api.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/Model/Cart/Api.php
+++ b/app/code/core/Mage/Checkout/Model/Cart/Api.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Model/Cart/Api.php
+++ b/app/code/core/Mage/Checkout/Model/Cart/Api.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Model/Cart/Api/V2.php
+++ b/app/code/core/Mage/Checkout/Model/Cart/Api/V2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/Model/Cart/Api/V2.php
+++ b/app/code/core/Mage/Checkout/Model/Cart/Api/V2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Model/Cart/Api/V2.php
+++ b/app/code/core/Mage/Checkout/Model/Cart/Api/V2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Model/Cart/Coupon/Api.php
+++ b/app/code/core/Mage/Checkout/Model/Cart/Coupon/Api.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/Model/Cart/Coupon/Api.php
+++ b/app/code/core/Mage/Checkout/Model/Cart/Coupon/Api.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Model/Cart/Coupon/Api.php
+++ b/app/code/core/Mage/Checkout/Model/Cart/Coupon/Api.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Model/Cart/Coupon/Api/V2.php
+++ b/app/code/core/Mage/Checkout/Model/Cart/Coupon/Api/V2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/Model/Cart/Coupon/Api/V2.php
+++ b/app/code/core/Mage/Checkout/Model/Cart/Coupon/Api/V2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Model/Cart/Coupon/Api/V2.php
+++ b/app/code/core/Mage/Checkout/Model/Cart/Coupon/Api/V2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Model/Cart/Customer/Api.php
+++ b/app/code/core/Mage/Checkout/Model/Cart/Customer/Api.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/Model/Cart/Customer/Api.php
+++ b/app/code/core/Mage/Checkout/Model/Cart/Customer/Api.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Model/Cart/Customer/Api.php
+++ b/app/code/core/Mage/Checkout/Model/Cart/Customer/Api.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Model/Cart/Customer/Api/V2.php
+++ b/app/code/core/Mage/Checkout/Model/Cart/Customer/Api/V2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/Model/Cart/Customer/Api/V2.php
+++ b/app/code/core/Mage/Checkout/Model/Cart/Customer/Api/V2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Model/Cart/Customer/Api/V2.php
+++ b/app/code/core/Mage/Checkout/Model/Cart/Customer/Api/V2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Model/Cart/Interface.php
+++ b/app/code/core/Mage/Checkout/Model/Cart/Interface.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/Model/Cart/Interface.php
+++ b/app/code/core/Mage/Checkout/Model/Cart/Interface.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Model/Cart/Interface.php
+++ b/app/code/core/Mage/Checkout/Model/Cart/Interface.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Model/Cart/Payment/Api.php
+++ b/app/code/core/Mage/Checkout/Model/Cart/Payment/Api.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/Model/Cart/Payment/Api.php
+++ b/app/code/core/Mage/Checkout/Model/Cart/Payment/Api.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Model/Cart/Payment/Api.php
+++ b/app/code/core/Mage/Checkout/Model/Cart/Payment/Api.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Model/Cart/Payment/Api/V2.php
+++ b/app/code/core/Mage/Checkout/Model/Cart/Payment/Api/V2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/Model/Cart/Payment/Api/V2.php
+++ b/app/code/core/Mage/Checkout/Model/Cart/Payment/Api/V2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Model/Cart/Payment/Api/V2.php
+++ b/app/code/core/Mage/Checkout/Model/Cart/Payment/Api/V2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Model/Cart/Product/Api.php
+++ b/app/code/core/Mage/Checkout/Model/Cart/Product/Api.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/Model/Cart/Product/Api.php
+++ b/app/code/core/Mage/Checkout/Model/Cart/Product/Api.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Model/Cart/Product/Api.php
+++ b/app/code/core/Mage/Checkout/Model/Cart/Product/Api.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Model/Cart/Product/Api/V2.php
+++ b/app/code/core/Mage/Checkout/Model/Cart/Product/Api/V2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/Model/Cart/Product/Api/V2.php
+++ b/app/code/core/Mage/Checkout/Model/Cart/Product/Api/V2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Model/Cart/Product/Api/V2.php
+++ b/app/code/core/Mage/Checkout/Model/Cart/Product/Api/V2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Model/Cart/Shipping/Api.php
+++ b/app/code/core/Mage/Checkout/Model/Cart/Shipping/Api.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/Model/Cart/Shipping/Api.php
+++ b/app/code/core/Mage/Checkout/Model/Cart/Shipping/Api.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Model/Cart/Shipping/Api.php
+++ b/app/code/core/Mage/Checkout/Model/Cart/Shipping/Api.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Model/Cart/Shipping/Api/V2.php
+++ b/app/code/core/Mage/Checkout/Model/Cart/Shipping/Api/V2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/Model/Cart/Shipping/Api/V2.php
+++ b/app/code/core/Mage/Checkout/Model/Cart/Shipping/Api/V2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Model/Cart/Shipping/Api/V2.php
+++ b/app/code/core/Mage/Checkout/Model/Cart/Shipping/Api/V2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Model/Config/Source/Cart/Summary.php
+++ b/app/code/core/Mage/Checkout/Model/Config/Source/Cart/Summary.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/Model/Config/Source/Cart/Summary.php
+++ b/app/code/core/Mage/Checkout/Model/Config/Source/Cart/Summary.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Model/Config/Source/Cart/Summary.php
+++ b/app/code/core/Mage/Checkout/Model/Config/Source/Cart/Summary.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Model/Mysql4/Agreement.php
+++ b/app/code/core/Mage/Checkout/Model/Mysql4/Agreement.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/Model/Mysql4/Agreement.php
+++ b/app/code/core/Mage/Checkout/Model/Mysql4/Agreement.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Model/Mysql4/Agreement.php
+++ b/app/code/core/Mage/Checkout/Model/Mysql4/Agreement.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Model/Mysql4/Agreement/Collection.php
+++ b/app/code/core/Mage/Checkout/Model/Mysql4/Agreement/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/Model/Mysql4/Agreement/Collection.php
+++ b/app/code/core/Mage/Checkout/Model/Mysql4/Agreement/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Model/Mysql4/Agreement/Collection.php
+++ b/app/code/core/Mage/Checkout/Model/Mysql4/Agreement/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Model/Mysql4/Cart.php
+++ b/app/code/core/Mage/Checkout/Model/Mysql4/Cart.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/Model/Mysql4/Cart.php
+++ b/app/code/core/Mage/Checkout/Model/Mysql4/Cart.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Model/Mysql4/Cart.php
+++ b/app/code/core/Mage/Checkout/Model/Mysql4/Cart.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Model/Mysql4/Setup.php
+++ b/app/code/core/Mage/Checkout/Model/Mysql4/Setup.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/Model/Mysql4/Setup.php
+++ b/app/code/core/Mage/Checkout/Model/Mysql4/Setup.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Model/Mysql4/Setup.php
+++ b/app/code/core/Mage/Checkout/Model/Mysql4/Setup.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Model/Observer.php
+++ b/app/code/core/Mage/Checkout/Model/Observer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/Model/Observer.php
+++ b/app/code/core/Mage/Checkout/Model/Observer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Model/Observer.php
+++ b/app/code/core/Mage/Checkout/Model/Observer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Model/Resource/Agreement.php
+++ b/app/code/core/Mage/Checkout/Model/Resource/Agreement.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/Model/Resource/Agreement.php
+++ b/app/code/core/Mage/Checkout/Model/Resource/Agreement.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Model/Resource/Agreement.php
+++ b/app/code/core/Mage/Checkout/Model/Resource/Agreement.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Model/Resource/Agreement/Collection.php
+++ b/app/code/core/Mage/Checkout/Model/Resource/Agreement/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/Model/Resource/Agreement/Collection.php
+++ b/app/code/core/Mage/Checkout/Model/Resource/Agreement/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Model/Resource/Agreement/Collection.php
+++ b/app/code/core/Mage/Checkout/Model/Resource/Agreement/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Model/Resource/Cart.php
+++ b/app/code/core/Mage/Checkout/Model/Resource/Cart.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/Model/Resource/Cart.php
+++ b/app/code/core/Mage/Checkout/Model/Resource/Cart.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Model/Resource/Cart.php
+++ b/app/code/core/Mage/Checkout/Model/Resource/Cart.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Model/Resource/Setup.php
+++ b/app/code/core/Mage/Checkout/Model/Resource/Setup.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/Model/Resource/Setup.php
+++ b/app/code/core/Mage/Checkout/Model/Resource/Setup.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Model/Resource/Setup.php
+++ b/app/code/core/Mage/Checkout/Model/Resource/Setup.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Model/Session.php
+++ b/app/code/core/Mage/Checkout/Model/Session.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/Model/Session.php
+++ b/app/code/core/Mage/Checkout/Model/Session.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Model/Session.php
+++ b/app/code/core/Mage/Checkout/Model/Session.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Model/Type/Abstract.php
+++ b/app/code/core/Mage/Checkout/Model/Type/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/Model/Type/Abstract.php
+++ b/app/code/core/Mage/Checkout/Model/Type/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Model/Type/Abstract.php
+++ b/app/code/core/Mage/Checkout/Model/Type/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Model/Type/Multishipping.php
+++ b/app/code/core/Mage/Checkout/Model/Type/Multishipping.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/Model/Type/Multishipping.php
+++ b/app/code/core/Mage/Checkout/Model/Type/Multishipping.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Model/Type/Multishipping.php
+++ b/app/code/core/Mage/Checkout/Model/Type/Multishipping.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Model/Type/Multishipping/State.php
+++ b/app/code/core/Mage/Checkout/Model/Type/Multishipping/State.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/Model/Type/Multishipping/State.php
+++ b/app/code/core/Mage/Checkout/Model/Type/Multishipping/State.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Model/Type/Multishipping/State.php
+++ b/app/code/core/Mage/Checkout/Model/Type/Multishipping/State.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Model/Type/Onepage.php
+++ b/app/code/core/Mage/Checkout/Model/Type/Onepage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/Model/Type/Onepage.php
+++ b/app/code/core/Mage/Checkout/Model/Type/Onepage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/Model/Type/Onepage.php
+++ b/app/code/core/Mage/Checkout/Model/Type/Onepage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/controllers/CartController.php
+++ b/app/code/core/Mage/Checkout/controllers/CartController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/controllers/CartController.php
+++ b/app/code/core/Mage/Checkout/controllers/CartController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/controllers/CartController.php
+++ b/app/code/core/Mage/Checkout/controllers/CartController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/controllers/IndexController.php
+++ b/app/code/core/Mage/Checkout/controllers/IndexController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/controllers/IndexController.php
+++ b/app/code/core/Mage/Checkout/controllers/IndexController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/controllers/IndexController.php
+++ b/app/code/core/Mage/Checkout/controllers/IndexController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/controllers/Multishipping/AddressController.php
+++ b/app/code/core/Mage/Checkout/controllers/Multishipping/AddressController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/controllers/Multishipping/AddressController.php
+++ b/app/code/core/Mage/Checkout/controllers/Multishipping/AddressController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/controllers/Multishipping/AddressController.php
+++ b/app/code/core/Mage/Checkout/controllers/Multishipping/AddressController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/controllers/MultishippingController.php
+++ b/app/code/core/Mage/Checkout/controllers/MultishippingController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/controllers/MultishippingController.php
+++ b/app/code/core/Mage/Checkout/controllers/MultishippingController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/controllers/MultishippingController.php
+++ b/app/code/core/Mage/Checkout/controllers/MultishippingController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/controllers/OnepageController.php
+++ b/app/code/core/Mage/Checkout/controllers/OnepageController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/controllers/OnepageController.php
+++ b/app/code/core/Mage/Checkout/controllers/OnepageController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/controllers/OnepageController.php
+++ b/app/code/core/Mage/Checkout/controllers/OnepageController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/etc/adminhtml.xml
+++ b/app/code/core/Mage/Checkout/etc/adminhtml.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/etc/adminhtml.xml
+++ b/app/code/core/Mage/Checkout/etc/adminhtml.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/etc/adminhtml.xml
+++ b/app/code/core/Mage/Checkout/etc/adminhtml.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/etc/api.xml
+++ b/app/code/core/Mage/Checkout/etc/api.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/etc/api.xml
+++ b/app/code/core/Mage/Checkout/etc/api.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/etc/api.xml
+++ b/app/code/core/Mage/Checkout/etc/api.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/etc/config.xml
+++ b/app/code/core/Mage/Checkout/etc/config.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/etc/config.xml
+++ b/app/code/core/Mage/Checkout/etc/config.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/etc/config.xml
+++ b/app/code/core/Mage/Checkout/etc/config.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/etc/jstranslator.xml
+++ b/app/code/core/Mage/Checkout/etc/jstranslator.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/etc/jstranslator.xml
+++ b/app/code/core/Mage/Checkout/etc/jstranslator.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/etc/jstranslator.xml
+++ b/app/code/core/Mage/Checkout/etc/jstranslator.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/etc/system.xml
+++ b/app/code/core/Mage/Checkout/etc/system.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/etc/system.xml
+++ b/app/code/core/Mage/Checkout/etc/system.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/etc/system.xml
+++ b/app/code/core/Mage/Checkout/etc/system.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/sql/checkout_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Checkout/sql/checkout_setup/install-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/sql/checkout_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Checkout/sql/checkout_setup/install-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/sql/checkout_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Checkout/sql/checkout_setup/install-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/sql/checkout_setup/mysql4-install-0.9.1.php
+++ b/app/code/core/Mage/Checkout/sql/checkout_setup/mysql4-install-0.9.1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/sql/checkout_setup/mysql4-install-0.9.1.php
+++ b/app/code/core/Mage/Checkout/sql/checkout_setup/mysql4-install-0.9.1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/sql/checkout_setup/mysql4-install-0.9.1.php
+++ b/app/code/core/Mage/Checkout/sql/checkout_setup/mysql4-install-0.9.1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/sql/checkout_setup/mysql4-upgrade-0.9.0-0.9.1.php
+++ b/app/code/core/Mage/Checkout/sql/checkout_setup/mysql4-upgrade-0.9.0-0.9.1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/sql/checkout_setup/mysql4-upgrade-0.9.0-0.9.1.php
+++ b/app/code/core/Mage/Checkout/sql/checkout_setup/mysql4-upgrade-0.9.0-0.9.1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/sql/checkout_setup/mysql4-upgrade-0.9.0-0.9.1.php
+++ b/app/code/core/Mage/Checkout/sql/checkout_setup/mysql4-upgrade-0.9.0-0.9.1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/sql/checkout_setup/mysql4-upgrade-0.9.1-0.9.2.php
+++ b/app/code/core/Mage/Checkout/sql/checkout_setup/mysql4-upgrade-0.9.1-0.9.2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/sql/checkout_setup/mysql4-upgrade-0.9.1-0.9.2.php
+++ b/app/code/core/Mage/Checkout/sql/checkout_setup/mysql4-upgrade-0.9.1-0.9.2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/sql/checkout_setup/mysql4-upgrade-0.9.1-0.9.2.php
+++ b/app/code/core/Mage/Checkout/sql/checkout_setup/mysql4-upgrade-0.9.1-0.9.2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/sql/checkout_setup/mysql4-upgrade-0.9.2-0.9.3.php
+++ b/app/code/core/Mage/Checkout/sql/checkout_setup/mysql4-upgrade-0.9.2-0.9.3.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/sql/checkout_setup/mysql4-upgrade-0.9.2-0.9.3.php
+++ b/app/code/core/Mage/Checkout/sql/checkout_setup/mysql4-upgrade-0.9.2-0.9.3.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/sql/checkout_setup/mysql4-upgrade-0.9.2-0.9.3.php
+++ b/app/code/core/Mage/Checkout/sql/checkout_setup/mysql4-upgrade-0.9.2-0.9.3.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/sql/checkout_setup/mysql4-upgrade-0.9.3-0.9.4.php
+++ b/app/code/core/Mage/Checkout/sql/checkout_setup/mysql4-upgrade-0.9.3-0.9.4.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/sql/checkout_setup/mysql4-upgrade-0.9.3-0.9.4.php
+++ b/app/code/core/Mage/Checkout/sql/checkout_setup/mysql4-upgrade-0.9.3-0.9.4.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/sql/checkout_setup/mysql4-upgrade-0.9.3-0.9.4.php
+++ b/app/code/core/Mage/Checkout/sql/checkout_setup/mysql4-upgrade-0.9.3-0.9.4.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/sql/checkout_setup/mysql4-upgrade-0.9.4-0.9.5.php
+++ b/app/code/core/Mage/Checkout/sql/checkout_setup/mysql4-upgrade-0.9.4-0.9.5.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/sql/checkout_setup/mysql4-upgrade-0.9.4-0.9.5.php
+++ b/app/code/core/Mage/Checkout/sql/checkout_setup/mysql4-upgrade-0.9.4-0.9.5.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/sql/checkout_setup/mysql4-upgrade-0.9.4-0.9.5.php
+++ b/app/code/core/Mage/Checkout/sql/checkout_setup/mysql4-upgrade-0.9.4-0.9.5.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/sql/checkout_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/Checkout/sql/checkout_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/sql/checkout_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/Checkout/sql/checkout_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/sql/checkout_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/Checkout/sql/checkout_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/sql/checkout_setup/mysql4-upgrade-1.6.0.0-1.6.0.1.php
+++ b/app/code/core/Mage/Checkout/sql/checkout_setup/mysql4-upgrade-1.6.0.0-1.6.0.1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Checkout/sql/checkout_setup/mysql4-upgrade-1.6.0.0-1.6.0.1.php
+++ b/app/code/core/Mage/Checkout/sql/checkout_setup/mysql4-upgrade-1.6.0.0-1.6.0.1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Checkout/sql/checkout_setup/mysql4-upgrade-1.6.0.0-1.6.0.1.php
+++ b/app/code/core/Mage/Checkout/sql/checkout_setup/mysql4-upgrade-1.6.0.0-1.6.0.1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/code/core/Mage/Cms/Block/Block.php
+++ b/app/code/core/Mage/Cms/Block/Block.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Cms/Block/Block.php
+++ b/app/code/core/Mage/Cms/Block/Block.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/Block/Block.php
+++ b/app/code/core/Mage/Cms/Block/Block.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/Block/Page.php
+++ b/app/code/core/Mage/Cms/Block/Page.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Cms/Block/Page.php
+++ b/app/code/core/Mage/Cms/Block/Page.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/Block/Page.php
+++ b/app/code/core/Mage/Cms/Block/Page.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/Block/Widget/Block.php
+++ b/app/code/core/Mage/Cms/Block/Widget/Block.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Cms/Block/Widget/Block.php
+++ b/app/code/core/Mage/Cms/Block/Widget/Block.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/Block/Widget/Block.php
+++ b/app/code/core/Mage/Cms/Block/Widget/Block.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/Block/Widget/Page/Link.php
+++ b/app/code/core/Mage/Cms/Block/Widget/Page/Link.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Cms/Block/Widget/Page/Link.php
+++ b/app/code/core/Mage/Cms/Block/Widget/Page/Link.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/Block/Widget/Page/Link.php
+++ b/app/code/core/Mage/Cms/Block/Widget/Page/Link.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/Controller/Router.php
+++ b/app/code/core/Mage/Cms/Controller/Router.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Cms/Controller/Router.php
+++ b/app/code/core/Mage/Cms/Controller/Router.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/Controller/Router.php
+++ b/app/code/core/Mage/Cms/Controller/Router.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/Helper/Data.php
+++ b/app/code/core/Mage/Cms/Helper/Data.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Cms/Helper/Data.php
+++ b/app/code/core/Mage/Cms/Helper/Data.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/Helper/Data.php
+++ b/app/code/core/Mage/Cms/Helper/Data.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/Helper/Page.php
+++ b/app/code/core/Mage/Cms/Helper/Page.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Cms/Helper/Page.php
+++ b/app/code/core/Mage/Cms/Helper/Page.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/Helper/Page.php
+++ b/app/code/core/Mage/Cms/Helper/Page.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/Helper/Wysiwyg/Images.php
+++ b/app/code/core/Mage/Cms/Helper/Wysiwyg/Images.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Cms/Helper/Wysiwyg/Images.php
+++ b/app/code/core/Mage/Cms/Helper/Wysiwyg/Images.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/Helper/Wysiwyg/Images.php
+++ b/app/code/core/Mage/Cms/Helper/Wysiwyg/Images.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/Model/Adminhtml/Template/Filter.php
+++ b/app/code/core/Mage/Cms/Model/Adminhtml/Template/Filter.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Cms/Model/Adminhtml/Template/Filter.php
+++ b/app/code/core/Mage/Cms/Model/Adminhtml/Template/Filter.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/Model/Adminhtml/Template/Filter.php
+++ b/app/code/core/Mage/Cms/Model/Adminhtml/Template/Filter.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/Model/Block.php
+++ b/app/code/core/Mage/Cms/Model/Block.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Cms/Model/Block.php
+++ b/app/code/core/Mage/Cms/Model/Block.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/Model/Block.php
+++ b/app/code/core/Mage/Cms/Model/Block.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/Model/Mysql4/Block.php
+++ b/app/code/core/Mage/Cms/Model/Mysql4/Block.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Cms/Model/Mysql4/Block.php
+++ b/app/code/core/Mage/Cms/Model/Mysql4/Block.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/Model/Mysql4/Block.php
+++ b/app/code/core/Mage/Cms/Model/Mysql4/Block.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/Model/Mysql4/Block/Collection.php
+++ b/app/code/core/Mage/Cms/Model/Mysql4/Block/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Cms/Model/Mysql4/Block/Collection.php
+++ b/app/code/core/Mage/Cms/Model/Mysql4/Block/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/Model/Mysql4/Block/Collection.php
+++ b/app/code/core/Mage/Cms/Model/Mysql4/Block/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/Model/Mysql4/Page.php
+++ b/app/code/core/Mage/Cms/Model/Mysql4/Page.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Cms/Model/Mysql4/Page.php
+++ b/app/code/core/Mage/Cms/Model/Mysql4/Page.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/Model/Mysql4/Page.php
+++ b/app/code/core/Mage/Cms/Model/Mysql4/Page.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/Model/Mysql4/Page/Collection.php
+++ b/app/code/core/Mage/Cms/Model/Mysql4/Page/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Cms/Model/Mysql4/Page/Collection.php
+++ b/app/code/core/Mage/Cms/Model/Mysql4/Page/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/Model/Mysql4/Page/Collection.php
+++ b/app/code/core/Mage/Cms/Model/Mysql4/Page/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/Model/Mysql4/Page/Service.php
+++ b/app/code/core/Mage/Cms/Model/Mysql4/Page/Service.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Cms/Model/Mysql4/Page/Service.php
+++ b/app/code/core/Mage/Cms/Model/Mysql4/Page/Service.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/Model/Mysql4/Page/Service.php
+++ b/app/code/core/Mage/Cms/Model/Mysql4/Page/Service.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/Model/Observer.php
+++ b/app/code/core/Mage/Cms/Model/Observer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Cms/Model/Observer.php
+++ b/app/code/core/Mage/Cms/Model/Observer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/Model/Observer.php
+++ b/app/code/core/Mage/Cms/Model/Observer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/Model/Page.php
+++ b/app/code/core/Mage/Cms/Model/Page.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Cms/Model/Page.php
+++ b/app/code/core/Mage/Cms/Model/Page.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/Model/Page.php
+++ b/app/code/core/Mage/Cms/Model/Page.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/Model/Resource/Block.php
+++ b/app/code/core/Mage/Cms/Model/Resource/Block.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Cms/Model/Resource/Block.php
+++ b/app/code/core/Mage/Cms/Model/Resource/Block.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/Model/Resource/Block.php
+++ b/app/code/core/Mage/Cms/Model/Resource/Block.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/Model/Resource/Block/Collection.php
+++ b/app/code/core/Mage/Cms/Model/Resource/Block/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Cms/Model/Resource/Block/Collection.php
+++ b/app/code/core/Mage/Cms/Model/Resource/Block/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/Model/Resource/Block/Collection.php
+++ b/app/code/core/Mage/Cms/Model/Resource/Block/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/Model/Resource/Page.php
+++ b/app/code/core/Mage/Cms/Model/Resource/Page.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Cms/Model/Resource/Page.php
+++ b/app/code/core/Mage/Cms/Model/Resource/Page.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/Model/Resource/Page.php
+++ b/app/code/core/Mage/Cms/Model/Resource/Page.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/Model/Resource/Page/Collection.php
+++ b/app/code/core/Mage/Cms/Model/Resource/Page/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Cms/Model/Resource/Page/Collection.php
+++ b/app/code/core/Mage/Cms/Model/Resource/Page/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/Model/Resource/Page/Collection.php
+++ b/app/code/core/Mage/Cms/Model/Resource/Page/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/Model/Resource/Page/Service.php
+++ b/app/code/core/Mage/Cms/Model/Resource/Page/Service.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Cms/Model/Resource/Page/Service.php
+++ b/app/code/core/Mage/Cms/Model/Resource/Page/Service.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/Model/Resource/Page/Service.php
+++ b/app/code/core/Mage/Cms/Model/Resource/Page/Service.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/Model/Template/Filter.php
+++ b/app/code/core/Mage/Cms/Model/Template/Filter.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Cms/Model/Template/Filter.php
+++ b/app/code/core/Mage/Cms/Model/Template/Filter.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/Model/Template/Filter.php
+++ b/app/code/core/Mage/Cms/Model/Template/Filter.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/Model/Wysiwyg/Config.php
+++ b/app/code/core/Mage/Cms/Model/Wysiwyg/Config.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Cms/Model/Wysiwyg/Config.php
+++ b/app/code/core/Mage/Cms/Model/Wysiwyg/Config.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/Model/Wysiwyg/Config.php
+++ b/app/code/core/Mage/Cms/Model/Wysiwyg/Config.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/Model/Wysiwyg/Images/Storage.php
+++ b/app/code/core/Mage/Cms/Model/Wysiwyg/Images/Storage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Cms/Model/Wysiwyg/Images/Storage.php
+++ b/app/code/core/Mage/Cms/Model/Wysiwyg/Images/Storage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/Model/Wysiwyg/Images/Storage.php
+++ b/app/code/core/Mage/Cms/Model/Wysiwyg/Images/Storage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/Model/Wysiwyg/Images/Storage/Collection.php
+++ b/app/code/core/Mage/Cms/Model/Wysiwyg/Images/Storage/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Cms/Model/Wysiwyg/Images/Storage/Collection.php
+++ b/app/code/core/Mage/Cms/Model/Wysiwyg/Images/Storage/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/Model/Wysiwyg/Images/Storage/Collection.php
+++ b/app/code/core/Mage/Cms/Model/Wysiwyg/Images/Storage/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/controllers/IndexController.php
+++ b/app/code/core/Mage/Cms/controllers/IndexController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Cms/controllers/IndexController.php
+++ b/app/code/core/Mage/Cms/controllers/IndexController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/controllers/IndexController.php
+++ b/app/code/core/Mage/Cms/controllers/IndexController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/controllers/PageController.php
+++ b/app/code/core/Mage/Cms/controllers/PageController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Cms/controllers/PageController.php
+++ b/app/code/core/Mage/Cms/controllers/PageController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/controllers/PageController.php
+++ b/app/code/core/Mage/Cms/controllers/PageController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/data/cms_setup/data-install-1.6.0.0.php
+++ b/app/code/core/Mage/Cms/data/cms_setup/data-install-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Cms/data/cms_setup/data-install-1.6.0.0.php
+++ b/app/code/core/Mage/Cms/data/cms_setup/data-install-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/data/cms_setup/data-install-1.6.0.0.php
+++ b/app/code/core/Mage/Cms/data/cms_setup/data-install-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/data/cms_setup/data-upgrade-1.6.0.0.0-1.6.0.0.1.php
+++ b/app/code/core/Mage/Cms/data/cms_setup/data-upgrade-1.6.0.0.0-1.6.0.0.1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Cms/data/cms_setup/data-upgrade-1.6.0.0.0-1.6.0.0.1.php
+++ b/app/code/core/Mage/Cms/data/cms_setup/data-upgrade-1.6.0.0.0-1.6.0.0.1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/data/cms_setup/data-upgrade-1.6.0.0.0-1.6.0.0.1.php
+++ b/app/code/core/Mage/Cms/data/cms_setup/data-upgrade-1.6.0.0.0-1.6.0.0.1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/data/cms_setup/data-upgrade-1.6.0.0.1-1.6.0.0.2.php
+++ b/app/code/core/Mage/Cms/data/cms_setup/data-upgrade-1.6.0.0.1-1.6.0.0.2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Cms/data/cms_setup/data-upgrade-1.6.0.0.1-1.6.0.0.2.php
+++ b/app/code/core/Mage/Cms/data/cms_setup/data-upgrade-1.6.0.0.1-1.6.0.0.2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/data/cms_setup/data-upgrade-1.6.0.0.1-1.6.0.0.2.php
+++ b/app/code/core/Mage/Cms/data/cms_setup/data-upgrade-1.6.0.0.1-1.6.0.0.2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/etc/adminhtml.xml
+++ b/app/code/core/Mage/Cms/etc/adminhtml.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/etc/adminhtml.xml
+++ b/app/code/core/Mage/Cms/etc/adminhtml.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/etc/adminhtml.xml
+++ b/app/code/core/Mage/Cms/etc/adminhtml.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Cms/etc/config.xml
+++ b/app/code/core/Mage/Cms/etc/config.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/etc/config.xml
+++ b/app/code/core/Mage/Cms/etc/config.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/etc/config.xml
+++ b/app/code/core/Mage/Cms/etc/config.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Cms/etc/system.xml
+++ b/app/code/core/Mage/Cms/etc/system.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/etc/system.xml
+++ b/app/code/core/Mage/Cms/etc/system.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/etc/system.xml
+++ b/app/code/core/Mage/Cms/etc/system.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Cms/etc/widget.xml
+++ b/app/code/core/Mage/Cms/etc/widget.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/etc/widget.xml
+++ b/app/code/core/Mage/Cms/etc/widget.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/etc/widget.xml
+++ b/app/code/core/Mage/Cms/etc/widget.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Cms/sql/cms_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Cms/sql/cms_setup/install-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Cms/sql/cms_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Cms/sql/cms_setup/install-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/sql/cms_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Cms/sql/cms_setup/install-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/sql/cms_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/Cms/sql/cms_setup/mysql4-install-0.7.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Cms/sql/cms_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/Cms/sql/cms_setup/mysql4-install-0.7.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/sql/cms_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/Cms/sql/cms_setup/mysql4-install-0.7.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/sql/cms_setup/mysql4-upgrade-0.7.0-0.7.1.php
+++ b/app/code/core/Mage/Cms/sql/cms_setup/mysql4-upgrade-0.7.0-0.7.1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Cms/sql/cms_setup/mysql4-upgrade-0.7.0-0.7.1.php
+++ b/app/code/core/Mage/Cms/sql/cms_setup/mysql4-upgrade-0.7.0-0.7.1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/sql/cms_setup/mysql4-upgrade-0.7.0-0.7.1.php
+++ b/app/code/core/Mage/Cms/sql/cms_setup/mysql4-upgrade-0.7.0-0.7.1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/sql/cms_setup/mysql4-upgrade-0.7.1-0.7.2.php
+++ b/app/code/core/Mage/Cms/sql/cms_setup/mysql4-upgrade-0.7.1-0.7.2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Cms/sql/cms_setup/mysql4-upgrade-0.7.1-0.7.2.php
+++ b/app/code/core/Mage/Cms/sql/cms_setup/mysql4-upgrade-0.7.1-0.7.2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/sql/cms_setup/mysql4-upgrade-0.7.1-0.7.2.php
+++ b/app/code/core/Mage/Cms/sql/cms_setup/mysql4-upgrade-0.7.1-0.7.2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/sql/cms_setup/mysql4-upgrade-0.7.10-0.7.11.php
+++ b/app/code/core/Mage/Cms/sql/cms_setup/mysql4-upgrade-0.7.10-0.7.11.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Cms/sql/cms_setup/mysql4-upgrade-0.7.10-0.7.11.php
+++ b/app/code/core/Mage/Cms/sql/cms_setup/mysql4-upgrade-0.7.10-0.7.11.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/sql/cms_setup/mysql4-upgrade-0.7.10-0.7.11.php
+++ b/app/code/core/Mage/Cms/sql/cms_setup/mysql4-upgrade-0.7.10-0.7.11.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/sql/cms_setup/mysql4-upgrade-0.7.11-0.7.12.php
+++ b/app/code/core/Mage/Cms/sql/cms_setup/mysql4-upgrade-0.7.11-0.7.12.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Cms/sql/cms_setup/mysql4-upgrade-0.7.11-0.7.12.php
+++ b/app/code/core/Mage/Cms/sql/cms_setup/mysql4-upgrade-0.7.11-0.7.12.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/sql/cms_setup/mysql4-upgrade-0.7.11-0.7.12.php
+++ b/app/code/core/Mage/Cms/sql/cms_setup/mysql4-upgrade-0.7.11-0.7.12.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/sql/cms_setup/mysql4-upgrade-0.7.12-0.7.13.php
+++ b/app/code/core/Mage/Cms/sql/cms_setup/mysql4-upgrade-0.7.12-0.7.13.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Cms/sql/cms_setup/mysql4-upgrade-0.7.12-0.7.13.php
+++ b/app/code/core/Mage/Cms/sql/cms_setup/mysql4-upgrade-0.7.12-0.7.13.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/sql/cms_setup/mysql4-upgrade-0.7.12-0.7.13.php
+++ b/app/code/core/Mage/Cms/sql/cms_setup/mysql4-upgrade-0.7.12-0.7.13.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/sql/cms_setup/mysql4-upgrade-0.7.2-0.7.3.php
+++ b/app/code/core/Mage/Cms/sql/cms_setup/mysql4-upgrade-0.7.2-0.7.3.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Cms/sql/cms_setup/mysql4-upgrade-0.7.2-0.7.3.php
+++ b/app/code/core/Mage/Cms/sql/cms_setup/mysql4-upgrade-0.7.2-0.7.3.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/sql/cms_setup/mysql4-upgrade-0.7.2-0.7.3.php
+++ b/app/code/core/Mage/Cms/sql/cms_setup/mysql4-upgrade-0.7.2-0.7.3.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/sql/cms_setup/mysql4-upgrade-0.7.4-0.7.5.php
+++ b/app/code/core/Mage/Cms/sql/cms_setup/mysql4-upgrade-0.7.4-0.7.5.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Cms/sql/cms_setup/mysql4-upgrade-0.7.4-0.7.5.php
+++ b/app/code/core/Mage/Cms/sql/cms_setup/mysql4-upgrade-0.7.4-0.7.5.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/sql/cms_setup/mysql4-upgrade-0.7.4-0.7.5.php
+++ b/app/code/core/Mage/Cms/sql/cms_setup/mysql4-upgrade-0.7.4-0.7.5.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/sql/cms_setup/mysql4-upgrade-0.7.5-0.7.6.php
+++ b/app/code/core/Mage/Cms/sql/cms_setup/mysql4-upgrade-0.7.5-0.7.6.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Cms/sql/cms_setup/mysql4-upgrade-0.7.5-0.7.6.php
+++ b/app/code/core/Mage/Cms/sql/cms_setup/mysql4-upgrade-0.7.5-0.7.6.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/sql/cms_setup/mysql4-upgrade-0.7.5-0.7.6.php
+++ b/app/code/core/Mage/Cms/sql/cms_setup/mysql4-upgrade-0.7.5-0.7.6.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/sql/cms_setup/mysql4-upgrade-0.7.7-0.7.8.php
+++ b/app/code/core/Mage/Cms/sql/cms_setup/mysql4-upgrade-0.7.7-0.7.8.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Cms/sql/cms_setup/mysql4-upgrade-0.7.7-0.7.8.php
+++ b/app/code/core/Mage/Cms/sql/cms_setup/mysql4-upgrade-0.7.7-0.7.8.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/sql/cms_setup/mysql4-upgrade-0.7.7-0.7.8.php
+++ b/app/code/core/Mage/Cms/sql/cms_setup/mysql4-upgrade-0.7.7-0.7.8.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/sql/cms_setup/mysql4-upgrade-0.7.8-0.7.9.php
+++ b/app/code/core/Mage/Cms/sql/cms_setup/mysql4-upgrade-0.7.8-0.7.9.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Cms/sql/cms_setup/mysql4-upgrade-0.7.8-0.7.9.php
+++ b/app/code/core/Mage/Cms/sql/cms_setup/mysql4-upgrade-0.7.8-0.7.9.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/sql/cms_setup/mysql4-upgrade-0.7.8-0.7.9.php
+++ b/app/code/core/Mage/Cms/sql/cms_setup/mysql4-upgrade-0.7.8-0.7.9.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/sql/cms_setup/mysql4-upgrade-0.7.9-0.7.10.php
+++ b/app/code/core/Mage/Cms/sql/cms_setup/mysql4-upgrade-0.7.9-0.7.10.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Cms/sql/cms_setup/mysql4-upgrade-0.7.9-0.7.10.php
+++ b/app/code/core/Mage/Cms/sql/cms_setup/mysql4-upgrade-0.7.9-0.7.10.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/sql/cms_setup/mysql4-upgrade-0.7.9-0.7.10.php
+++ b/app/code/core/Mage/Cms/sql/cms_setup/mysql4-upgrade-0.7.9-0.7.10.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/sql/cms_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/Cms/sql/cms_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Cms/sql/cms_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/Cms/sql/cms_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/Cms/sql/cms_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/Cms/sql/cms_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/code/core/Mage/ConfigurableSwatches/Block/Catalog/Layer/State/Swatch.php
+++ b/app/code/core/Mage/ConfigurableSwatches/Block/Catalog/Layer/State/Swatch.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ConfigurableSwatches/Block/Catalog/Layer/State/Swatch.php
+++ b/app/code/core/Mage/ConfigurableSwatches/Block/Catalog/Layer/State/Swatch.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ConfigurableSwatches

--- a/app/code/core/Mage/ConfigurableSwatches/Block/Catalog/Layer/State/Swatch.php
+++ b/app/code/core/Mage/ConfigurableSwatches/Block/Catalog/Layer/State/Swatch.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ConfigurableSwatches

--- a/app/code/core/Mage/ConfigurableSwatches/Block/Catalog/Media/Js/Abstract.php
+++ b/app/code/core/Mage/ConfigurableSwatches/Block/Catalog/Media/Js/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ConfigurableSwatches/Block/Catalog/Media/Js/Abstract.php
+++ b/app/code/core/Mage/ConfigurableSwatches/Block/Catalog/Media/Js/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ConfigurableSwatches

--- a/app/code/core/Mage/ConfigurableSwatches/Block/Catalog/Media/Js/Abstract.php
+++ b/app/code/core/Mage/ConfigurableSwatches/Block/Catalog/Media/Js/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ConfigurableSwatches

--- a/app/code/core/Mage/ConfigurableSwatches/Block/Catalog/Media/Js/List.php
+++ b/app/code/core/Mage/ConfigurableSwatches/Block/Catalog/Media/Js/List.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ConfigurableSwatches/Block/Catalog/Media/Js/List.php
+++ b/app/code/core/Mage/ConfigurableSwatches/Block/Catalog/Media/Js/List.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ConfigurableSwatches

--- a/app/code/core/Mage/ConfigurableSwatches/Block/Catalog/Media/Js/List.php
+++ b/app/code/core/Mage/ConfigurableSwatches/Block/Catalog/Media/Js/List.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ConfigurableSwatches

--- a/app/code/core/Mage/ConfigurableSwatches/Block/Catalog/Media/Js/Product.php
+++ b/app/code/core/Mage/ConfigurableSwatches/Block/Catalog/Media/Js/Product.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ConfigurableSwatches/Block/Catalog/Media/Js/Product.php
+++ b/app/code/core/Mage/ConfigurableSwatches/Block/Catalog/Media/Js/Product.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ConfigurableSwatches

--- a/app/code/core/Mage/ConfigurableSwatches/Block/Catalog/Media/Js/Product.php
+++ b/app/code/core/Mage/ConfigurableSwatches/Block/Catalog/Media/Js/Product.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ConfigurableSwatches

--- a/app/code/core/Mage/ConfigurableSwatches/Block/Catalog/Product/List/Price.php
+++ b/app/code/core/Mage/ConfigurableSwatches/Block/Catalog/Product/List/Price.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ConfigurableSwatches/Block/Catalog/Product/List/Price.php
+++ b/app/code/core/Mage/ConfigurableSwatches/Block/Catalog/Product/List/Price.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ConfigurableSwatches

--- a/app/code/core/Mage/ConfigurableSwatches/Block/Catalog/Product/List/Price.php
+++ b/app/code/core/Mage/ConfigurableSwatches/Block/Catalog/Product/List/Price.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ConfigurableSwatches

--- a/app/code/core/Mage/ConfigurableSwatches/Block/Catalog/Product/View/Type/Configurable/Swatches.php
+++ b/app/code/core/Mage/ConfigurableSwatches/Block/Catalog/Product/View/Type/Configurable/Swatches.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ConfigurableSwatches/Block/Catalog/Product/View/Type/Configurable/Swatches.php
+++ b/app/code/core/Mage/ConfigurableSwatches/Block/Catalog/Product/View/Type/Configurable/Swatches.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ConfigurableSwatches

--- a/app/code/core/Mage/ConfigurableSwatches/Block/Catalog/Product/View/Type/Configurable/Swatches.php
+++ b/app/code/core/Mage/ConfigurableSwatches/Block/Catalog/Product/View/Type/Configurable/Swatches.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ConfigurableSwatches

--- a/app/code/core/Mage/ConfigurableSwatches/Helper/Data.php
+++ b/app/code/core/Mage/ConfigurableSwatches/Helper/Data.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ConfigurableSwatches/Helper/Data.php
+++ b/app/code/core/Mage/ConfigurableSwatches/Helper/Data.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ConfigurableSwatches

--- a/app/code/core/Mage/ConfigurableSwatches/Helper/Data.php
+++ b/app/code/core/Mage/ConfigurableSwatches/Helper/Data.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ConfigurableSwatches

--- a/app/code/core/Mage/ConfigurableSwatches/Helper/List/Price.php
+++ b/app/code/core/Mage/ConfigurableSwatches/Helper/List/Price.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ConfigurableSwatches/Helper/List/Price.php
+++ b/app/code/core/Mage/ConfigurableSwatches/Helper/List/Price.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ConfigurableSwatches

--- a/app/code/core/Mage/ConfigurableSwatches/Helper/List/Price.php
+++ b/app/code/core/Mage/ConfigurableSwatches/Helper/List/Price.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ConfigurableSwatches

--- a/app/code/core/Mage/ConfigurableSwatches/Helper/Mediafallback.php
+++ b/app/code/core/Mage/ConfigurableSwatches/Helper/Mediafallback.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ConfigurableSwatches/Helper/Mediafallback.php
+++ b/app/code/core/Mage/ConfigurableSwatches/Helper/Mediafallback.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ConfigurableSwatches

--- a/app/code/core/Mage/ConfigurableSwatches/Helper/Mediafallback.php
+++ b/app/code/core/Mage/ConfigurableSwatches/Helper/Mediafallback.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ConfigurableSwatches

--- a/app/code/core/Mage/ConfigurableSwatches/Helper/Productimg.php
+++ b/app/code/core/Mage/ConfigurableSwatches/Helper/Productimg.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ConfigurableSwatches/Helper/Productimg.php
+++ b/app/code/core/Mage/ConfigurableSwatches/Helper/Productimg.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ConfigurableSwatches

--- a/app/code/core/Mage/ConfigurableSwatches/Helper/Productimg.php
+++ b/app/code/core/Mage/ConfigurableSwatches/Helper/Productimg.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ConfigurableSwatches

--- a/app/code/core/Mage/ConfigurableSwatches/Helper/Productlist.php
+++ b/app/code/core/Mage/ConfigurableSwatches/Helper/Productlist.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ConfigurableSwatches/Helper/Productlist.php
+++ b/app/code/core/Mage/ConfigurableSwatches/Helper/Productlist.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ConfigurableSwatches

--- a/app/code/core/Mage/ConfigurableSwatches/Helper/Productlist.php
+++ b/app/code/core/Mage/ConfigurableSwatches/Helper/Productlist.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ConfigurableSwatches

--- a/app/code/core/Mage/ConfigurableSwatches/Helper/Swatchdimensions.php
+++ b/app/code/core/Mage/ConfigurableSwatches/Helper/Swatchdimensions.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ConfigurableSwatches/Helper/Swatchdimensions.php
+++ b/app/code/core/Mage/ConfigurableSwatches/Helper/Swatchdimensions.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ConfigurableSwatches

--- a/app/code/core/Mage/ConfigurableSwatches/Helper/Swatchdimensions.php
+++ b/app/code/core/Mage/ConfigurableSwatches/Helper/Swatchdimensions.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ConfigurableSwatches

--- a/app/code/core/Mage/ConfigurableSwatches/Model/Observer.php
+++ b/app/code/core/Mage/ConfigurableSwatches/Model/Observer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ConfigurableSwatches/Model/Observer.php
+++ b/app/code/core/Mage/ConfigurableSwatches/Model/Observer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ConfigurableSwatches

--- a/app/code/core/Mage/ConfigurableSwatches/Model/Observer.php
+++ b/app/code/core/Mage/ConfigurableSwatches/Model/Observer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ConfigurableSwatches

--- a/app/code/core/Mage/ConfigurableSwatches/Model/Resource/Catalog/Product/Attribute/Super/Collection.php
+++ b/app/code/core/Mage/ConfigurableSwatches/Model/Resource/Catalog/Product/Attribute/Super/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ConfigurableSwatches/Model/Resource/Catalog/Product/Attribute/Super/Collection.php
+++ b/app/code/core/Mage/ConfigurableSwatches/Model/Resource/Catalog/Product/Attribute/Super/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ConfigurableSwatches

--- a/app/code/core/Mage/ConfigurableSwatches/Model/Resource/Catalog/Product/Attribute/Super/Collection.php
+++ b/app/code/core/Mage/ConfigurableSwatches/Model/Resource/Catalog/Product/Attribute/Super/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ConfigurableSwatches

--- a/app/code/core/Mage/ConfigurableSwatches/Model/Resource/Catalog/Product/Type/Configurable.php
+++ b/app/code/core/Mage/ConfigurableSwatches/Model/Resource/Catalog/Product/Type/Configurable.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ConfigurableSwatches/Model/Resource/Catalog/Product/Type/Configurable.php
+++ b/app/code/core/Mage/ConfigurableSwatches/Model/Resource/Catalog/Product/Type/Configurable.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ConfigurableSwatches

--- a/app/code/core/Mage/ConfigurableSwatches/Model/Resource/Catalog/Product/Type/Configurable.php
+++ b/app/code/core/Mage/ConfigurableSwatches/Model/Resource/Catalog/Product/Type/Configurable.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ConfigurableSwatches

--- a/app/code/core/Mage/ConfigurableSwatches/Model/Resource/Catalog/Product/Type/Configurable/Product/Collection.php
+++ b/app/code/core/Mage/ConfigurableSwatches/Model/Resource/Catalog/Product/Type/Configurable/Product/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ConfigurableSwatches/Model/Resource/Catalog/Product/Type/Configurable/Product/Collection.php
+++ b/app/code/core/Mage/ConfigurableSwatches/Model/Resource/Catalog/Product/Type/Configurable/Product/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ConfigurableSwatches

--- a/app/code/core/Mage/ConfigurableSwatches/Model/Resource/Catalog/Product/Type/Configurable/Product/Collection.php
+++ b/app/code/core/Mage/ConfigurableSwatches/Model/Resource/Catalog/Product/Type/Configurable/Product/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ConfigurableSwatches

--- a/app/code/core/Mage/ConfigurableSwatches/Model/System/Config/Source/Catalog/Product/Configattribute.php
+++ b/app/code/core/Mage/ConfigurableSwatches/Model/System/Config/Source/Catalog/Product/Configattribute.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ConfigurableSwatches/Model/System/Config/Source/Catalog/Product/Configattribute.php
+++ b/app/code/core/Mage/ConfigurableSwatches/Model/System/Config/Source/Catalog/Product/Configattribute.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ConfigurableSwatches

--- a/app/code/core/Mage/ConfigurableSwatches/Model/System/Config/Source/Catalog/Product/Configattribute.php
+++ b/app/code/core/Mage/ConfigurableSwatches/Model/System/Config/Source/Catalog/Product/Configattribute.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ConfigurableSwatches

--- a/app/code/core/Mage/ConfigurableSwatches/Model/System/Config/Source/Catalog/Product/Configattribute/Select.php
+++ b/app/code/core/Mage/ConfigurableSwatches/Model/System/Config/Source/Catalog/Product/Configattribute/Select.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ConfigurableSwatches/Model/System/Config/Source/Catalog/Product/Configattribute/Select.php
+++ b/app/code/core/Mage/ConfigurableSwatches/Model/System/Config/Source/Catalog/Product/Configattribute/Select.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ConfigurableSwatches

--- a/app/code/core/Mage/ConfigurableSwatches/Model/System/Config/Source/Catalog/Product/Configattribute/Select.php
+++ b/app/code/core/Mage/ConfigurableSwatches/Model/System/Config/Source/Catalog/Product/Configattribute/Select.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ConfigurableSwatches

--- a/app/code/core/Mage/ConfigurableSwatches/etc/adminhtml.xml
+++ b/app/code/core/Mage/ConfigurableSwatches/etc/adminhtml.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ConfigurableSwatches

--- a/app/code/core/Mage/ConfigurableSwatches/etc/adminhtml.xml
+++ b/app/code/core/Mage/ConfigurableSwatches/etc/adminhtml.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ConfigurableSwatches

--- a/app/code/core/Mage/ConfigurableSwatches/etc/adminhtml.xml
+++ b/app/code/core/Mage/ConfigurableSwatches/etc/adminhtml.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ConfigurableSwatches/etc/config.xml
+++ b/app/code/core/Mage/ConfigurableSwatches/etc/config.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ConfigurableSwatches

--- a/app/code/core/Mage/ConfigurableSwatches/etc/config.xml
+++ b/app/code/core/Mage/ConfigurableSwatches/etc/config.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ConfigurableSwatches

--- a/app/code/core/Mage/ConfigurableSwatches/etc/config.xml
+++ b/app/code/core/Mage/ConfigurableSwatches/etc/config.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ConfigurableSwatches/etc/jstranslator.xml
+++ b/app/code/core/Mage/ConfigurableSwatches/etc/jstranslator.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ConfigurableSwatches

--- a/app/code/core/Mage/ConfigurableSwatches/etc/jstranslator.xml
+++ b/app/code/core/Mage/ConfigurableSwatches/etc/jstranslator.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ConfigurableSwatches

--- a/app/code/core/Mage/ConfigurableSwatches/etc/jstranslator.xml
+++ b/app/code/core/Mage/ConfigurableSwatches/etc/jstranslator.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ConfigurableSwatches/etc/system.xml
+++ b/app/code/core/Mage/ConfigurableSwatches/etc/system.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ConfigurableSwatches

--- a/app/code/core/Mage/ConfigurableSwatches/etc/system.xml
+++ b/app/code/core/Mage/ConfigurableSwatches/etc/system.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ConfigurableSwatches

--- a/app/code/core/Mage/ConfigurableSwatches/etc/system.xml
+++ b/app/code/core/Mage/ConfigurableSwatches/etc/system.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Contacts/Helper/Data.php
+++ b/app/code/core/Mage/Contacts/Helper/Data.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Contacts/Helper/Data.php
+++ b/app/code/core/Mage/Contacts/Helper/Data.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Contacts

--- a/app/code/core/Mage/Contacts/Helper/Data.php
+++ b/app/code/core/Mage/Contacts/Helper/Data.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Contacts

--- a/app/code/core/Mage/Contacts/Model/System/Config/Backend/Links.php
+++ b/app/code/core/Mage/Contacts/Model/System/Config/Backend/Links.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Contacts/Model/System/Config/Backend/Links.php
+++ b/app/code/core/Mage/Contacts/Model/System/Config/Backend/Links.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Contacts

--- a/app/code/core/Mage/Contacts/Model/System/Config/Backend/Links.php
+++ b/app/code/core/Mage/Contacts/Model/System/Config/Backend/Links.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Contacts

--- a/app/code/core/Mage/Contacts/controllers/IndexController.php
+++ b/app/code/core/Mage/Contacts/controllers/IndexController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Contacts/controllers/IndexController.php
+++ b/app/code/core/Mage/Contacts/controllers/IndexController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Contacts

--- a/app/code/core/Mage/Contacts/controllers/IndexController.php
+++ b/app/code/core/Mage/Contacts/controllers/IndexController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Contacts

--- a/app/code/core/Mage/Contacts/etc/adminhtml.xml
+++ b/app/code/core/Mage/Contacts/etc/adminhtml.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Contacts

--- a/app/code/core/Mage/Contacts/etc/adminhtml.xml
+++ b/app/code/core/Mage/Contacts/etc/adminhtml.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Contacts/etc/adminhtml.xml
+++ b/app/code/core/Mage/Contacts/etc/adminhtml.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Contacts

--- a/app/code/core/Mage/Contacts/etc/config.xml
+++ b/app/code/core/Mage/Contacts/etc/config.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Contacts

--- a/app/code/core/Mage/Contacts/etc/config.xml
+++ b/app/code/core/Mage/Contacts/etc/config.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Contacts/etc/config.xml
+++ b/app/code/core/Mage/Contacts/etc/config.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Contacts

--- a/app/code/core/Mage/Contacts/etc/system.xml
+++ b/app/code/core/Mage/Contacts/etc/system.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Contacts

--- a/app/code/core/Mage/Contacts/etc/system.xml
+++ b/app/code/core/Mage/Contacts/etc/system.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Contacts/etc/system.xml
+++ b/app/code/core/Mage/Contacts/etc/system.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Contacts

--- a/app/code/core/Mage/Contacts/sql/contacts_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Contacts/sql/contacts_setup/install-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Contacts/sql/contacts_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Contacts/sql/contacts_setup/install-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Contacts

--- a/app/code/core/Mage/Contacts/sql/contacts_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Contacts/sql/contacts_setup/install-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Contacts

--- a/app/code/core/Mage/Contacts/sql/contacts_setup/mysql4-install-0.7.1.php
+++ b/app/code/core/Mage/Contacts/sql/contacts_setup/mysql4-install-0.7.1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Contacts/sql/contacts_setup/mysql4-install-0.7.1.php
+++ b/app/code/core/Mage/Contacts/sql/contacts_setup/mysql4-install-0.7.1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Contacts

--- a/app/code/core/Mage/Contacts/sql/contacts_setup/mysql4-install-0.7.1.php
+++ b/app/code/core/Mage/Contacts/sql/contacts_setup/mysql4-install-0.7.1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Contacts

--- a/app/code/core/Mage/Contacts/sql/contacts_setup/mysql4-install-0.8.0.php
+++ b/app/code/core/Mage/Contacts/sql/contacts_setup/mysql4-install-0.8.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Contacts/sql/contacts_setup/mysql4-install-0.8.0.php
+++ b/app/code/core/Mage/Contacts/sql/contacts_setup/mysql4-install-0.8.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Contacts

--- a/app/code/core/Mage/Contacts/sql/contacts_setup/mysql4-install-0.8.0.php
+++ b/app/code/core/Mage/Contacts/sql/contacts_setup/mysql4-install-0.8.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Contacts

--- a/app/code/core/Mage/Contacts/sql/contacts_setup/mysql4-upgrade-0.7.1-0.7.2.php
+++ b/app/code/core/Mage/Contacts/sql/contacts_setup/mysql4-upgrade-0.7.1-0.7.2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Contacts/sql/contacts_setup/mysql4-upgrade-0.7.1-0.7.2.php
+++ b/app/code/core/Mage/Contacts/sql/contacts_setup/mysql4-upgrade-0.7.1-0.7.2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Contacts

--- a/app/code/core/Mage/Contacts/sql/contacts_setup/mysql4-upgrade-0.7.1-0.7.2.php
+++ b/app/code/core/Mage/Contacts/sql/contacts_setup/mysql4-upgrade-0.7.1-0.7.2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Contacts

--- a/app/code/core/Mage/Core/Block/Abstract.php
+++ b/app/code/core/Mage/Core/Block/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Block/Abstract.php
+++ b/app/code/core/Mage/Core/Block/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Block/Abstract.php
+++ b/app/code/core/Mage/Core/Block/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Block/Flush.php
+++ b/app/code/core/Mage/Core/Block/Flush.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Block/Flush.php
+++ b/app/code/core/Mage/Core/Block/Flush.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Block/Flush.php
+++ b/app/code/core/Mage/Core/Block/Flush.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Block/Html/Calendar.php
+++ b/app/code/core/Mage/Core/Block/Html/Calendar.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Block/Html/Calendar.php
+++ b/app/code/core/Mage/Core/Block/Html/Calendar.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Block/Html/Calendar.php
+++ b/app/code/core/Mage/Core/Block/Html/Calendar.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Block/Html/Date.php
+++ b/app/code/core/Mage/Core/Block/Html/Date.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Block/Html/Date.php
+++ b/app/code/core/Mage/Core/Block/Html/Date.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Block/Html/Date.php
+++ b/app/code/core/Mage/Core/Block/Html/Date.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Block/Html/Link.php
+++ b/app/code/core/Mage/Core/Block/Html/Link.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Block/Html/Link.php
+++ b/app/code/core/Mage/Core/Block/Html/Link.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Block/Html/Link.php
+++ b/app/code/core/Mage/Core/Block/Html/Link.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Block/Html/Select.php
+++ b/app/code/core/Mage/Core/Block/Html/Select.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Block/Html/Select.php
+++ b/app/code/core/Mage/Core/Block/Html/Select.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Block/Html/Select.php
+++ b/app/code/core/Mage/Core/Block/Html/Select.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Block/Messages.php
+++ b/app/code/core/Mage/Core/Block/Messages.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Block/Messages.php
+++ b/app/code/core/Mage/Core/Block/Messages.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Block/Messages.php
+++ b/app/code/core/Mage/Core/Block/Messages.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Block/Profiler.php
+++ b/app/code/core/Mage/Core/Block/Profiler.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Block/Profiler.php
+++ b/app/code/core/Mage/Core/Block/Profiler.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Block/Profiler.php
+++ b/app/code/core/Mage/Core/Block/Profiler.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Block/Store/Switcher.php
+++ b/app/code/core/Mage/Core/Block/Store/Switcher.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Block/Store/Switcher.php
+++ b/app/code/core/Mage/Core/Block/Store/Switcher.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Block/Store/Switcher.php
+++ b/app/code/core/Mage/Core/Block/Store/Switcher.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Block/Template.php
+++ b/app/code/core/Mage/Core/Block/Template.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Block/Template.php
+++ b/app/code/core/Mage/Core/Block/Template.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Block/Template.php
+++ b/app/code/core/Mage/Core/Block/Template.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Block/Template/Facade.php
+++ b/app/code/core/Mage/Core/Block/Template/Facade.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Block/Template/Facade.php
+++ b/app/code/core/Mage/Core/Block/Template/Facade.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Block/Template/Facade.php
+++ b/app/code/core/Mage/Core/Block/Template/Facade.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Block/Template/Smarty.php
+++ b/app/code/core/Mage/Core/Block/Template/Smarty.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Block/Template/Smarty.php
+++ b/app/code/core/Mage/Core/Block/Template/Smarty.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Block/Template/Smarty.php
+++ b/app/code/core/Mage/Core/Block/Template/Smarty.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Block/Template/Zend.php
+++ b/app/code/core/Mage/Core/Block/Template/Zend.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Block/Template/Zend.php
+++ b/app/code/core/Mage/Core/Block/Template/Zend.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Block/Template/Zend.php
+++ b/app/code/core/Mage/Core/Block/Template/Zend.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Block/Text.php
+++ b/app/code/core/Mage/Core/Block/Text.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Block/Text.php
+++ b/app/code/core/Mage/Core/Block/Text.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Block/Text.php
+++ b/app/code/core/Mage/Core/Block/Text.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Block/Text/List.php
+++ b/app/code/core/Mage/Core/Block/Text/List.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Block/Text/List.php
+++ b/app/code/core/Mage/Core/Block/Text/List.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Block/Text/List.php
+++ b/app/code/core/Mage/Core/Block/Text/List.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Block/Text/List/Item.php
+++ b/app/code/core/Mage/Core/Block/Text/List/Item.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Block/Text/List/Item.php
+++ b/app/code/core/Mage/Core/Block/Text/List/Item.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Block/Text/List/Item.php
+++ b/app/code/core/Mage/Core/Block/Text/List/Item.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Block/Text/List/Link.php
+++ b/app/code/core/Mage/Core/Block/Text/List/Link.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Block/Text/List/Link.php
+++ b/app/code/core/Mage/Core/Block/Text/List/Link.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Block/Text/List/Link.php
+++ b/app/code/core/Mage/Core/Block/Text/List/Link.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Block/Text/Tag.php
+++ b/app/code/core/Mage/Core/Block/Text/Tag.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Block/Text/Tag.php
+++ b/app/code/core/Mage/Core/Block/Text/Tag.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Block/Text/Tag.php
+++ b/app/code/core/Mage/Core/Block/Text/Tag.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Block/Text/Tag/Css.php
+++ b/app/code/core/Mage/Core/Block/Text/Tag/Css.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Block/Text/Tag/Css.php
+++ b/app/code/core/Mage/Core/Block/Text/Tag/Css.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Block/Text/Tag/Css.php
+++ b/app/code/core/Mage/Core/Block/Text/Tag/Css.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Block/Text/Tag/Css/Admin.php
+++ b/app/code/core/Mage/Core/Block/Text/Tag/Css/Admin.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Block/Text/Tag/Css/Admin.php
+++ b/app/code/core/Mage/Core/Block/Text/Tag/Css/Admin.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Block/Text/Tag/Css/Admin.php
+++ b/app/code/core/Mage/Core/Block/Text/Tag/Css/Admin.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Block/Text/Tag/Debug.php
+++ b/app/code/core/Mage/Core/Block/Text/Tag/Debug.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Block/Text/Tag/Debug.php
+++ b/app/code/core/Mage/Core/Block/Text/Tag/Debug.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Block/Text/Tag/Debug.php
+++ b/app/code/core/Mage/Core/Block/Text/Tag/Debug.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Block/Text/Tag/Js.php
+++ b/app/code/core/Mage/Core/Block/Text/Tag/Js.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Block/Text/Tag/Js.php
+++ b/app/code/core/Mage/Core/Block/Text/Tag/Js.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Block/Text/Tag/Js.php
+++ b/app/code/core/Mage/Core/Block/Text/Tag/Js.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Block/Text/Tag/Meta.php
+++ b/app/code/core/Mage/Core/Block/Text/Tag/Meta.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Block/Text/Tag/Meta.php
+++ b/app/code/core/Mage/Core/Block/Text/Tag/Meta.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Block/Text/Tag/Meta.php
+++ b/app/code/core/Mage/Core/Block/Text/Tag/Meta.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Controller/Front/Action.php
+++ b/app/code/core/Mage/Core/Controller/Front/Action.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Controller/Front/Action.php
+++ b/app/code/core/Mage/Core/Controller/Front/Action.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Controller/Front/Action.php
+++ b/app/code/core/Mage/Core/Controller/Front/Action.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Controller/Front/Router.php
+++ b/app/code/core/Mage/Core/Controller/Front/Router.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Controller/Front/Router.php
+++ b/app/code/core/Mage/Core/Controller/Front/Router.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Controller/Front/Router.php
+++ b/app/code/core/Mage/Core/Controller/Front/Router.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Controller/Request/Http.php
+++ b/app/code/core/Mage/Core/Controller/Request/Http.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Controller/Request/Http.php
+++ b/app/code/core/Mage/Core/Controller/Request/Http.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Controller/Request/Http.php
+++ b/app/code/core/Mage/Core/Controller/Request/Http.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Controller/Response/Http.php
+++ b/app/code/core/Mage/Core/Controller/Response/Http.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Controller/Response/Http.php
+++ b/app/code/core/Mage/Core/Controller/Response/Http.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Controller/Response/Http.php
+++ b/app/code/core/Mage/Core/Controller/Response/Http.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Controller/Varien/Action.php
+++ b/app/code/core/Mage/Core/Controller/Varien/Action.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Controller/Varien/Action.php
+++ b/app/code/core/Mage/Core/Controller/Varien/Action.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Controller/Varien/Action.php
+++ b/app/code/core/Mage/Core/Controller/Varien/Action.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Controller/Varien/Exception.php
+++ b/app/code/core/Mage/Core/Controller/Varien/Exception.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Controller/Varien/Exception.php
+++ b/app/code/core/Mage/Core/Controller/Varien/Exception.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Controller/Varien/Exception.php
+++ b/app/code/core/Mage/Core/Controller/Varien/Exception.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Controller/Varien/Front.php
+++ b/app/code/core/Mage/Core/Controller/Varien/Front.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Controller/Varien/Front.php
+++ b/app/code/core/Mage/Core/Controller/Varien/Front.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Controller/Varien/Front.php
+++ b/app/code/core/Mage/Core/Controller/Varien/Front.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Controller/Varien/Router/Abstract.php
+++ b/app/code/core/Mage/Core/Controller/Varien/Router/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Controller/Varien/Router/Abstract.php
+++ b/app/code/core/Mage/Core/Controller/Varien/Router/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Controller/Varien/Router/Abstract.php
+++ b/app/code/core/Mage/Core/Controller/Varien/Router/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Controller/Varien/Router/Admin.php
+++ b/app/code/core/Mage/Core/Controller/Varien/Router/Admin.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Controller/Varien/Router/Admin.php
+++ b/app/code/core/Mage/Core/Controller/Varien/Router/Admin.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Controller/Varien/Router/Admin.php
+++ b/app/code/core/Mage/Core/Controller/Varien/Router/Admin.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Controller/Varien/Router/Default.php
+++ b/app/code/core/Mage/Core/Controller/Varien/Router/Default.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Controller/Varien/Router/Default.php
+++ b/app/code/core/Mage/Core/Controller/Varien/Router/Default.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Controller/Varien/Router/Default.php
+++ b/app/code/core/Mage/Core/Controller/Varien/Router/Default.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Controller/Varien/Router/Standard.php
+++ b/app/code/core/Mage/Core/Controller/Varien/Router/Standard.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Controller/Varien/Router/Standard.php
+++ b/app/code/core/Mage/Core/Controller/Varien/Router/Standard.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Controller/Varien/Router/Standard.php
+++ b/app/code/core/Mage/Core/Controller/Varien/Router/Standard.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Exception.php
+++ b/app/code/core/Mage/Core/Exception.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Exception.php
+++ b/app/code/core/Mage/Core/Exception.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Exception.php
+++ b/app/code/core/Mage/Core/Exception.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Helper/Abstract.php
+++ b/app/code/core/Mage/Core/Helper/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Helper/Abstract.php
+++ b/app/code/core/Mage/Core/Helper/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Helper/Abstract.php
+++ b/app/code/core/Mage/Core/Helper/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Helper/Array.php
+++ b/app/code/core/Mage/Core/Helper/Array.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Helper/Array.php
+++ b/app/code/core/Mage/Core/Helper/Array.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Helper/Array.php
+++ b/app/code/core/Mage/Core/Helper/Array.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Helper/Cookie.php
+++ b/app/code/core/Mage/Core/Helper/Cookie.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Helper/Cookie.php
+++ b/app/code/core/Mage/Core/Helper/Cookie.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Helper/Cookie.php
+++ b/app/code/core/Mage/Core/Helper/Cookie.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Helper/Data.php
+++ b/app/code/core/Mage/Core/Helper/Data.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Helper/Data.php
+++ b/app/code/core/Mage/Core/Helper/Data.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Helper/Data.php
+++ b/app/code/core/Mage/Core/Helper/Data.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Helper/File/Storage.php
+++ b/app/code/core/Mage/Core/Helper/File/Storage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Helper/File/Storage.php
+++ b/app/code/core/Mage/Core/Helper/File/Storage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Helper/File/Storage.php
+++ b/app/code/core/Mage/Core/Helper/File/Storage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Helper/File/Storage/Database.php
+++ b/app/code/core/Mage/Core/Helper/File/Storage/Database.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Helper/File/Storage/Database.php
+++ b/app/code/core/Mage/Core/Helper/File/Storage/Database.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Helper/File/Storage/Database.php
+++ b/app/code/core/Mage/Core/Helper/File/Storage/Database.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Helper/Hint.php
+++ b/app/code/core/Mage/Core/Helper/Hint.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Helper/Hint.php
+++ b/app/code/core/Mage/Core/Helper/Hint.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Helper/Hint.php
+++ b/app/code/core/Mage/Core/Helper/Hint.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Helper/Http.php
+++ b/app/code/core/Mage/Core/Helper/Http.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Helper/Http.php
+++ b/app/code/core/Mage/Core/Helper/Http.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Helper/Http.php
+++ b/app/code/core/Mage/Core/Helper/Http.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Helper/Js.php
+++ b/app/code/core/Mage/Core/Helper/Js.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Helper/Js.php
+++ b/app/code/core/Mage/Core/Helper/Js.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Helper/Js.php
+++ b/app/code/core/Mage/Core/Helper/Js.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Helper/Security.php
+++ b/app/code/core/Mage/Core/Helper/Security.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Helper/Security.php
+++ b/app/code/core/Mage/Core/Helper/Security.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Helper/Security.php
+++ b/app/code/core/Mage/Core/Helper/Security.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Helper/String.php
+++ b/app/code/core/Mage/Core/Helper/String.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Helper/String.php
+++ b/app/code/core/Mage/Core/Helper/String.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Helper/String.php
+++ b/app/code/core/Mage/Core/Helper/String.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Helper/Translate.php
+++ b/app/code/core/Mage/Core/Helper/Translate.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Helper/Translate.php
+++ b/app/code/core/Mage/Core/Helper/Translate.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Helper/Translate.php
+++ b/app/code/core/Mage/Core/Helper/Translate.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Helper/UnserializeArray.php
+++ b/app/code/core/Mage/Core/Helper/UnserializeArray.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Helper/UnserializeArray.php
+++ b/app/code/core/Mage/Core/Helper/UnserializeArray.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Helper/UnserializeArray.php
+++ b/app/code/core/Mage/Core/Helper/UnserializeArray.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Helper/Url.php
+++ b/app/code/core/Mage/Core/Helper/Url.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Helper/Url.php
+++ b/app/code/core/Mage/Core/Helper/Url.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Helper/Url.php
+++ b/app/code/core/Mage/Core/Helper/Url.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Helper/Url/Rewrite.php
+++ b/app/code/core/Mage/Core/Helper/Url/Rewrite.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Helper/Url/Rewrite.php
+++ b/app/code/core/Mage/Core/Helper/Url/Rewrite.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Helper/Url/Rewrite.php
+++ b/app/code/core/Mage/Core/Helper/Url/Rewrite.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Abstract.php
+++ b/app/code/core/Mage/Core/Model/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Abstract.php
+++ b/app/code/core/Mage/Core/Model/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Abstract.php
+++ b/app/code/core/Mage/Core/Model/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/App.php
+++ b/app/code/core/Mage/Core/Model/App.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/App.php
+++ b/app/code/core/Mage/Core/Model/App.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/App.php
+++ b/app/code/core/Mage/Core/Model/App.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/App/Area.php
+++ b/app/code/core/Mage/Core/Model/App/Area.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/App/Area.php
+++ b/app/code/core/Mage/Core/Model/App/Area.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/App/Area.php
+++ b/app/code/core/Mage/Core/Model/App/Area.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/App/Emulation.php
+++ b/app/code/core/Mage/Core/Model/App/Emulation.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/App/Emulation.php
+++ b/app/code/core/Mage/Core/Model/App/Emulation.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/App/Emulation.php
+++ b/app/code/core/Mage/Core/Model/App/Emulation.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Cache.php
+++ b/app/code/core/Mage/Core/Model/Cache.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Cache.php
+++ b/app/code/core/Mage/Core/Model/Cache.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Cache.php
+++ b/app/code/core/Mage/Core/Model/Cache.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Calculator.php
+++ b/app/code/core/Mage/Core/Model/Calculator.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Calculator.php
+++ b/app/code/core/Mage/Core/Model/Calculator.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Calculator.php
+++ b/app/code/core/Mage/Core/Model/Calculator.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Config.php
+++ b/app/code/core/Mage/Core/Model/Config.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Config.php
+++ b/app/code/core/Mage/Core/Model/Config.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Config.php
+++ b/app/code/core/Mage/Core/Model/Config.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Config/Base.php
+++ b/app/code/core/Mage/Core/Model/Config/Base.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Config/Base.php
+++ b/app/code/core/Mage/Core/Model/Config/Base.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Config/Base.php
+++ b/app/code/core/Mage/Core/Model/Config/Base.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Config/Data.php
+++ b/app/code/core/Mage/Core/Model/Config/Data.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Config/Data.php
+++ b/app/code/core/Mage/Core/Model/Config/Data.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Config/Data.php
+++ b/app/code/core/Mage/Core/Model/Config/Data.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Config/Element.php
+++ b/app/code/core/Mage/Core/Model/Config/Element.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Config/Element.php
+++ b/app/code/core/Mage/Core/Model/Config/Element.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Config/Element.php
+++ b/app/code/core/Mage/Core/Model/Config/Element.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Config/Options.php
+++ b/app/code/core/Mage/Core/Model/Config/Options.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Config/Options.php
+++ b/app/code/core/Mage/Core/Model/Config/Options.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Config/Options.php
+++ b/app/code/core/Mage/Core/Model/Config/Options.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Config/System.php
+++ b/app/code/core/Mage/Core/Model/Config/System.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Config/System.php
+++ b/app/code/core/Mage/Core/Model/Config/System.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Config/System.php
+++ b/app/code/core/Mage/Core/Model/Config/System.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Convert.php
+++ b/app/code/core/Mage/Core/Model/Convert.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Convert.php
+++ b/app/code/core/Mage/Core/Model/Convert.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Convert.php
+++ b/app/code/core/Mage/Core/Model/Convert.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Cookie.php
+++ b/app/code/core/Mage/Core/Model/Cookie.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Cookie.php
+++ b/app/code/core/Mage/Core/Model/Cookie.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Cookie.php
+++ b/app/code/core/Mage/Core/Model/Cookie.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Date.php
+++ b/app/code/core/Mage/Core/Model/Date.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Date.php
+++ b/app/code/core/Mage/Core/Model/Date.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Date.php
+++ b/app/code/core/Mage/Core/Model/Date.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Design.php
+++ b/app/code/core/Mage/Core/Model/Design.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Design.php
+++ b/app/code/core/Mage/Core/Model/Design.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Design.php
+++ b/app/code/core/Mage/Core/Model/Design.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Design/Config.php
+++ b/app/code/core/Mage/Core/Model/Design/Config.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Design/Config.php
+++ b/app/code/core/Mage/Core/Model/Design/Config.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Design/Config.php
+++ b/app/code/core/Mage/Core/Model/Design/Config.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Design/Fallback.php
+++ b/app/code/core/Mage/Core/Model/Design/Fallback.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Design/Fallback.php
+++ b/app/code/core/Mage/Core/Model/Design/Fallback.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Design/Fallback.php
+++ b/app/code/core/Mage/Core/Model/Design/Fallback.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Design/Package.php
+++ b/app/code/core/Mage/Core/Model/Design/Package.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Design/Package.php
+++ b/app/code/core/Mage/Core/Model/Design/Package.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Design/Package.php
+++ b/app/code/core/Mage/Core/Model/Design/Package.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Design/Source/Apply.php
+++ b/app/code/core/Mage/Core/Model/Design/Source/Apply.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Design/Source/Apply.php
+++ b/app/code/core/Mage/Core/Model/Design/Source/Apply.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Design/Source/Apply.php
+++ b/app/code/core/Mage/Core/Model/Design/Source/Apply.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Design/Source/Design.php
+++ b/app/code/core/Mage/Core/Model/Design/Source/Design.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Design/Source/Design.php
+++ b/app/code/core/Mage/Core/Model/Design/Source/Design.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Design/Source/Design.php
+++ b/app/code/core/Mage/Core/Model/Design/Source/Design.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Domainpolicy.php
+++ b/app/code/core/Mage/Core/Model/Domainpolicy.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Domainpolicy.php
+++ b/app/code/core/Mage/Core/Model/Domainpolicy.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Domainpolicy.php
+++ b/app/code/core/Mage/Core/Model/Domainpolicy.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Email.php
+++ b/app/code/core/Mage/Core/Model/Email.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Email.php
+++ b/app/code/core/Mage/Core/Model/Email.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Email.php
+++ b/app/code/core/Mage/Core/Model/Email.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Email/Info.php
+++ b/app/code/core/Mage/Core/Model/Email/Info.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Email/Info.php
+++ b/app/code/core/Mage/Core/Model/Email/Info.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Email/Info.php
+++ b/app/code/core/Mage/Core/Model/Email/Info.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Email/Queue.php
+++ b/app/code/core/Mage/Core/Model/Email/Queue.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Email/Queue.php
+++ b/app/code/core/Mage/Core/Model/Email/Queue.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Email/Queue.php
+++ b/app/code/core/Mage/Core/Model/Email/Queue.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Email/Template.php
+++ b/app/code/core/Mage/Core/Model/Email/Template.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Email/Template.php
+++ b/app/code/core/Mage/Core/Model/Email/Template.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Email/Template.php
+++ b/app/code/core/Mage/Core/Model/Email/Template.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Email/Template/Abstract.php
+++ b/app/code/core/Mage/Core/Model/Email/Template/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Email/Template/Abstract.php
+++ b/app/code/core/Mage/Core/Model/Email/Template/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Email/Template/Abstract.php
+++ b/app/code/core/Mage/Core/Model/Email/Template/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Email/Template/Filter.php
+++ b/app/code/core/Mage/Core/Model/Email/Template/Filter.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Email/Template/Filter.php
+++ b/app/code/core/Mage/Core/Model/Email/Template/Filter.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Email/Template/Filter.php
+++ b/app/code/core/Mage/Core/Model/Email/Template/Filter.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Email/Template/Mailer.php
+++ b/app/code/core/Mage/Core/Model/Email/Template/Mailer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Email/Template/Mailer.php
+++ b/app/code/core/Mage/Core/Model/Email/Template/Mailer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Email/Template/Mailer.php
+++ b/app/code/core/Mage/Core/Model/Email/Template/Mailer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Email/Transport.php
+++ b/app/code/core/Mage/Core/Model/Email/Transport.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Email/Transport.php
+++ b/app/code/core/Mage/Core/Model/Email/Transport.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Email/Transport.php
+++ b/app/code/core/Mage/Core/Model/Email/Transport.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Encryption.php
+++ b/app/code/core/Mage/Core/Model/Encryption.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Encryption.php
+++ b/app/code/core/Mage/Core/Model/Encryption.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Encryption.php
+++ b/app/code/core/Mage/Core/Model/Encryption.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Factory.php
+++ b/app/code/core/Mage/Core/Model/Factory.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Factory.php
+++ b/app/code/core/Mage/Core/Model/Factory.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Factory.php
+++ b/app/code/core/Mage/Core/Model/Factory.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/File/Storage.php
+++ b/app/code/core/Mage/Core/Model/File/Storage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/File/Storage.php
+++ b/app/code/core/Mage/Core/Model/File/Storage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/File/Storage.php
+++ b/app/code/core/Mage/Core/Model/File/Storage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/File/Storage/Abstract.php
+++ b/app/code/core/Mage/Core/Model/File/Storage/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/File/Storage/Abstract.php
+++ b/app/code/core/Mage/Core/Model/File/Storage/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/File/Storage/Abstract.php
+++ b/app/code/core/Mage/Core/Model/File/Storage/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/File/Storage/Database.php
+++ b/app/code/core/Mage/Core/Model/File/Storage/Database.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/File/Storage/Database.php
+++ b/app/code/core/Mage/Core/Model/File/Storage/Database.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/File/Storage/Database.php
+++ b/app/code/core/Mage/Core/Model/File/Storage/Database.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/File/Storage/Database/Abstract.php
+++ b/app/code/core/Mage/Core/Model/File/Storage/Database/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/File/Storage/Database/Abstract.php
+++ b/app/code/core/Mage/Core/Model/File/Storage/Database/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/File/Storage/Database/Abstract.php
+++ b/app/code/core/Mage/Core/Model/File/Storage/Database/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/File/Storage/Directory/Database.php
+++ b/app/code/core/Mage/Core/Model/File/Storage/Directory/Database.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/File/Storage/Directory/Database.php
+++ b/app/code/core/Mage/Core/Model/File/Storage/Directory/Database.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/File/Storage/Directory/Database.php
+++ b/app/code/core/Mage/Core/Model/File/Storage/Directory/Database.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/File/Storage/File.php
+++ b/app/code/core/Mage/Core/Model/File/Storage/File.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/File/Storage/File.php
+++ b/app/code/core/Mage/Core/Model/File/Storage/File.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/File/Storage/File.php
+++ b/app/code/core/Mage/Core/Model/File/Storage/File.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/File/Storage/Flag.php
+++ b/app/code/core/Mage/Core/Model/File/Storage/Flag.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/File/Storage/Flag.php
+++ b/app/code/core/Mage/Core/Model/File/Storage/Flag.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/File/Storage/Flag.php
+++ b/app/code/core/Mage/Core/Model/File/Storage/Flag.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/File/Uploader.php
+++ b/app/code/core/Mage/Core/Model/File/Uploader.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/File/Uploader.php
+++ b/app/code/core/Mage/Core/Model/File/Uploader.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/File/Uploader.php
+++ b/app/code/core/Mage/Core/Model/File/Uploader.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/File/Validator/AvailablePath.php
+++ b/app/code/core/Mage/Core/Model/File/Validator/AvailablePath.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/File/Validator/AvailablePath.php
+++ b/app/code/core/Mage/Core/Model/File/Validator/AvailablePath.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/File/Validator/AvailablePath.php
+++ b/app/code/core/Mage/Core/Model/File/Validator/AvailablePath.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/File/Validator/Image.php
+++ b/app/code/core/Mage/Core/Model/File/Validator/Image.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/File/Validator/Image.php
+++ b/app/code/core/Mage/Core/Model/File/Validator/Image.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/File/Validator/Image.php
+++ b/app/code/core/Mage/Core/Model/File/Validator/Image.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/File/Validator/NotProtectedExtension.php
+++ b/app/code/core/Mage/Core/Model/File/Validator/NotProtectedExtension.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/File/Validator/NotProtectedExtension.php
+++ b/app/code/core/Mage/Core/Model/File/Validator/NotProtectedExtension.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/File/Validator/NotProtectedExtension.php
+++ b/app/code/core/Mage/Core/Model/File/Validator/NotProtectedExtension.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/File/Validator/StreamWrapper.php
+++ b/app/code/core/Mage/Core/Model/File/Validator/StreamWrapper.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/File/Validator/StreamWrapper.php
+++ b/app/code/core/Mage/Core/Model/File/Validator/StreamWrapper.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/File/Validator/StreamWrapper.php
+++ b/app/code/core/Mage/Core/Model/File/Validator/StreamWrapper.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Flag.php
+++ b/app/code/core/Mage/Core/Model/Flag.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Flag.php
+++ b/app/code/core/Mage/Core/Model/Flag.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Flag.php
+++ b/app/code/core/Mage/Core/Model/Flag.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Input/Filter.php
+++ b/app/code/core/Mage/Core/Model/Input/Filter.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Input/Filter.php
+++ b/app/code/core/Mage/Core/Model/Input/Filter.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Input/Filter.php
+++ b/app/code/core/Mage/Core/Model/Input/Filter.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Input/Filter/MaliciousCode.php
+++ b/app/code/core/Mage/Core/Model/Input/Filter/MaliciousCode.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Input/Filter/MaliciousCode.php
+++ b/app/code/core/Mage/Core/Model/Input/Filter/MaliciousCode.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Input/Filter/MaliciousCode.php
+++ b/app/code/core/Mage/Core/Model/Input/Filter/MaliciousCode.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Language.php
+++ b/app/code/core/Mage/Core/Model/Language.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Language.php
+++ b/app/code/core/Mage/Core/Model/Language.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Language.php
+++ b/app/code/core/Mage/Core/Model/Language.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Layout.php
+++ b/app/code/core/Mage/Core/Model/Layout.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Layout.php
+++ b/app/code/core/Mage/Core/Model/Layout.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Layout.php
+++ b/app/code/core/Mage/Core/Model/Layout.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Layout/Data.php
+++ b/app/code/core/Mage/Core/Model/Layout/Data.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Layout/Data.php
+++ b/app/code/core/Mage/Core/Model/Layout/Data.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Layout/Data.php
+++ b/app/code/core/Mage/Core/Model/Layout/Data.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Layout/Element.php
+++ b/app/code/core/Mage/Core/Model/Layout/Element.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Layout/Element.php
+++ b/app/code/core/Mage/Core/Model/Layout/Element.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Layout/Element.php
+++ b/app/code/core/Mage/Core/Model/Layout/Element.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Layout/Update.php
+++ b/app/code/core/Mage/Core/Model/Layout/Update.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Layout/Update.php
+++ b/app/code/core/Mage/Core/Model/Layout/Update.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Layout/Update.php
+++ b/app/code/core/Mage/Core/Model/Layout/Update.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Layout/Validator.php
+++ b/app/code/core/Mage/Core/Model/Layout/Validator.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Layout/Validator.php
+++ b/app/code/core/Mage/Core/Model/Layout/Validator.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Layout/Validator.php
+++ b/app/code/core/Mage/Core/Model/Layout/Validator.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Locale.php
+++ b/app/code/core/Mage/Core/Model/Locale.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Locale.php
+++ b/app/code/core/Mage/Core/Model/Locale.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Locale.php
+++ b/app/code/core/Mage/Core/Model/Locale.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Locale/Config.php
+++ b/app/code/core/Mage/Core/Model/Locale/Config.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Locale/Config.php
+++ b/app/code/core/Mage/Core/Model/Locale/Config.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Locale/Config.php
+++ b/app/code/core/Mage/Core/Model/Locale/Config.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Log/Adapter.php
+++ b/app/code/core/Mage/Core/Model/Log/Adapter.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Log/Adapter.php
+++ b/app/code/core/Mage/Core/Model/Log/Adapter.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Log/Adapter.php
+++ b/app/code/core/Mage/Core/Model/Log/Adapter.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Logger.php
+++ b/app/code/core/Mage/Core/Model/Logger.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Logger.php
+++ b/app/code/core/Mage/Core/Model/Logger.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Logger.php
+++ b/app/code/core/Mage/Core/Model/Logger.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Magento/Api.php
+++ b/app/code/core/Mage/Core/Model/Magento/Api.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Magento/Api.php
+++ b/app/code/core/Mage/Core/Model/Magento/Api.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Magento/Api.php
+++ b/app/code/core/Mage/Core/Model/Magento/Api.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Magento/Api/V2.php
+++ b/app/code/core/Mage/Core/Model/Magento/Api/V2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Magento/Api/V2.php
+++ b/app/code/core/Mage/Core/Model/Magento/Api/V2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Magento/Api/V2.php
+++ b/app/code/core/Mage/Core/Model/Magento/Api/V2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Message.php
+++ b/app/code/core/Mage/Core/Model/Message.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Message.php
+++ b/app/code/core/Mage/Core/Model/Message.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Message.php
+++ b/app/code/core/Mage/Core/Model/Message.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Message/Abstract.php
+++ b/app/code/core/Mage/Core/Model/Message/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Message/Abstract.php
+++ b/app/code/core/Mage/Core/Model/Message/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Message/Abstract.php
+++ b/app/code/core/Mage/Core/Model/Message/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Message/Collection.php
+++ b/app/code/core/Mage/Core/Model/Message/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Message/Collection.php
+++ b/app/code/core/Mage/Core/Model/Message/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Message/Collection.php
+++ b/app/code/core/Mage/Core/Model/Message/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Message/Error.php
+++ b/app/code/core/Mage/Core/Model/Message/Error.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Message/Error.php
+++ b/app/code/core/Mage/Core/Model/Message/Error.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Message/Error.php
+++ b/app/code/core/Mage/Core/Model/Message/Error.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Message/Notice.php
+++ b/app/code/core/Mage/Core/Model/Message/Notice.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Message/Notice.php
+++ b/app/code/core/Mage/Core/Model/Message/Notice.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Message/Notice.php
+++ b/app/code/core/Mage/Core/Model/Message/Notice.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Message/Success.php
+++ b/app/code/core/Mage/Core/Model/Message/Success.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Message/Success.php
+++ b/app/code/core/Mage/Core/Model/Message/Success.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Message/Success.php
+++ b/app/code/core/Mage/Core/Model/Message/Success.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Message/Warning.php
+++ b/app/code/core/Mage/Core/Model/Message/Warning.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Message/Warning.php
+++ b/app/code/core/Mage/Core/Model/Message/Warning.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Message/Warning.php
+++ b/app/code/core/Mage/Core/Model/Message/Warning.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Mysql4/Abstract.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Mysql4/Abstract.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Mysql4/Abstract.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Mysql4/Cache.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/Cache.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Mysql4/Cache.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/Cache.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Mysql4/Cache.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/Cache.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Mysql4/Collection/Abstract.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/Collection/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Mysql4/Collection/Abstract.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/Collection/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Mysql4/Collection/Abstract.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/Collection/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Mysql4/Config.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/Config.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Mysql4/Config.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/Config.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Mysql4/Config.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/Config.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Mysql4/Config/Data.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/Config/Data.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Mysql4/Config/Data.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/Config/Data.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Mysql4/Config/Data.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/Config/Data.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Mysql4/Config/Data/Collection.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/Config/Data/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Mysql4/Config/Data/Collection.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/Config/Data/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Mysql4/Config/Data/Collection.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/Config/Data/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Mysql4/Design.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/Design.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Mysql4/Design.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/Design.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Mysql4/Design.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/Design.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Mysql4/Design/Collection.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/Design/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Mysql4/Design/Collection.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/Design/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Mysql4/Design/Collection.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/Design/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Mysql4/Design/Package/Collection.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/Design/Package/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Mysql4/Design/Package/Collection.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/Design/Package/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Mysql4/Design/Package/Collection.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/Design/Package/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Mysql4/Design/Theme/Collection.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/Design/Theme/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Mysql4/Design/Theme/Collection.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/Design/Theme/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Mysql4/Design/Theme/Collection.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/Design/Theme/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Mysql4/Email/Template.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/Email/Template.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Mysql4/Email/Template.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/Email/Template.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Mysql4/Email/Template.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/Email/Template.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Mysql4/Email/Template/Collection.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/Email/Template/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Mysql4/Email/Template/Collection.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/Email/Template/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Mysql4/Email/Template/Collection.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/Email/Template/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Mysql4/File/Storage/Abstract.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/File/Storage/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Mysql4/File/Storage/Abstract.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/File/Storage/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Mysql4/File/Storage/Abstract.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/File/Storage/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Mysql4/File/Storage/Database.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/File/Storage/Database.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Mysql4/File/Storage/Database.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/File/Storage/Database.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Mysql4/File/Storage/Database.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/File/Storage/Database.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Mysql4/File/Storage/Directory/Database.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/File/Storage/Directory/Database.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Mysql4/File/Storage/Directory/Database.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/File/Storage/Directory/Database.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Mysql4/File/Storage/Directory/Database.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/File/Storage/Directory/Database.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Mysql4/File/Storage/File.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/File/Storage/File.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Mysql4/File/Storage/File.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/File/Storage/File.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Mysql4/File/Storage/File.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/File/Storage/File.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Mysql4/Flag.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/Flag.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Mysql4/Flag.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/Flag.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Mysql4/Flag.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/Flag.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Mysql4/Language.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/Language.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Mysql4/Language.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/Language.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Mysql4/Language.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/Language.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Mysql4/Language/Collection.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/Language/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Mysql4/Language/Collection.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/Language/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Mysql4/Language/Collection.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/Language/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Mysql4/Layout.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/Layout.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Mysql4/Layout.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/Layout.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Mysql4/Layout.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/Layout.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Mysql4/Resource.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/Resource.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Mysql4/Resource.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/Resource.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Mysql4/Resource.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/Resource.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Mysql4/Session.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/Session.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Mysql4/Session.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/Session.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Mysql4/Session.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/Session.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Mysql4/Store.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/Store.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Mysql4/Store.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/Store.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Mysql4/Store.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/Store.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Mysql4/Store/Collection.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/Store/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Mysql4/Store/Collection.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/Store/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Mysql4/Store/Collection.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/Store/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Mysql4/Store/Group.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/Store/Group.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Mysql4/Store/Group.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/Store/Group.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Mysql4/Store/Group.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/Store/Group.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Mysql4/Store/Group/Collection.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/Store/Group/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Mysql4/Store/Group/Collection.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/Store/Group/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Mysql4/Store/Group/Collection.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/Store/Group/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Mysql4/Translate.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/Translate.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Mysql4/Translate.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/Translate.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Mysql4/Translate.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/Translate.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Mysql4/Translate/String.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/Translate/String.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Mysql4/Translate/String.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/Translate/String.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Mysql4/Translate/String.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/Translate/String.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Mysql4/Url/Rewrite.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/Url/Rewrite.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Mysql4/Url/Rewrite.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/Url/Rewrite.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Mysql4/Url/Rewrite.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/Url/Rewrite.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Mysql4/Url/Rewrite/Collection.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/Url/Rewrite/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Mysql4/Url/Rewrite/Collection.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/Url/Rewrite/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Mysql4/Url/Rewrite/Collection.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/Url/Rewrite/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Mysql4/Variable.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/Variable.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Mysql4/Variable.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/Variable.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Mysql4/Variable.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/Variable.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Mysql4/Variable/Collection.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/Variable/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Mysql4/Variable/Collection.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/Variable/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Mysql4/Variable/Collection.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/Variable/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Mysql4/Website.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/Website.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Mysql4/Website.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/Website.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Mysql4/Website.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/Website.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Mysql4/Website/Collection.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/Website/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Mysql4/Website/Collection.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/Website/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Mysql4/Website/Collection.php
+++ b/app/code/core/Mage/Core/Model/Mysql4/Website/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Observer.php
+++ b/app/code/core/Mage/Core/Model/Observer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Observer.php
+++ b/app/code/core/Mage/Core/Model/Observer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Observer.php
+++ b/app/code/core/Mage/Core/Model/Observer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource.php
+++ b/app/code/core/Mage/Core/Model/Resource.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Resource.php
+++ b/app/code/core/Mage/Core/Model/Resource.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource.php
+++ b/app/code/core/Mage/Core/Model/Resource.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/Abstract.php
+++ b/app/code/core/Mage/Core/Model/Resource/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Resource/Abstract.php
+++ b/app/code/core/Mage/Core/Model/Resource/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/Abstract.php
+++ b/app/code/core/Mage/Core/Model/Resource/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/Cache.php
+++ b/app/code/core/Mage/Core/Model/Resource/Cache.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Resource/Cache.php
+++ b/app/code/core/Mage/Core/Model/Resource/Cache.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/Cache.php
+++ b/app/code/core/Mage/Core/Model/Resource/Cache.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/Config.php
+++ b/app/code/core/Mage/Core/Model/Resource/Config.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Resource/Config.php
+++ b/app/code/core/Mage/Core/Model/Resource/Config.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/Config.php
+++ b/app/code/core/Mage/Core/Model/Resource/Config.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/Config/Data.php
+++ b/app/code/core/Mage/Core/Model/Resource/Config/Data.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Resource/Config/Data.php
+++ b/app/code/core/Mage/Core/Model/Resource/Config/Data.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/Config/Data.php
+++ b/app/code/core/Mage/Core/Model/Resource/Config/Data.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/Config/Data/Collection.php
+++ b/app/code/core/Mage/Core/Model/Resource/Config/Data/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Resource/Config/Data/Collection.php
+++ b/app/code/core/Mage/Core/Model/Resource/Config/Data/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/Config/Data/Collection.php
+++ b/app/code/core/Mage/Core/Model/Resource/Config/Data/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/Db/Abstract.php
+++ b/app/code/core/Mage/Core/Model/Resource/Db/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Resource/Db/Abstract.php
+++ b/app/code/core/Mage/Core/Model/Resource/Db/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/Db/Abstract.php
+++ b/app/code/core/Mage/Core/Model/Resource/Db/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/Db/Collection/Abstract.php
+++ b/app/code/core/Mage/Core/Model/Resource/Db/Collection/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Resource/Db/Collection/Abstract.php
+++ b/app/code/core/Mage/Core/Model/Resource/Db/Collection/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/Db/Collection/Abstract.php
+++ b/app/code/core/Mage/Core/Model/Resource/Db/Collection/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/Design.php
+++ b/app/code/core/Mage/Core/Model/Resource/Design.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Resource/Design.php
+++ b/app/code/core/Mage/Core/Model/Resource/Design.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/Design.php
+++ b/app/code/core/Mage/Core/Model/Resource/Design.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/Design/Collection.php
+++ b/app/code/core/Mage/Core/Model/Resource/Design/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Resource/Design/Collection.php
+++ b/app/code/core/Mage/Core/Model/Resource/Design/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/Design/Collection.php
+++ b/app/code/core/Mage/Core/Model/Resource/Design/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/Design/Package/Collection.php
+++ b/app/code/core/Mage/Core/Model/Resource/Design/Package/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Resource/Design/Package/Collection.php
+++ b/app/code/core/Mage/Core/Model/Resource/Design/Package/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/Design/Package/Collection.php
+++ b/app/code/core/Mage/Core/Model/Resource/Design/Package/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/Email/Queue.php
+++ b/app/code/core/Mage/Core/Model/Resource/Email/Queue.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Resource/Email/Queue.php
+++ b/app/code/core/Mage/Core/Model/Resource/Email/Queue.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/Email/Queue.php
+++ b/app/code/core/Mage/Core/Model/Resource/Email/Queue.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/Email/Queue/Collection.php
+++ b/app/code/core/Mage/Core/Model/Resource/Email/Queue/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Resource/Email/Queue/Collection.php
+++ b/app/code/core/Mage/Core/Model/Resource/Email/Queue/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/Email/Queue/Collection.php
+++ b/app/code/core/Mage/Core/Model/Resource/Email/Queue/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/Email/Template.php
+++ b/app/code/core/Mage/Core/Model/Resource/Email/Template.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Resource/Email/Template.php
+++ b/app/code/core/Mage/Core/Model/Resource/Email/Template.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/Email/Template.php
+++ b/app/code/core/Mage/Core/Model/Resource/Email/Template.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/Email/Template/Collection.php
+++ b/app/code/core/Mage/Core/Model/Resource/Email/Template/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Resource/Email/Template/Collection.php
+++ b/app/code/core/Mage/Core/Model/Resource/Email/Template/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/Email/Template/Collection.php
+++ b/app/code/core/Mage/Core/Model/Resource/Email/Template/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/Entity/Abstract.php
+++ b/app/code/core/Mage/Core/Model/Resource/Entity/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Resource/Entity/Abstract.php
+++ b/app/code/core/Mage/Core/Model/Resource/Entity/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/Entity/Abstract.php
+++ b/app/code/core/Mage/Core/Model/Resource/Entity/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/Entity/Table.php
+++ b/app/code/core/Mage/Core/Model/Resource/Entity/Table.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Resource/Entity/Table.php
+++ b/app/code/core/Mage/Core/Model/Resource/Entity/Table.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/Entity/Table.php
+++ b/app/code/core/Mage/Core/Model/Resource/Entity/Table.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/File/Storage/Abstract.php
+++ b/app/code/core/Mage/Core/Model/Resource/File/Storage/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Resource/File/Storage/Abstract.php
+++ b/app/code/core/Mage/Core/Model/Resource/File/Storage/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/File/Storage/Abstract.php
+++ b/app/code/core/Mage/Core/Model/Resource/File/Storage/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/File/Storage/Database.php
+++ b/app/code/core/Mage/Core/Model/Resource/File/Storage/Database.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Resource/File/Storage/Database.php
+++ b/app/code/core/Mage/Core/Model/Resource/File/Storage/Database.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/File/Storage/Database.php
+++ b/app/code/core/Mage/Core/Model/Resource/File/Storage/Database.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/File/Storage/Directory/Database.php
+++ b/app/code/core/Mage/Core/Model/Resource/File/Storage/Directory/Database.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Resource/File/Storage/Directory/Database.php
+++ b/app/code/core/Mage/Core/Model/Resource/File/Storage/Directory/Database.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/File/Storage/Directory/Database.php
+++ b/app/code/core/Mage/Core/Model/Resource/File/Storage/Directory/Database.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/File/Storage/File.php
+++ b/app/code/core/Mage/Core/Model/Resource/File/Storage/File.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Resource/File/Storage/File.php
+++ b/app/code/core/Mage/Core/Model/Resource/File/Storage/File.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/File/Storage/File.php
+++ b/app/code/core/Mage/Core/Model/Resource/File/Storage/File.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/Flag.php
+++ b/app/code/core/Mage/Core/Model/Resource/Flag.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Resource/Flag.php
+++ b/app/code/core/Mage/Core/Model/Resource/Flag.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/Flag.php
+++ b/app/code/core/Mage/Core/Model/Resource/Flag.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/Helper/Abstract.php
+++ b/app/code/core/Mage/Core/Model/Resource/Helper/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Resource/Helper/Abstract.php
+++ b/app/code/core/Mage/Core/Model/Resource/Helper/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/Helper/Abstract.php
+++ b/app/code/core/Mage/Core/Model/Resource/Helper/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/Helper/Mysql4.php
+++ b/app/code/core/Mage/Core/Model/Resource/Helper/Mysql4.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Resource/Helper/Mysql4.php
+++ b/app/code/core/Mage/Core/Model/Resource/Helper/Mysql4.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/Helper/Mysql4.php
+++ b/app/code/core/Mage/Core/Model/Resource/Helper/Mysql4.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/Iterator.php
+++ b/app/code/core/Mage/Core/Model/Resource/Iterator.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Resource/Iterator.php
+++ b/app/code/core/Mage/Core/Model/Resource/Iterator.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/Iterator.php
+++ b/app/code/core/Mage/Core/Model/Resource/Iterator.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/Language.php
+++ b/app/code/core/Mage/Core/Model/Resource/Language.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Resource/Language.php
+++ b/app/code/core/Mage/Core/Model/Resource/Language.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/Language.php
+++ b/app/code/core/Mage/Core/Model/Resource/Language.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/Language/Collection.php
+++ b/app/code/core/Mage/Core/Model/Resource/Language/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Resource/Language/Collection.php
+++ b/app/code/core/Mage/Core/Model/Resource/Language/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/Language/Collection.php
+++ b/app/code/core/Mage/Core/Model/Resource/Language/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/Layout.php
+++ b/app/code/core/Mage/Core/Model/Resource/Layout.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Resource/Layout.php
+++ b/app/code/core/Mage/Core/Model/Resource/Layout.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/Layout.php
+++ b/app/code/core/Mage/Core/Model/Resource/Layout.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/Resource.php
+++ b/app/code/core/Mage/Core/Model/Resource/Resource.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Resource/Resource.php
+++ b/app/code/core/Mage/Core/Model/Resource/Resource.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/Resource.php
+++ b/app/code/core/Mage/Core/Model/Resource/Resource.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/Session.php
+++ b/app/code/core/Mage/Core/Model/Resource/Session.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Resource/Session.php
+++ b/app/code/core/Mage/Core/Model/Resource/Session.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/Session.php
+++ b/app/code/core/Mage/Core/Model/Resource/Session.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/Setup.php
+++ b/app/code/core/Mage/Core/Model/Resource/Setup.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Resource/Setup.php
+++ b/app/code/core/Mage/Core/Model/Resource/Setup.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/Setup.php
+++ b/app/code/core/Mage/Core/Model/Resource/Setup.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/Setup/Query/Modifier.php
+++ b/app/code/core/Mage/Core/Model/Resource/Setup/Query/Modifier.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Resource/Setup/Query/Modifier.php
+++ b/app/code/core/Mage/Core/Model/Resource/Setup/Query/Modifier.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/Setup/Query/Modifier.php
+++ b/app/code/core/Mage/Core/Model/Resource/Setup/Query/Modifier.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/Store.php
+++ b/app/code/core/Mage/Core/Model/Resource/Store.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Resource/Store.php
+++ b/app/code/core/Mage/Core/Model/Resource/Store.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/Store.php
+++ b/app/code/core/Mage/Core/Model/Resource/Store.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/Store/Collection.php
+++ b/app/code/core/Mage/Core/Model/Resource/Store/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Resource/Store/Collection.php
+++ b/app/code/core/Mage/Core/Model/Resource/Store/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/Store/Collection.php
+++ b/app/code/core/Mage/Core/Model/Resource/Store/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/Store/Group.php
+++ b/app/code/core/Mage/Core/Model/Resource/Store/Group.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Resource/Store/Group.php
+++ b/app/code/core/Mage/Core/Model/Resource/Store/Group.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/Store/Group.php
+++ b/app/code/core/Mage/Core/Model/Resource/Store/Group.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/Store/Group/Collection.php
+++ b/app/code/core/Mage/Core/Model/Resource/Store/Group/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Resource/Store/Group/Collection.php
+++ b/app/code/core/Mage/Core/Model/Resource/Store/Group/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/Store/Group/Collection.php
+++ b/app/code/core/Mage/Core/Model/Resource/Store/Group/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/Transaction.php
+++ b/app/code/core/Mage/Core/Model/Resource/Transaction.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Resource/Transaction.php
+++ b/app/code/core/Mage/Core/Model/Resource/Transaction.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/Transaction.php
+++ b/app/code/core/Mage/Core/Model/Resource/Transaction.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/Translate.php
+++ b/app/code/core/Mage/Core/Model/Resource/Translate.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Resource/Translate.php
+++ b/app/code/core/Mage/Core/Model/Resource/Translate.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/Translate.php
+++ b/app/code/core/Mage/Core/Model/Resource/Translate.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/Translate/String.php
+++ b/app/code/core/Mage/Core/Model/Resource/Translate/String.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Resource/Translate/String.php
+++ b/app/code/core/Mage/Core/Model/Resource/Translate/String.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/Translate/String.php
+++ b/app/code/core/Mage/Core/Model/Resource/Translate/String.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/Type/Abstract.php
+++ b/app/code/core/Mage/Core/Model/Resource/Type/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Resource/Type/Abstract.php
+++ b/app/code/core/Mage/Core/Model/Resource/Type/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/Type/Abstract.php
+++ b/app/code/core/Mage/Core/Model/Resource/Type/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/Type/Db.php
+++ b/app/code/core/Mage/Core/Model/Resource/Type/Db.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Resource/Type/Db.php
+++ b/app/code/core/Mage/Core/Model/Resource/Type/Db.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/Type/Db.php
+++ b/app/code/core/Mage/Core/Model/Resource/Type/Db.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/Type/Db/Mysqli.php
+++ b/app/code/core/Mage/Core/Model/Resource/Type/Db/Mysqli.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Resource/Type/Db/Mysqli.php
+++ b/app/code/core/Mage/Core/Model/Resource/Type/Db/Mysqli.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/Type/Db/Mysqli.php
+++ b/app/code/core/Mage/Core/Model/Resource/Type/Db/Mysqli.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/Type/Db/Mysqli/Setup.php
+++ b/app/code/core/Mage/Core/Model/Resource/Type/Db/Mysqli/Setup.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Resource/Type/Db/Mysqli/Setup.php
+++ b/app/code/core/Mage/Core/Model/Resource/Type/Db/Mysqli/Setup.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/Type/Db/Mysqli/Setup.php
+++ b/app/code/core/Mage/Core/Model/Resource/Type/Db/Mysqli/Setup.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/Type/Db/Pdo/Mysql.php
+++ b/app/code/core/Mage/Core/Model/Resource/Type/Db/Pdo/Mysql.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Resource/Type/Db/Pdo/Mysql.php
+++ b/app/code/core/Mage/Core/Model/Resource/Type/Db/Pdo/Mysql.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/Type/Db/Pdo/Mysql.php
+++ b/app/code/core/Mage/Core/Model/Resource/Type/Db/Pdo/Mysql.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/Url/Rewrite.php
+++ b/app/code/core/Mage/Core/Model/Resource/Url/Rewrite.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Resource/Url/Rewrite.php
+++ b/app/code/core/Mage/Core/Model/Resource/Url/Rewrite.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/Url/Rewrite.php
+++ b/app/code/core/Mage/Core/Model/Resource/Url/Rewrite.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/Url/Rewrite/Collection.php
+++ b/app/code/core/Mage/Core/Model/Resource/Url/Rewrite/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Resource/Url/Rewrite/Collection.php
+++ b/app/code/core/Mage/Core/Model/Resource/Url/Rewrite/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/Url/Rewrite/Collection.php
+++ b/app/code/core/Mage/Core/Model/Resource/Url/Rewrite/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/Variable.php
+++ b/app/code/core/Mage/Core/Model/Resource/Variable.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Resource/Variable.php
+++ b/app/code/core/Mage/Core/Model/Resource/Variable.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/Variable.php
+++ b/app/code/core/Mage/Core/Model/Resource/Variable.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/Variable/Collection.php
+++ b/app/code/core/Mage/Core/Model/Resource/Variable/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Resource/Variable/Collection.php
+++ b/app/code/core/Mage/Core/Model/Resource/Variable/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/Variable/Collection.php
+++ b/app/code/core/Mage/Core/Model/Resource/Variable/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/Website.php
+++ b/app/code/core/Mage/Core/Model/Resource/Website.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Resource/Website.php
+++ b/app/code/core/Mage/Core/Model/Resource/Website.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/Website.php
+++ b/app/code/core/Mage/Core/Model/Resource/Website.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/Website/Collection.php
+++ b/app/code/core/Mage/Core/Model/Resource/Website/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Resource/Website/Collection.php
+++ b/app/code/core/Mage/Core/Model/Resource/Website/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Resource/Website/Collection.php
+++ b/app/code/core/Mage/Core/Model/Resource/Website/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Session.php
+++ b/app/code/core/Mage/Core/Model/Session.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Session.php
+++ b/app/code/core/Mage/Core/Model/Session.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Session.php
+++ b/app/code/core/Mage/Core/Model/Session.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Session/Abstract.php
+++ b/app/code/core/Mage/Core/Model/Session/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Session/Abstract.php
+++ b/app/code/core/Mage/Core/Model/Session/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Session/Abstract.php
+++ b/app/code/core/Mage/Core/Model/Session/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Session/Abstract/Varien.php
+++ b/app/code/core/Mage/Core/Model/Session/Abstract/Varien.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Session/Abstract/Varien.php
+++ b/app/code/core/Mage/Core/Model/Session/Abstract/Varien.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Session/Abstract/Varien.php
+++ b/app/code/core/Mage/Core/Model/Session/Abstract/Varien.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Session/Abstract/Zend.php
+++ b/app/code/core/Mage/Core/Model/Session/Abstract/Zend.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Session/Abstract/Zend.php
+++ b/app/code/core/Mage/Core/Model/Session/Abstract/Zend.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Session/Abstract/Zend.php
+++ b/app/code/core/Mage/Core/Model/Session/Abstract/Zend.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Session/Exception.php
+++ b/app/code/core/Mage/Core/Model/Session/Exception.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Session/Exception.php
+++ b/app/code/core/Mage/Core/Model/Session/Exception.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Session/Exception.php
+++ b/app/code/core/Mage/Core/Model/Session/Exception.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Source/Email/Variables.php
+++ b/app/code/core/Mage/Core/Model/Source/Email/Variables.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Source/Email/Variables.php
+++ b/app/code/core/Mage/Core/Model/Source/Email/Variables.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Source/Email/Variables.php
+++ b/app/code/core/Mage/Core/Model/Source/Email/Variables.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Store.php
+++ b/app/code/core/Mage/Core/Model/Store.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Store.php
+++ b/app/code/core/Mage/Core/Model/Store.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Store.php
+++ b/app/code/core/Mage/Core/Model/Store.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Store/Api.php
+++ b/app/code/core/Mage/Core/Model/Store/Api.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Store/Api.php
+++ b/app/code/core/Mage/Core/Model/Store/Api.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Store/Api.php
+++ b/app/code/core/Mage/Core/Model/Store/Api.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Store/Api/V2.php
+++ b/app/code/core/Mage/Core/Model/Store/Api/V2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Store/Api/V2.php
+++ b/app/code/core/Mage/Core/Model/Store/Api/V2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Store/Api/V2.php
+++ b/app/code/core/Mage/Core/Model/Store/Api/V2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Store/Exception.php
+++ b/app/code/core/Mage/Core/Model/Store/Exception.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Store/Exception.php
+++ b/app/code/core/Mage/Core/Model/Store/Exception.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Store/Exception.php
+++ b/app/code/core/Mage/Core/Model/Store/Exception.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Store/Group.php
+++ b/app/code/core/Mage/Core/Model/Store/Group.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Store/Group.php
+++ b/app/code/core/Mage/Core/Model/Store/Group.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Store/Group.php
+++ b/app/code/core/Mage/Core/Model/Store/Group.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Store/Observer.php
+++ b/app/code/core/Mage/Core/Model/Store/Observer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Store/Observer.php
+++ b/app/code/core/Mage/Core/Model/Store/Observer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Store/Observer.php
+++ b/app/code/core/Mage/Core/Model/Store/Observer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Template.php
+++ b/app/code/core/Mage/Core/Model/Template.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Template.php
+++ b/app/code/core/Mage/Core/Model/Template.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Template.php
+++ b/app/code/core/Mage/Core/Model/Template.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Translate.php
+++ b/app/code/core/Mage/Core/Model/Translate.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Translate.php
+++ b/app/code/core/Mage/Core/Model/Translate.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Translate.php
+++ b/app/code/core/Mage/Core/Model/Translate.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Translate/Expr.php
+++ b/app/code/core/Mage/Core/Model/Translate/Expr.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Translate/Expr.php
+++ b/app/code/core/Mage/Core/Model/Translate/Expr.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Translate/Expr.php
+++ b/app/code/core/Mage/Core/Model/Translate/Expr.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Translate/Inline.php
+++ b/app/code/core/Mage/Core/Model/Translate/Inline.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Translate/Inline.php
+++ b/app/code/core/Mage/Core/Model/Translate/Inline.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Translate/Inline.php
+++ b/app/code/core/Mage/Core/Model/Translate/Inline.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Translate/String.php
+++ b/app/code/core/Mage/Core/Model/Translate/String.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Translate/String.php
+++ b/app/code/core/Mage/Core/Model/Translate/String.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Translate/String.php
+++ b/app/code/core/Mage/Core/Model/Translate/String.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Url.php
+++ b/app/code/core/Mage/Core/Model/Url.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Url.php
+++ b/app/code/core/Mage/Core/Model/Url.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Url.php
+++ b/app/code/core/Mage/Core/Model/Url.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Url/Rewrite.php
+++ b/app/code/core/Mage/Core/Model/Url/Rewrite.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Url/Rewrite.php
+++ b/app/code/core/Mage/Core/Model/Url/Rewrite.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Url/Rewrite.php
+++ b/app/code/core/Mage/Core/Model/Url/Rewrite.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Url/Rewrite/Interface.php
+++ b/app/code/core/Mage/Core/Model/Url/Rewrite/Interface.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Url/Rewrite/Interface.php
+++ b/app/code/core/Mage/Core/Model/Url/Rewrite/Interface.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Url/Rewrite/Interface.php
+++ b/app/code/core/Mage/Core/Model/Url/Rewrite/Interface.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Url/Rewrite/Request.php
+++ b/app/code/core/Mage/Core/Model/Url/Rewrite/Request.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Url/Rewrite/Request.php
+++ b/app/code/core/Mage/Core/Model/Url/Rewrite/Request.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Url/Rewrite/Request.php
+++ b/app/code/core/Mage/Core/Model/Url/Rewrite/Request.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Url/Validator.php
+++ b/app/code/core/Mage/Core/Model/Url/Validator.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Url/Validator.php
+++ b/app/code/core/Mage/Core/Model/Url/Validator.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Url/Validator.php
+++ b/app/code/core/Mage/Core/Model/Url/Validator.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Variable.php
+++ b/app/code/core/Mage/Core/Model/Variable.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Variable.php
+++ b/app/code/core/Mage/Core/Model/Variable.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Variable.php
+++ b/app/code/core/Mage/Core/Model/Variable.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Variable/Config.php
+++ b/app/code/core/Mage/Core/Model/Variable/Config.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Variable/Config.php
+++ b/app/code/core/Mage/Core/Model/Variable/Config.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Variable/Config.php
+++ b/app/code/core/Mage/Core/Model/Variable/Config.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Variable/Observer.php
+++ b/app/code/core/Mage/Core/Model/Variable/Observer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Variable/Observer.php
+++ b/app/code/core/Mage/Core/Model/Variable/Observer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Variable/Observer.php
+++ b/app/code/core/Mage/Core/Model/Variable/Observer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Website.php
+++ b/app/code/core/Mage/Core/Model/Website.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/Model/Website.php
+++ b/app/code/core/Mage/Core/Model/Website.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/Model/Website.php
+++ b/app/code/core/Mage/Core/Model/Website.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/controllers/AjaxController.php
+++ b/app/code/core/Mage/Core/controllers/AjaxController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/controllers/AjaxController.php
+++ b/app/code/core/Mage/Core/controllers/AjaxController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/controllers/AjaxController.php
+++ b/app/code/core/Mage/Core/controllers/AjaxController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/controllers/IndexController.php
+++ b/app/code/core/Mage/Core/controllers/IndexController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/controllers/IndexController.php
+++ b/app/code/core/Mage/Core/controllers/IndexController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/controllers/IndexController.php
+++ b/app/code/core/Mage/Core/controllers/IndexController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/etc/api.xml
+++ b/app/code/core/Mage/Core/etc/api.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/etc/api.xml
+++ b/app/code/core/Mage/Core/etc/api.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/etc/api.xml
+++ b/app/code/core/Mage/Core/etc/api.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/etc/config.xml
+++ b/app/code/core/Mage/Core/etc/config.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/etc/config.xml
+++ b/app/code/core/Mage/Core/etc/config.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/etc/config.xml
+++ b/app/code/core/Mage/Core/etc/config.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/etc/jstranslator.xml
+++ b/app/code/core/Mage/Core/etc/jstranslator.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/etc/jstranslator.xml
+++ b/app/code/core/Mage/Core/etc/jstranslator.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/etc/jstranslator.xml
+++ b/app/code/core/Mage/Core/etc/jstranslator.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/etc/system.xml
+++ b/app/code/core/Mage/Core/etc/system.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/etc/system.xml
+++ b/app/code/core/Mage/Core/etc/system.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/etc/system.xml
+++ b/app/code/core/Mage/Core/etc/system.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/functions.php
+++ b/app/code/core/Mage/Core/functions.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/functions.php
+++ b/app/code/core/Mage/Core/functions.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/functions.php
+++ b/app/code/core/Mage/Core/functions.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Core/sql/core_setup/install-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/sql/core_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Core/sql/core_setup/install-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Core/sql/core_setup/install-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-data-upgrade-1.6.0.2-1.6.0.3.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-data-upgrade-1.6.0.2-1.6.0.3.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-data-upgrade-1.6.0.2-1.6.0.3.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-data-upgrade-1.6.0.2-1.6.0.3.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-data-upgrade-1.6.0.2-1.6.0.3.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-data-upgrade-1.6.0.2-1.6.0.3.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-install-0.7.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-install-0.7.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-install-0.7.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-install-0.8.0.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-install-0.8.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-install-0.8.0.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-install-0.8.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-install-0.8.0.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-install-0.8.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.6.26-0.7.0.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.6.26-0.7.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.6.26-0.7.0.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.6.26-0.7.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.6.26-0.7.0.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.6.26-0.7.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.7.1-0.7.2.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.7.1-0.7.2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.7.1-0.7.2.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.7.1-0.7.2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.7.1-0.7.2.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.7.1-0.7.2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.7.2-0.7.3.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.7.2-0.7.3.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.7.2-0.7.3.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.7.2-0.7.3.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.7.2-0.7.3.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.7.2-0.7.3.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.7.3-0.7.4.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.7.3-0.7.4.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.7.3-0.7.4.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.7.3-0.7.4.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.7.3-0.7.4.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.7.3-0.7.4.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.7.4-0.7.5.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.7.4-0.7.5.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.7.4-0.7.5.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.7.4-0.7.5.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.7.4-0.7.5.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.7.4-0.7.5.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.7.5-0.7.6.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.7.5-0.7.6.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.7.5-0.7.6.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.7.5-0.7.6.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.7.5-0.7.6.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.7.5-0.7.6.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.7.6-0.7.7.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.7.6-0.7.7.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.7.6-0.7.7.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.7.6-0.7.7.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.7.6-0.7.7.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.7.6-0.7.7.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.7.7-0.7.8.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.7.7-0.7.8.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.7.7-0.7.8.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.7.7-0.7.8.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.7.7-0.7.8.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.7.7-0.7.8.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.7.8-0.7.9.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.7.8-0.7.9.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.7.8-0.7.9.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.7.8-0.7.9.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.7.8-0.7.9.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.7.8-0.7.9.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.0-0.8.1.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.0-0.8.1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.0-0.8.1.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.0-0.8.1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.0-0.8.1.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.0-0.8.1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.1-0.8.2.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.1-0.8.2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.1-0.8.2.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.1-0.8.2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.1-0.8.2.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.1-0.8.2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.10-0.8.11.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.10-0.8.11.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.10-0.8.11.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.10-0.8.11.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.10-0.8.11.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.10-0.8.11.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.11-0.8.12.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.11-0.8.12.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.11-0.8.12.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.11-0.8.12.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.11-0.8.12.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.11-0.8.12.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.12-0.8.13.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.12-0.8.13.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.12-0.8.13.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.12-0.8.13.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.12-0.8.13.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.12-0.8.13.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.13-0.8.14.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.13-0.8.14.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.13-0.8.14.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.13-0.8.14.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.13-0.8.14.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.13-0.8.14.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.14-0.8.15.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.14-0.8.15.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.14-0.8.15.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.14-0.8.15.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.14-0.8.15.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.14-0.8.15.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.15-0.8.16.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.15-0.8.16.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.15-0.8.16.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.15-0.8.16.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.15-0.8.16.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.15-0.8.16.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.16-0.8.17.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.16-0.8.17.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.16-0.8.17.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.16-0.8.17.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.16-0.8.17.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.16-0.8.17.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.17-0.8.18.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.17-0.8.18.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.17-0.8.18.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.17-0.8.18.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.17-0.8.18.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.17-0.8.18.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.18-0.8.19.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.18-0.8.19.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.18-0.8.19.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.18-0.8.19.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.18-0.8.19.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.18-0.8.19.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.19-0.8.20.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.19-0.8.20.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.19-0.8.20.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.19-0.8.20.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.19-0.8.20.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.19-0.8.20.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.2-0.8.3.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.2-0.8.3.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.2-0.8.3.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.2-0.8.3.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.2-0.8.3.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.2-0.8.3.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.20-0.8.21.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.20-0.8.21.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.20-0.8.21.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.20-0.8.21.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.20-0.8.21.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.20-0.8.21.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.21-0.8.22.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.21-0.8.22.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.21-0.8.22.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.21-0.8.22.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.21-0.8.22.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.21-0.8.22.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.22-0.8.23.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.22-0.8.23.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.22-0.8.23.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.22-0.8.23.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.22-0.8.23.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.22-0.8.23.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.23-0.8.24.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.23-0.8.24.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.23-0.8.24.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.23-0.8.24.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.23-0.8.24.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.23-0.8.24.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.24-0.8.25.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.24-0.8.25.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.24-0.8.25.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.24-0.8.25.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.24-0.8.25.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.24-0.8.25.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.25-0.8.26.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.25-0.8.26.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.25-0.8.26.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.25-0.8.26.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.25-0.8.26.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.25-0.8.26.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.26-0.8.27.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.26-0.8.27.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.26-0.8.27.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.26-0.8.27.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.26-0.8.27.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.26-0.8.27.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.27-0.8.28.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.27-0.8.28.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.27-0.8.28.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.27-0.8.28.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.27-0.8.28.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.27-0.8.28.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.3-0.8.4.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.3-0.8.4.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.3-0.8.4.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.3-0.8.4.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.3-0.8.4.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.3-0.8.4.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.4-0.8.5.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.4-0.8.5.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.4-0.8.5.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.4-0.8.5.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.4-0.8.5.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.4-0.8.5.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.5-0.8.6.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.5-0.8.6.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.5-0.8.6.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.5-0.8.6.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.5-0.8.6.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.5-0.8.6.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.6-0.8.7.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.6-0.8.7.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.6-0.8.7.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.6-0.8.7.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.6-0.8.7.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.6-0.8.7.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.7-0.8.8.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.7-0.8.8.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.7-0.8.8.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.7-0.8.8.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.7-0.8.8.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.7-0.8.8.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.8-0.8.9.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.8-0.8.9.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.8-0.8.9.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.8-0.8.9.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.8-0.8.9.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.8-0.8.9.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.9-0.8.10.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.9-0.8.10.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.9-0.8.10.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.9-0.8.10.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.9-0.8.10.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-0.8.9-0.8.10.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/Core/sql/core_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/upgrade-1.6.0.1-1.6.0.2.php
+++ b/app/code/core/Mage/Core/sql/core_setup/upgrade-1.6.0.1-1.6.0.2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/sql/core_setup/upgrade-1.6.0.1-1.6.0.2.php
+++ b/app/code/core/Mage/Core/sql/core_setup/upgrade-1.6.0.1-1.6.0.2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/upgrade-1.6.0.1-1.6.0.2.php
+++ b/app/code/core/Mage/Core/sql/core_setup/upgrade-1.6.0.1-1.6.0.2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/upgrade-1.6.0.2-1.6.0.3.php
+++ b/app/code/core/Mage/Core/sql/core_setup/upgrade-1.6.0.2-1.6.0.3.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/sql/core_setup/upgrade-1.6.0.2-1.6.0.3.php
+++ b/app/code/core/Mage/Core/sql/core_setup/upgrade-1.6.0.2-1.6.0.3.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/upgrade-1.6.0.2-1.6.0.3.php
+++ b/app/code/core/Mage/Core/sql/core_setup/upgrade-1.6.0.2-1.6.0.3.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/upgrade-1.6.0.3-1.6.0.4.php
+++ b/app/code/core/Mage/Core/sql/core_setup/upgrade-1.6.0.3-1.6.0.4.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/sql/core_setup/upgrade-1.6.0.3-1.6.0.4.php
+++ b/app/code/core/Mage/Core/sql/core_setup/upgrade-1.6.0.3-1.6.0.4.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/upgrade-1.6.0.3-1.6.0.4.php
+++ b/app/code/core/Mage/Core/sql/core_setup/upgrade-1.6.0.3-1.6.0.4.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/upgrade-1.6.0.5-1.6.0.6.php
+++ b/app/code/core/Mage/Core/sql/core_setup/upgrade-1.6.0.5-1.6.0.6.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/sql/core_setup/upgrade-1.6.0.5-1.6.0.6.php
+++ b/app/code/core/Mage/Core/sql/core_setup/upgrade-1.6.0.5-1.6.0.6.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/upgrade-1.6.0.5-1.6.0.6.php
+++ b/app/code/core/Mage/Core/sql/core_setup/upgrade-1.6.0.5-1.6.0.6.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/upgrade-1.6.0.6-1.6.0.7.php
+++ b/app/code/core/Mage/Core/sql/core_setup/upgrade-1.6.0.6-1.6.0.7.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/sql/core_setup/upgrade-1.6.0.6-1.6.0.7.php
+++ b/app/code/core/Mage/Core/sql/core_setup/upgrade-1.6.0.6-1.6.0.7.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/upgrade-1.6.0.6-1.6.0.7.php
+++ b/app/code/core/Mage/Core/sql/core_setup/upgrade-1.6.0.6-1.6.0.7.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/upgrade-1.6.0.7-1.6.0.8.php
+++ b/app/code/core/Mage/Core/sql/core_setup/upgrade-1.6.0.7-1.6.0.8.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/sql/core_setup/upgrade-1.6.0.7-1.6.0.8.php
+++ b/app/code/core/Mage/Core/sql/core_setup/upgrade-1.6.0.7-1.6.0.8.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/upgrade-1.6.0.7-1.6.0.8.php
+++ b/app/code/core/Mage/Core/sql/core_setup/upgrade-1.6.0.7-1.6.0.8.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/upgrade-1.6.0.8-1.6.0.9.php
+++ b/app/code/core/Mage/Core/sql/core_setup/upgrade-1.6.0.8-1.6.0.9.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/sql/core_setup/upgrade-1.6.0.8-1.6.0.9.php
+++ b/app/code/core/Mage/Core/sql/core_setup/upgrade-1.6.0.8-1.6.0.9.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/upgrade-1.6.0.8-1.6.0.9.php
+++ b/app/code/core/Mage/Core/sql/core_setup/upgrade-1.6.0.8-1.6.0.9.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/upgrade-1.6.0.9-1.6.0.10.php
+++ b/app/code/core/Mage/Core/sql/core_setup/upgrade-1.6.0.9-1.6.0.10.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Core/sql/core_setup/upgrade-1.6.0.9-1.6.0.10.php
+++ b/app/code/core/Mage/Core/sql/core_setup/upgrade-1.6.0.9-1.6.0.10.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Core/sql/core_setup/upgrade-1.6.0.9-1.6.0.10.php
+++ b/app/code/core/Mage/Core/sql/core_setup/upgrade-1.6.0.9-1.6.0.10.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/code/core/Mage/Cron/Exception.php
+++ b/app/code/core/Mage/Cron/Exception.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Cron/Exception.php
+++ b/app/code/core/Mage/Cron/Exception.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Cron

--- a/app/code/core/Mage/Cron/Exception.php
+++ b/app/code/core/Mage/Cron/Exception.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Cron

--- a/app/code/core/Mage/Cron/Helper/Data.php
+++ b/app/code/core/Mage/Cron/Helper/Data.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Cron/Helper/Data.php
+++ b/app/code/core/Mage/Cron/Helper/Data.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Cron

--- a/app/code/core/Mage/Cron/Helper/Data.php
+++ b/app/code/core/Mage/Cron/Helper/Data.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Cron

--- a/app/code/core/Mage/Cron/Model/Mysql4/Schedule.php
+++ b/app/code/core/Mage/Cron/Model/Mysql4/Schedule.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Cron/Model/Mysql4/Schedule.php
+++ b/app/code/core/Mage/Cron/Model/Mysql4/Schedule.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Cron

--- a/app/code/core/Mage/Cron/Model/Mysql4/Schedule.php
+++ b/app/code/core/Mage/Cron/Model/Mysql4/Schedule.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Cron

--- a/app/code/core/Mage/Cron/Model/Mysql4/Schedule/Collection.php
+++ b/app/code/core/Mage/Cron/Model/Mysql4/Schedule/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Cron/Model/Mysql4/Schedule/Collection.php
+++ b/app/code/core/Mage/Cron/Model/Mysql4/Schedule/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Cron

--- a/app/code/core/Mage/Cron/Model/Mysql4/Schedule/Collection.php
+++ b/app/code/core/Mage/Cron/Model/Mysql4/Schedule/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Cron

--- a/app/code/core/Mage/Cron/Model/Observer.php
+++ b/app/code/core/Mage/Cron/Model/Observer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Cron/Model/Observer.php
+++ b/app/code/core/Mage/Cron/Model/Observer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Cron

--- a/app/code/core/Mage/Cron/Model/Observer.php
+++ b/app/code/core/Mage/Cron/Model/Observer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Cron

--- a/app/code/core/Mage/Cron/Model/Resource/Schedule.php
+++ b/app/code/core/Mage/Cron/Model/Resource/Schedule.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Cron/Model/Resource/Schedule.php
+++ b/app/code/core/Mage/Cron/Model/Resource/Schedule.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Cron

--- a/app/code/core/Mage/Cron/Model/Resource/Schedule.php
+++ b/app/code/core/Mage/Cron/Model/Resource/Schedule.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Cron

--- a/app/code/core/Mage/Cron/Model/Resource/Schedule/Collection.php
+++ b/app/code/core/Mage/Cron/Model/Resource/Schedule/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Cron/Model/Resource/Schedule/Collection.php
+++ b/app/code/core/Mage/Cron/Model/Resource/Schedule/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Cron

--- a/app/code/core/Mage/Cron/Model/Resource/Schedule/Collection.php
+++ b/app/code/core/Mage/Cron/Model/Resource/Schedule/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Cron

--- a/app/code/core/Mage/Cron/Model/Schedule.php
+++ b/app/code/core/Mage/Cron/Model/Schedule.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Cron/Model/Schedule.php
+++ b/app/code/core/Mage/Cron/Model/Schedule.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Cron

--- a/app/code/core/Mage/Cron/Model/Schedule.php
+++ b/app/code/core/Mage/Cron/Model/Schedule.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Cron

--- a/app/code/core/Mage/Cron/etc/config.xml
+++ b/app/code/core/Mage/Cron/etc/config.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Cron

--- a/app/code/core/Mage/Cron/etc/config.xml
+++ b/app/code/core/Mage/Cron/etc/config.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Cron/etc/config.xml
+++ b/app/code/core/Mage/Cron/etc/config.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Cron

--- a/app/code/core/Mage/Cron/etc/system.xml
+++ b/app/code/core/Mage/Cron/etc/system.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Cron

--- a/app/code/core/Mage/Cron/etc/system.xml
+++ b/app/code/core/Mage/Cron/etc/system.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Cron/etc/system.xml
+++ b/app/code/core/Mage/Cron/etc/system.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Cron

--- a/app/code/core/Mage/Cron/sql/cron_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Cron/sql/cron_setup/install-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Cron/sql/cron_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Cron/sql/cron_setup/install-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Cron

--- a/app/code/core/Mage/Cron/sql/cron_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Cron/sql/cron_setup/install-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Cron

--- a/app/code/core/Mage/Cron/sql/cron_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/Cron/sql/cron_setup/mysql4-install-0.7.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Cron/sql/cron_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/Cron/sql/cron_setup/mysql4-install-0.7.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Cron

--- a/app/code/core/Mage/Cron/sql/cron_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/Cron/sql/cron_setup/mysql4-install-0.7.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Cron

--- a/app/code/core/Mage/Cron/sql/cron_setup/mysql4-upgrade-0.7.0-0.7.1.php
+++ b/app/code/core/Mage/Cron/sql/cron_setup/mysql4-upgrade-0.7.0-0.7.1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Cron/sql/cron_setup/mysql4-upgrade-0.7.0-0.7.1.php
+++ b/app/code/core/Mage/Cron/sql/cron_setup/mysql4-upgrade-0.7.0-0.7.1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Cron

--- a/app/code/core/Mage/Cron/sql/cron_setup/mysql4-upgrade-0.7.0-0.7.1.php
+++ b/app/code/core/Mage/Cron/sql/cron_setup/mysql4-upgrade-0.7.0-0.7.1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Cron

--- a/app/code/core/Mage/Cron/sql/cron_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/Cron/sql/cron_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Cron/sql/cron_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/Cron/sql/cron_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Cron

--- a/app/code/core/Mage/Cron/sql/cron_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/Cron/sql/cron_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Cron

--- a/app/code/core/Mage/CurrencySymbol/Block/Adminhtml/System/Currencysymbol.php
+++ b/app/code/core/Mage/CurrencySymbol/Block/Adminhtml/System/Currencysymbol.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CurrencySymbol

--- a/app/code/core/Mage/CurrencySymbol/Block/Adminhtml/System/Currencysymbol.php
+++ b/app/code/core/Mage/CurrencySymbol/Block/Adminhtml/System/Currencysymbol.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CurrencySymbol/Block/Adminhtml/System/Currencysymbol.php
+++ b/app/code/core/Mage/CurrencySymbol/Block/Adminhtml/System/Currencysymbol.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CurrencySymbol

--- a/app/code/core/Mage/CurrencySymbol/Helper/Data.php
+++ b/app/code/core/Mage/CurrencySymbol/Helper/Data.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CurrencySymbol

--- a/app/code/core/Mage/CurrencySymbol/Helper/Data.php
+++ b/app/code/core/Mage/CurrencySymbol/Helper/Data.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CurrencySymbol/Helper/Data.php
+++ b/app/code/core/Mage/CurrencySymbol/Helper/Data.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CurrencySymbol

--- a/app/code/core/Mage/CurrencySymbol/Model/Observer.php
+++ b/app/code/core/Mage/CurrencySymbol/Model/Observer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CurrencySymbol

--- a/app/code/core/Mage/CurrencySymbol/Model/Observer.php
+++ b/app/code/core/Mage/CurrencySymbol/Model/Observer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CurrencySymbol/Model/Observer.php
+++ b/app/code/core/Mage/CurrencySymbol/Model/Observer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CurrencySymbol

--- a/app/code/core/Mage/CurrencySymbol/Model/System/Currencysymbol.php
+++ b/app/code/core/Mage/CurrencySymbol/Model/System/Currencysymbol.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CurrencySymbol

--- a/app/code/core/Mage/CurrencySymbol/Model/System/Currencysymbol.php
+++ b/app/code/core/Mage/CurrencySymbol/Model/System/Currencysymbol.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CurrencySymbol/Model/System/Currencysymbol.php
+++ b/app/code/core/Mage/CurrencySymbol/Model/System/Currencysymbol.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CurrencySymbol

--- a/app/code/core/Mage/CurrencySymbol/controllers/Adminhtml/System/CurrencysymbolController.php
+++ b/app/code/core/Mage/CurrencySymbol/controllers/Adminhtml/System/CurrencysymbolController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CurrencySymbol

--- a/app/code/core/Mage/CurrencySymbol/controllers/Adminhtml/System/CurrencysymbolController.php
+++ b/app/code/core/Mage/CurrencySymbol/controllers/Adminhtml/System/CurrencysymbolController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CurrencySymbol/controllers/Adminhtml/System/CurrencysymbolController.php
+++ b/app/code/core/Mage/CurrencySymbol/controllers/Adminhtml/System/CurrencysymbolController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CurrencySymbol

--- a/app/code/core/Mage/CurrencySymbol/etc/adminhtml.xml
+++ b/app/code/core/Mage/CurrencySymbol/etc/adminhtml.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CurrencySymbol

--- a/app/code/core/Mage/CurrencySymbol/etc/adminhtml.xml
+++ b/app/code/core/Mage/CurrencySymbol/etc/adminhtml.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CurrencySymbol

--- a/app/code/core/Mage/CurrencySymbol/etc/adminhtml.xml
+++ b/app/code/core/Mage/CurrencySymbol/etc/adminhtml.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/CurrencySymbol/etc/config.xml
+++ b/app/code/core/Mage/CurrencySymbol/etc/config.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CurrencySymbol

--- a/app/code/core/Mage/CurrencySymbol/etc/config.xml
+++ b/app/code/core/Mage/CurrencySymbol/etc/config.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CurrencySymbol

--- a/app/code/core/Mage/CurrencySymbol/etc/config.xml
+++ b/app/code/core/Mage/CurrencySymbol/etc/config.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Block/Account.php
+++ b/app/code/core/Mage/Customer/Block/Account.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Block/Account.php
+++ b/app/code/core/Mage/Customer/Block/Account.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Block/Account.php
+++ b/app/code/core/Mage/Customer/Block/Account.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Block/Account/Changeforgotten.php
+++ b/app/code/core/Mage/Customer/Block/Account/Changeforgotten.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Block/Account/Changeforgotten.php
+++ b/app/code/core/Mage/Customer/Block/Account/Changeforgotten.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Block/Account/Changeforgotten.php
+++ b/app/code/core/Mage/Customer/Block/Account/Changeforgotten.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Block/Account/Dashboard.php
+++ b/app/code/core/Mage/Customer/Block/Account/Dashboard.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Block/Account/Dashboard.php
+++ b/app/code/core/Mage/Customer/Block/Account/Dashboard.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Block/Account/Dashboard.php
+++ b/app/code/core/Mage/Customer/Block/Account/Dashboard.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Block/Account/Dashboard/Address.php
+++ b/app/code/core/Mage/Customer/Block/Account/Dashboard/Address.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Block/Account/Dashboard/Address.php
+++ b/app/code/core/Mage/Customer/Block/Account/Dashboard/Address.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Block/Account/Dashboard/Address.php
+++ b/app/code/core/Mage/Customer/Block/Account/Dashboard/Address.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Block/Account/Dashboard/Block.php
+++ b/app/code/core/Mage/Customer/Block/Account/Dashboard/Block.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Block/Account/Dashboard/Block.php
+++ b/app/code/core/Mage/Customer/Block/Account/Dashboard/Block.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Block/Account/Dashboard/Block.php
+++ b/app/code/core/Mage/Customer/Block/Account/Dashboard/Block.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Block/Account/Dashboard/Hello.php
+++ b/app/code/core/Mage/Customer/Block/Account/Dashboard/Hello.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Block/Account/Dashboard/Hello.php
+++ b/app/code/core/Mage/Customer/Block/Account/Dashboard/Hello.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Block/Account/Dashboard/Hello.php
+++ b/app/code/core/Mage/Customer/Block/Account/Dashboard/Hello.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Block/Account/Dashboard/Info.php
+++ b/app/code/core/Mage/Customer/Block/Account/Dashboard/Info.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Block/Account/Dashboard/Info.php
+++ b/app/code/core/Mage/Customer/Block/Account/Dashboard/Info.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Block/Account/Dashboard/Info.php
+++ b/app/code/core/Mage/Customer/Block/Account/Dashboard/Info.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Block/Account/Dashboard/Newsletter.php
+++ b/app/code/core/Mage/Customer/Block/Account/Dashboard/Newsletter.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Block/Account/Dashboard/Newsletter.php
+++ b/app/code/core/Mage/Customer/Block/Account/Dashboard/Newsletter.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Block/Account/Dashboard/Newsletter.php
+++ b/app/code/core/Mage/Customer/Block/Account/Dashboard/Newsletter.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Block/Account/Dashboard/Sidebar.php
+++ b/app/code/core/Mage/Customer/Block/Account/Dashboard/Sidebar.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Block/Account/Dashboard/Sidebar.php
+++ b/app/code/core/Mage/Customer/Block/Account/Dashboard/Sidebar.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Block/Account/Dashboard/Sidebar.php
+++ b/app/code/core/Mage/Customer/Block/Account/Dashboard/Sidebar.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Block/Account/Forgotpassword.php
+++ b/app/code/core/Mage/Customer/Block/Account/Forgotpassword.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Block/Account/Forgotpassword.php
+++ b/app/code/core/Mage/Customer/Block/Account/Forgotpassword.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Block/Account/Forgotpassword.php
+++ b/app/code/core/Mage/Customer/Block/Account/Forgotpassword.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Block/Account/Navigation.php
+++ b/app/code/core/Mage/Customer/Block/Account/Navigation.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Block/Account/Navigation.php
+++ b/app/code/core/Mage/Customer/Block/Account/Navigation.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Block/Account/Navigation.php
+++ b/app/code/core/Mage/Customer/Block/Account/Navigation.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Block/Account/Resetpassword.php
+++ b/app/code/core/Mage/Customer/Block/Account/Resetpassword.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Block/Account/Resetpassword.php
+++ b/app/code/core/Mage/Customer/Block/Account/Resetpassword.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Block/Account/Resetpassword.php
+++ b/app/code/core/Mage/Customer/Block/Account/Resetpassword.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Block/Address/Book.php
+++ b/app/code/core/Mage/Customer/Block/Address/Book.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Block/Address/Book.php
+++ b/app/code/core/Mage/Customer/Block/Address/Book.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Block/Address/Book.php
+++ b/app/code/core/Mage/Customer/Block/Address/Book.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Block/Address/Edit.php
+++ b/app/code/core/Mage/Customer/Block/Address/Edit.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Block/Address/Edit.php
+++ b/app/code/core/Mage/Customer/Block/Address/Edit.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Block/Address/Edit.php
+++ b/app/code/core/Mage/Customer/Block/Address/Edit.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Block/Address/Renderer/Default.php
+++ b/app/code/core/Mage/Customer/Block/Address/Renderer/Default.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Block/Address/Renderer/Default.php
+++ b/app/code/core/Mage/Customer/Block/Address/Renderer/Default.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Block/Address/Renderer/Default.php
+++ b/app/code/core/Mage/Customer/Block/Address/Renderer/Default.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Block/Address/Renderer/Interface.php
+++ b/app/code/core/Mage/Customer/Block/Address/Renderer/Interface.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Block/Address/Renderer/Interface.php
+++ b/app/code/core/Mage/Customer/Block/Address/Renderer/Interface.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Block/Address/Renderer/Interface.php
+++ b/app/code/core/Mage/Customer/Block/Address/Renderer/Interface.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Block/Form/Edit.php
+++ b/app/code/core/Mage/Customer/Block/Form/Edit.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Block/Form/Edit.php
+++ b/app/code/core/Mage/Customer/Block/Form/Edit.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Block/Form/Edit.php
+++ b/app/code/core/Mage/Customer/Block/Form/Edit.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Block/Form/Login.php
+++ b/app/code/core/Mage/Customer/Block/Form/Login.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Block/Form/Login.php
+++ b/app/code/core/Mage/Customer/Block/Form/Login.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Block/Form/Login.php
+++ b/app/code/core/Mage/Customer/Block/Form/Login.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Block/Form/Register.php
+++ b/app/code/core/Mage/Customer/Block/Form/Register.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Block/Form/Register.php
+++ b/app/code/core/Mage/Customer/Block/Form/Register.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Block/Form/Register.php
+++ b/app/code/core/Mage/Customer/Block/Form/Register.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Block/Newsletter.php
+++ b/app/code/core/Mage/Customer/Block/Newsletter.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Block/Newsletter.php
+++ b/app/code/core/Mage/Customer/Block/Newsletter.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Block/Newsletter.php
+++ b/app/code/core/Mage/Customer/Block/Newsletter.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Block/Widget/Abstract.php
+++ b/app/code/core/Mage/Customer/Block/Widget/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Block/Widget/Abstract.php
+++ b/app/code/core/Mage/Customer/Block/Widget/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Block/Widget/Abstract.php
+++ b/app/code/core/Mage/Customer/Block/Widget/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Block/Widget/Dob.php
+++ b/app/code/core/Mage/Customer/Block/Widget/Dob.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Block/Widget/Dob.php
+++ b/app/code/core/Mage/Customer/Block/Widget/Dob.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Block/Widget/Dob.php
+++ b/app/code/core/Mage/Customer/Block/Widget/Dob.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Block/Widget/Gender.php
+++ b/app/code/core/Mage/Customer/Block/Widget/Gender.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Block/Widget/Gender.php
+++ b/app/code/core/Mage/Customer/Block/Widget/Gender.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Block/Widget/Gender.php
+++ b/app/code/core/Mage/Customer/Block/Widget/Gender.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Block/Widget/Name.php
+++ b/app/code/core/Mage/Customer/Block/Widget/Name.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Block/Widget/Name.php
+++ b/app/code/core/Mage/Customer/Block/Widget/Name.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Block/Widget/Name.php
+++ b/app/code/core/Mage/Customer/Block/Widget/Name.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Block/Widget/Taxvat.php
+++ b/app/code/core/Mage/Customer/Block/Widget/Taxvat.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Block/Widget/Taxvat.php
+++ b/app/code/core/Mage/Customer/Block/Widget/Taxvat.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Block/Widget/Taxvat.php
+++ b/app/code/core/Mage/Customer/Block/Widget/Taxvat.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Exception.php
+++ b/app/code/core/Mage/Customer/Exception.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Exception.php
+++ b/app/code/core/Mage/Customer/Exception.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Exception.php
+++ b/app/code/core/Mage/Customer/Exception.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Helper/Address.php
+++ b/app/code/core/Mage/Customer/Helper/Address.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Helper/Address.php
+++ b/app/code/core/Mage/Customer/Helper/Address.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Helper/Address.php
+++ b/app/code/core/Mage/Customer/Helper/Address.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Helper/Data.php
+++ b/app/code/core/Mage/Customer/Helper/Data.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Helper/Data.php
+++ b/app/code/core/Mage/Customer/Helper/Data.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Helper/Data.php
+++ b/app/code/core/Mage/Customer/Helper/Data.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Address.php
+++ b/app/code/core/Mage/Customer/Model/Address.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Address.php
+++ b/app/code/core/Mage/Customer/Model/Address.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Model/Address.php
+++ b/app/code/core/Mage/Customer/Model/Address.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Address/Abstract.php
+++ b/app/code/core/Mage/Customer/Model/Address/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Address/Abstract.php
+++ b/app/code/core/Mage/Customer/Model/Address/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Model/Address/Abstract.php
+++ b/app/code/core/Mage/Customer/Model/Address/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Address/Api.php
+++ b/app/code/core/Mage/Customer/Model/Address/Api.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Address/Api.php
+++ b/app/code/core/Mage/Customer/Model/Address/Api.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Model/Address/Api.php
+++ b/app/code/core/Mage/Customer/Model/Address/Api.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Address/Api/V2.php
+++ b/app/code/core/Mage/Customer/Model/Address/Api/V2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Address/Api/V2.php
+++ b/app/code/core/Mage/Customer/Model/Address/Api/V2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Model/Address/Api/V2.php
+++ b/app/code/core/Mage/Customer/Model/Address/Api/V2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Address/Config.php
+++ b/app/code/core/Mage/Customer/Model/Address/Config.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Address/Config.php
+++ b/app/code/core/Mage/Customer/Model/Address/Config.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Model/Address/Config.php
+++ b/app/code/core/Mage/Customer/Model/Address/Config.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Api/Resource.php
+++ b/app/code/core/Mage/Customer/Model/Api/Resource.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Api/Resource.php
+++ b/app/code/core/Mage/Customer/Model/Api/Resource.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Model/Api/Resource.php
+++ b/app/code/core/Mage/Customer/Model/Api/Resource.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Api2/Customer.php
+++ b/app/code/core/Mage/Customer/Model/Api2/Customer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Api2/Customer.php
+++ b/app/code/core/Mage/Customer/Model/Api2/Customer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Model/Api2/Customer.php
+++ b/app/code/core/Mage/Customer/Model/Api2/Customer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Api2/Customer/Address.php
+++ b/app/code/core/Mage/Customer/Model/Api2/Customer/Address.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Api2/Customer/Address.php
+++ b/app/code/core/Mage/Customer/Model/Api2/Customer/Address.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Model/Api2/Customer/Address.php
+++ b/app/code/core/Mage/Customer/Model/Api2/Customer/Address.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Api2/Customer/Address/Rest.php
+++ b/app/code/core/Mage/Customer/Model/Api2/Customer/Address/Rest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Api2/Customer/Address/Rest.php
+++ b/app/code/core/Mage/Customer/Model/Api2/Customer/Address/Rest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Model/Api2/Customer/Address/Rest.php
+++ b/app/code/core/Mage/Customer/Model/Api2/Customer/Address/Rest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Api2/Customer/Address/Rest/Admin/V1.php
+++ b/app/code/core/Mage/Customer/Model/Api2/Customer/Address/Rest/Admin/V1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Api2/Customer/Address/Rest/Admin/V1.php
+++ b/app/code/core/Mage/Customer/Model/Api2/Customer/Address/Rest/Admin/V1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Model/Api2/Customer/Address/Rest/Admin/V1.php
+++ b/app/code/core/Mage/Customer/Model/Api2/Customer/Address/Rest/Admin/V1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Api2/Customer/Address/Rest/Customer/V1.php
+++ b/app/code/core/Mage/Customer/Model/Api2/Customer/Address/Rest/Customer/V1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Api2/Customer/Address/Rest/Customer/V1.php
+++ b/app/code/core/Mage/Customer/Model/Api2/Customer/Address/Rest/Customer/V1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Model/Api2/Customer/Address/Rest/Customer/V1.php
+++ b/app/code/core/Mage/Customer/Model/Api2/Customer/Address/Rest/Customer/V1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Api2/Customer/Address/Validator.php
+++ b/app/code/core/Mage/Customer/Model/Api2/Customer/Address/Validator.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Api2/Customer/Address/Validator.php
+++ b/app/code/core/Mage/Customer/Model/Api2/Customer/Address/Validator.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Model/Api2/Customer/Address/Validator.php
+++ b/app/code/core/Mage/Customer/Model/Api2/Customer/Address/Validator.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Api2/Customer/Rest.php
+++ b/app/code/core/Mage/Customer/Model/Api2/Customer/Rest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Api2/Customer/Rest.php
+++ b/app/code/core/Mage/Customer/Model/Api2/Customer/Rest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Model/Api2/Customer/Rest.php
+++ b/app/code/core/Mage/Customer/Model/Api2/Customer/Rest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Api2/Customer/Rest/Admin/V1.php
+++ b/app/code/core/Mage/Customer/Model/Api2/Customer/Rest/Admin/V1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Api2/Customer/Rest/Admin/V1.php
+++ b/app/code/core/Mage/Customer/Model/Api2/Customer/Rest/Admin/V1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Model/Api2/Customer/Rest/Admin/V1.php
+++ b/app/code/core/Mage/Customer/Model/Api2/Customer/Rest/Admin/V1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Api2/Customer/Rest/Customer/V1.php
+++ b/app/code/core/Mage/Customer/Model/Api2/Customer/Rest/Customer/V1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Api2/Customer/Rest/Customer/V1.php
+++ b/app/code/core/Mage/Customer/Model/Api2/Customer/Rest/Customer/V1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Model/Api2/Customer/Rest/Customer/V1.php
+++ b/app/code/core/Mage/Customer/Model/Api2/Customer/Rest/Customer/V1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Attribute.php
+++ b/app/code/core/Mage/Customer/Model/Attribute.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Attribute.php
+++ b/app/code/core/Mage/Customer/Model/Attribute.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Model/Attribute.php
+++ b/app/code/core/Mage/Customer/Model/Attribute.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Attribute/Backend/Data/Boolean.php
+++ b/app/code/core/Mage/Customer/Model/Attribute/Backend/Data/Boolean.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Attribute/Backend/Data/Boolean.php
+++ b/app/code/core/Mage/Customer/Model/Attribute/Backend/Data/Boolean.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Model/Attribute/Backend/Data/Boolean.php
+++ b/app/code/core/Mage/Customer/Model/Attribute/Backend/Data/Boolean.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Attribute/Data.php
+++ b/app/code/core/Mage/Customer/Model/Attribute/Data.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Attribute/Data.php
+++ b/app/code/core/Mage/Customer/Model/Attribute/Data.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Model/Attribute/Data.php
+++ b/app/code/core/Mage/Customer/Model/Attribute/Data.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Attribute/Data/Abstract.php
+++ b/app/code/core/Mage/Customer/Model/Attribute/Data/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Attribute/Data/Abstract.php
+++ b/app/code/core/Mage/Customer/Model/Attribute/Data/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Model/Attribute/Data/Abstract.php
+++ b/app/code/core/Mage/Customer/Model/Attribute/Data/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Attribute/Data/Boolean.php
+++ b/app/code/core/Mage/Customer/Model/Attribute/Data/Boolean.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Attribute/Data/Boolean.php
+++ b/app/code/core/Mage/Customer/Model/Attribute/Data/Boolean.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Model/Attribute/Data/Boolean.php
+++ b/app/code/core/Mage/Customer/Model/Attribute/Data/Boolean.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Attribute/Data/Date.php
+++ b/app/code/core/Mage/Customer/Model/Attribute/Data/Date.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Attribute/Data/Date.php
+++ b/app/code/core/Mage/Customer/Model/Attribute/Data/Date.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Model/Attribute/Data/Date.php
+++ b/app/code/core/Mage/Customer/Model/Attribute/Data/Date.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Attribute/Data/File.php
+++ b/app/code/core/Mage/Customer/Model/Attribute/Data/File.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Attribute/Data/File.php
+++ b/app/code/core/Mage/Customer/Model/Attribute/Data/File.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Model/Attribute/Data/File.php
+++ b/app/code/core/Mage/Customer/Model/Attribute/Data/File.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Attribute/Data/Hidden.php
+++ b/app/code/core/Mage/Customer/Model/Attribute/Data/Hidden.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Attribute/Data/Hidden.php
+++ b/app/code/core/Mage/Customer/Model/Attribute/Data/Hidden.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Model/Attribute/Data/Hidden.php
+++ b/app/code/core/Mage/Customer/Model/Attribute/Data/Hidden.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Attribute/Data/Image.php
+++ b/app/code/core/Mage/Customer/Model/Attribute/Data/Image.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Attribute/Data/Image.php
+++ b/app/code/core/Mage/Customer/Model/Attribute/Data/Image.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Model/Attribute/Data/Image.php
+++ b/app/code/core/Mage/Customer/Model/Attribute/Data/Image.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Attribute/Data/Multiline.php
+++ b/app/code/core/Mage/Customer/Model/Attribute/Data/Multiline.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Attribute/Data/Multiline.php
+++ b/app/code/core/Mage/Customer/Model/Attribute/Data/Multiline.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Model/Attribute/Data/Multiline.php
+++ b/app/code/core/Mage/Customer/Model/Attribute/Data/Multiline.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Attribute/Data/Multiselect.php
+++ b/app/code/core/Mage/Customer/Model/Attribute/Data/Multiselect.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Attribute/Data/Multiselect.php
+++ b/app/code/core/Mage/Customer/Model/Attribute/Data/Multiselect.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Model/Attribute/Data/Multiselect.php
+++ b/app/code/core/Mage/Customer/Model/Attribute/Data/Multiselect.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Attribute/Data/Postcode.php
+++ b/app/code/core/Mage/Customer/Model/Attribute/Data/Postcode.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Attribute/Data/Postcode.php
+++ b/app/code/core/Mage/Customer/Model/Attribute/Data/Postcode.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Model/Attribute/Data/Postcode.php
+++ b/app/code/core/Mage/Customer/Model/Attribute/Data/Postcode.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Attribute/Data/Select.php
+++ b/app/code/core/Mage/Customer/Model/Attribute/Data/Select.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Attribute/Data/Select.php
+++ b/app/code/core/Mage/Customer/Model/Attribute/Data/Select.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Model/Attribute/Data/Select.php
+++ b/app/code/core/Mage/Customer/Model/Attribute/Data/Select.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Attribute/Data/Text.php
+++ b/app/code/core/Mage/Customer/Model/Attribute/Data/Text.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Attribute/Data/Text.php
+++ b/app/code/core/Mage/Customer/Model/Attribute/Data/Text.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Model/Attribute/Data/Text.php
+++ b/app/code/core/Mage/Customer/Model/Attribute/Data/Text.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Attribute/Data/Textarea.php
+++ b/app/code/core/Mage/Customer/Model/Attribute/Data/Textarea.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Attribute/Data/Textarea.php
+++ b/app/code/core/Mage/Customer/Model/Attribute/Data/Textarea.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Model/Attribute/Data/Textarea.php
+++ b/app/code/core/Mage/Customer/Model/Attribute/Data/Textarea.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Config/Share.php
+++ b/app/code/core/Mage/Customer/Model/Config/Share.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Config/Share.php
+++ b/app/code/core/Mage/Customer/Model/Config/Share.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Model/Config/Share.php
+++ b/app/code/core/Mage/Customer/Model/Config/Share.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Convert/Adapter/Customer.php
+++ b/app/code/core/Mage/Customer/Model/Convert/Adapter/Customer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Convert/Adapter/Customer.php
+++ b/app/code/core/Mage/Customer/Model/Convert/Adapter/Customer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Model/Convert/Adapter/Customer.php
+++ b/app/code/core/Mage/Customer/Model/Convert/Adapter/Customer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Convert/Parser/Customer.php
+++ b/app/code/core/Mage/Customer/Model/Convert/Parser/Customer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Convert/Parser/Customer.php
+++ b/app/code/core/Mage/Customer/Model/Convert/Parser/Customer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Model/Convert/Parser/Customer.php
+++ b/app/code/core/Mage/Customer/Model/Convert/Parser/Customer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Customer.php
+++ b/app/code/core/Mage/Customer/Model/Customer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Customer.php
+++ b/app/code/core/Mage/Customer/Model/Customer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Model/Customer.php
+++ b/app/code/core/Mage/Customer/Model/Customer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Customer/Api.php
+++ b/app/code/core/Mage/Customer/Model/Customer/Api.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Customer/Api.php
+++ b/app/code/core/Mage/Customer/Model/Customer/Api.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Model/Customer/Api.php
+++ b/app/code/core/Mage/Customer/Model/Customer/Api.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Customer/Api/V2.php
+++ b/app/code/core/Mage/Customer/Model/Customer/Api/V2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Customer/Api/V2.php
+++ b/app/code/core/Mage/Customer/Model/Customer/Api/V2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Model/Customer/Api/V2.php
+++ b/app/code/core/Mage/Customer/Model/Customer/Api/V2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Customer/Attribute/Backend/Billing.php
+++ b/app/code/core/Mage/Customer/Model/Customer/Attribute/Backend/Billing.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Customer/Attribute/Backend/Billing.php
+++ b/app/code/core/Mage/Customer/Model/Customer/Attribute/Backend/Billing.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Model/Customer/Attribute/Backend/Billing.php
+++ b/app/code/core/Mage/Customer/Model/Customer/Attribute/Backend/Billing.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Customer/Attribute/Backend/Password.php
+++ b/app/code/core/Mage/Customer/Model/Customer/Attribute/Backend/Password.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Customer/Attribute/Backend/Password.php
+++ b/app/code/core/Mage/Customer/Model/Customer/Attribute/Backend/Password.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Model/Customer/Attribute/Backend/Password.php
+++ b/app/code/core/Mage/Customer/Model/Customer/Attribute/Backend/Password.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Customer/Attribute/Backend/Shipping.php
+++ b/app/code/core/Mage/Customer/Model/Customer/Attribute/Backend/Shipping.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Customer/Attribute/Backend/Shipping.php
+++ b/app/code/core/Mage/Customer/Model/Customer/Attribute/Backend/Shipping.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Model/Customer/Attribute/Backend/Shipping.php
+++ b/app/code/core/Mage/Customer/Model/Customer/Attribute/Backend/Shipping.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Customer/Attribute/Backend/Store.php
+++ b/app/code/core/Mage/Customer/Model/Customer/Attribute/Backend/Store.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Customer/Attribute/Backend/Store.php
+++ b/app/code/core/Mage/Customer/Model/Customer/Attribute/Backend/Store.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Model/Customer/Attribute/Backend/Store.php
+++ b/app/code/core/Mage/Customer/Model/Customer/Attribute/Backend/Store.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Customer/Attribute/Backend/Website.php
+++ b/app/code/core/Mage/Customer/Model/Customer/Attribute/Backend/Website.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Customer/Attribute/Backend/Website.php
+++ b/app/code/core/Mage/Customer/Model/Customer/Attribute/Backend/Website.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Model/Customer/Attribute/Backend/Website.php
+++ b/app/code/core/Mage/Customer/Model/Customer/Attribute/Backend/Website.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Customer/Attribute/Source/Group.php
+++ b/app/code/core/Mage/Customer/Model/Customer/Attribute/Source/Group.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Customer/Attribute/Source/Group.php
+++ b/app/code/core/Mage/Customer/Model/Customer/Attribute/Source/Group.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Model/Customer/Attribute/Source/Group.php
+++ b/app/code/core/Mage/Customer/Model/Customer/Attribute/Source/Group.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Customer/Attribute/Source/Store.php
+++ b/app/code/core/Mage/Customer/Model/Customer/Attribute/Source/Store.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Customer/Attribute/Source/Store.php
+++ b/app/code/core/Mage/Customer/Model/Customer/Attribute/Source/Store.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Model/Customer/Attribute/Source/Store.php
+++ b/app/code/core/Mage/Customer/Model/Customer/Attribute/Source/Store.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Customer/Attribute/Source/Website.php
+++ b/app/code/core/Mage/Customer/Model/Customer/Attribute/Source/Website.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Customer/Attribute/Source/Website.php
+++ b/app/code/core/Mage/Customer/Model/Customer/Attribute/Source/Website.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Model/Customer/Attribute/Source/Website.php
+++ b/app/code/core/Mage/Customer/Model/Customer/Attribute/Source/Website.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Entity/Address.php
+++ b/app/code/core/Mage/Customer/Model/Entity/Address.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Entity/Address.php
+++ b/app/code/core/Mage/Customer/Model/Entity/Address.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Model/Entity/Address.php
+++ b/app/code/core/Mage/Customer/Model/Entity/Address.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Entity/Address/Attribute/Backend/Region.php
+++ b/app/code/core/Mage/Customer/Model/Entity/Address/Attribute/Backend/Region.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Entity/Address/Attribute/Backend/Region.php
+++ b/app/code/core/Mage/Customer/Model/Entity/Address/Attribute/Backend/Region.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Model/Entity/Address/Attribute/Backend/Region.php
+++ b/app/code/core/Mage/Customer/Model/Entity/Address/Attribute/Backend/Region.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Entity/Address/Attribute/Backend/Street.php
+++ b/app/code/core/Mage/Customer/Model/Entity/Address/Attribute/Backend/Street.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Entity/Address/Attribute/Backend/Street.php
+++ b/app/code/core/Mage/Customer/Model/Entity/Address/Attribute/Backend/Street.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Model/Entity/Address/Attribute/Backend/Street.php
+++ b/app/code/core/Mage/Customer/Model/Entity/Address/Attribute/Backend/Street.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Entity/Address/Attribute/Collection.php
+++ b/app/code/core/Mage/Customer/Model/Entity/Address/Attribute/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Entity/Address/Attribute/Collection.php
+++ b/app/code/core/Mage/Customer/Model/Entity/Address/Attribute/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Model/Entity/Address/Attribute/Collection.php
+++ b/app/code/core/Mage/Customer/Model/Entity/Address/Attribute/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Entity/Address/Attribute/Source/Country.php
+++ b/app/code/core/Mage/Customer/Model/Entity/Address/Attribute/Source/Country.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Entity/Address/Attribute/Source/Country.php
+++ b/app/code/core/Mage/Customer/Model/Entity/Address/Attribute/Source/Country.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Model/Entity/Address/Attribute/Source/Country.php
+++ b/app/code/core/Mage/Customer/Model/Entity/Address/Attribute/Source/Country.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Entity/Address/Attribute/Source/Region.php
+++ b/app/code/core/Mage/Customer/Model/Entity/Address/Attribute/Source/Region.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Entity/Address/Attribute/Source/Region.php
+++ b/app/code/core/Mage/Customer/Model/Entity/Address/Attribute/Source/Region.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Model/Entity/Address/Attribute/Source/Region.php
+++ b/app/code/core/Mage/Customer/Model/Entity/Address/Attribute/Source/Region.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Entity/Address/Collection.php
+++ b/app/code/core/Mage/Customer/Model/Entity/Address/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Entity/Address/Collection.php
+++ b/app/code/core/Mage/Customer/Model/Entity/Address/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Model/Entity/Address/Collection.php
+++ b/app/code/core/Mage/Customer/Model/Entity/Address/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Entity/Attribute.php
+++ b/app/code/core/Mage/Customer/Model/Entity/Attribute.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Entity/Attribute.php
+++ b/app/code/core/Mage/Customer/Model/Entity/Attribute.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Model/Entity/Attribute.php
+++ b/app/code/core/Mage/Customer/Model/Entity/Attribute.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Entity/Attribute/Collection.php
+++ b/app/code/core/Mage/Customer/Model/Entity/Attribute/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Entity/Attribute/Collection.php
+++ b/app/code/core/Mage/Customer/Model/Entity/Attribute/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Model/Entity/Attribute/Collection.php
+++ b/app/code/core/Mage/Customer/Model/Entity/Attribute/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Entity/Customer.php
+++ b/app/code/core/Mage/Customer/Model/Entity/Customer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Entity/Customer.php
+++ b/app/code/core/Mage/Customer/Model/Entity/Customer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Model/Entity/Customer.php
+++ b/app/code/core/Mage/Customer/Model/Entity/Customer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Entity/Customer/Collection.php
+++ b/app/code/core/Mage/Customer/Model/Entity/Customer/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Entity/Customer/Collection.php
+++ b/app/code/core/Mage/Customer/Model/Entity/Customer/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Model/Entity/Customer/Collection.php
+++ b/app/code/core/Mage/Customer/Model/Entity/Customer/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Entity/Form/Attribute.php
+++ b/app/code/core/Mage/Customer/Model/Entity/Form/Attribute.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Entity/Form/Attribute.php
+++ b/app/code/core/Mage/Customer/Model/Entity/Form/Attribute.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Model/Entity/Form/Attribute.php
+++ b/app/code/core/Mage/Customer/Model/Entity/Form/Attribute.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Entity/Form/Attribute/Collection.php
+++ b/app/code/core/Mage/Customer/Model/Entity/Form/Attribute/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Entity/Form/Attribute/Collection.php
+++ b/app/code/core/Mage/Customer/Model/Entity/Form/Attribute/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Model/Entity/Form/Attribute/Collection.php
+++ b/app/code/core/Mage/Customer/Model/Entity/Form/Attribute/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Entity/Group.php
+++ b/app/code/core/Mage/Customer/Model/Entity/Group.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Entity/Group.php
+++ b/app/code/core/Mage/Customer/Model/Entity/Group.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Model/Entity/Group.php
+++ b/app/code/core/Mage/Customer/Model/Entity/Group.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Entity/Group/Collection.php
+++ b/app/code/core/Mage/Customer/Model/Entity/Group/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Entity/Group/Collection.php
+++ b/app/code/core/Mage/Customer/Model/Entity/Group/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Model/Entity/Group/Collection.php
+++ b/app/code/core/Mage/Customer/Model/Entity/Group/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Entity/Setup.php
+++ b/app/code/core/Mage/Customer/Model/Entity/Setup.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Entity/Setup.php
+++ b/app/code/core/Mage/Customer/Model/Entity/Setup.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Model/Entity/Setup.php
+++ b/app/code/core/Mage/Customer/Model/Entity/Setup.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Entity/Wishlist/Collection.php
+++ b/app/code/core/Mage/Customer/Model/Entity/Wishlist/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Entity/Wishlist/Collection.php
+++ b/app/code/core/Mage/Customer/Model/Entity/Wishlist/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Model/Entity/Wishlist/Collection.php
+++ b/app/code/core/Mage/Customer/Model/Entity/Wishlist/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Flowpassword.php
+++ b/app/code/core/Mage/Customer/Model/Flowpassword.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Flowpassword.php
+++ b/app/code/core/Mage/Customer/Model/Flowpassword.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Model/Flowpassword.php
+++ b/app/code/core/Mage/Customer/Model/Flowpassword.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Form.php
+++ b/app/code/core/Mage/Customer/Model/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Form.php
+++ b/app/code/core/Mage/Customer/Model/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Model/Form.php
+++ b/app/code/core/Mage/Customer/Model/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Group.php
+++ b/app/code/core/Mage/Customer/Model/Group.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Group.php
+++ b/app/code/core/Mage/Customer/Model/Group.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Model/Group.php
+++ b/app/code/core/Mage/Customer/Model/Group.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Group/Api.php
+++ b/app/code/core/Mage/Customer/Model/Group/Api.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Group/Api.php
+++ b/app/code/core/Mage/Customer/Model/Group/Api.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Model/Group/Api.php
+++ b/app/code/core/Mage/Customer/Model/Group/Api.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Group/Api/V2.php
+++ b/app/code/core/Mage/Customer/Model/Group/Api/V2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Group/Api/V2.php
+++ b/app/code/core/Mage/Customer/Model/Group/Api/V2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Model/Group/Api/V2.php
+++ b/app/code/core/Mage/Customer/Model/Group/Api/V2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Observer.php
+++ b/app/code/core/Mage/Customer/Model/Observer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Observer.php
+++ b/app/code/core/Mage/Customer/Model/Observer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Model/Observer.php
+++ b/app/code/core/Mage/Customer/Model/Observer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Resource/Address.php
+++ b/app/code/core/Mage/Customer/Model/Resource/Address.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Resource/Address.php
+++ b/app/code/core/Mage/Customer/Model/Resource/Address.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Model/Resource/Address.php
+++ b/app/code/core/Mage/Customer/Model/Resource/Address.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Resource/Address/Attribute/Backend/Region.php
+++ b/app/code/core/Mage/Customer/Model/Resource/Address/Attribute/Backend/Region.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Resource/Address/Attribute/Backend/Region.php
+++ b/app/code/core/Mage/Customer/Model/Resource/Address/Attribute/Backend/Region.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Model/Resource/Address/Attribute/Backend/Region.php
+++ b/app/code/core/Mage/Customer/Model/Resource/Address/Attribute/Backend/Region.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Resource/Address/Attribute/Backend/Street.php
+++ b/app/code/core/Mage/Customer/Model/Resource/Address/Attribute/Backend/Street.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Resource/Address/Attribute/Backend/Street.php
+++ b/app/code/core/Mage/Customer/Model/Resource/Address/Attribute/Backend/Street.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Model/Resource/Address/Attribute/Backend/Street.php
+++ b/app/code/core/Mage/Customer/Model/Resource/Address/Attribute/Backend/Street.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Resource/Address/Attribute/Collection.php
+++ b/app/code/core/Mage/Customer/Model/Resource/Address/Attribute/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Resource/Address/Attribute/Collection.php
+++ b/app/code/core/Mage/Customer/Model/Resource/Address/Attribute/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Model/Resource/Address/Attribute/Collection.php
+++ b/app/code/core/Mage/Customer/Model/Resource/Address/Attribute/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Resource/Address/Attribute/Source/Country.php
+++ b/app/code/core/Mage/Customer/Model/Resource/Address/Attribute/Source/Country.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Resource/Address/Attribute/Source/Country.php
+++ b/app/code/core/Mage/Customer/Model/Resource/Address/Attribute/Source/Country.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Model/Resource/Address/Attribute/Source/Country.php
+++ b/app/code/core/Mage/Customer/Model/Resource/Address/Attribute/Source/Country.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Resource/Address/Attribute/Source/Region.php
+++ b/app/code/core/Mage/Customer/Model/Resource/Address/Attribute/Source/Region.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Resource/Address/Attribute/Source/Region.php
+++ b/app/code/core/Mage/Customer/Model/Resource/Address/Attribute/Source/Region.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Model/Resource/Address/Attribute/Source/Region.php
+++ b/app/code/core/Mage/Customer/Model/Resource/Address/Attribute/Source/Region.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Resource/Address/Collection.php
+++ b/app/code/core/Mage/Customer/Model/Resource/Address/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Resource/Address/Collection.php
+++ b/app/code/core/Mage/Customer/Model/Resource/Address/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Model/Resource/Address/Collection.php
+++ b/app/code/core/Mage/Customer/Model/Resource/Address/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Resource/Attribute.php
+++ b/app/code/core/Mage/Customer/Model/Resource/Attribute.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Resource/Attribute.php
+++ b/app/code/core/Mage/Customer/Model/Resource/Attribute.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Model/Resource/Attribute.php
+++ b/app/code/core/Mage/Customer/Model/Resource/Attribute.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Resource/Attribute/Collection.php
+++ b/app/code/core/Mage/Customer/Model/Resource/Attribute/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Resource/Attribute/Collection.php
+++ b/app/code/core/Mage/Customer/Model/Resource/Attribute/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Model/Resource/Attribute/Collection.php
+++ b/app/code/core/Mage/Customer/Model/Resource/Attribute/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Resource/Customer.php
+++ b/app/code/core/Mage/Customer/Model/Resource/Customer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Resource/Customer.php
+++ b/app/code/core/Mage/Customer/Model/Resource/Customer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Model/Resource/Customer.php
+++ b/app/code/core/Mage/Customer/Model/Resource/Customer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Resource/Customer/Collection.php
+++ b/app/code/core/Mage/Customer/Model/Resource/Customer/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Resource/Customer/Collection.php
+++ b/app/code/core/Mage/Customer/Model/Resource/Customer/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Model/Resource/Customer/Collection.php
+++ b/app/code/core/Mage/Customer/Model/Resource/Customer/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Resource/Flowpassword.php
+++ b/app/code/core/Mage/Customer/Model/Resource/Flowpassword.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Resource/Flowpassword.php
+++ b/app/code/core/Mage/Customer/Model/Resource/Flowpassword.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Model/Resource/Flowpassword.php
+++ b/app/code/core/Mage/Customer/Model/Resource/Flowpassword.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Resource/Flowpassword/Collection.php
+++ b/app/code/core/Mage/Customer/Model/Resource/Flowpassword/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Resource/Flowpassword/Collection.php
+++ b/app/code/core/Mage/Customer/Model/Resource/Flowpassword/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Model/Resource/Flowpassword/Collection.php
+++ b/app/code/core/Mage/Customer/Model/Resource/Flowpassword/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Resource/Form/Attribute.php
+++ b/app/code/core/Mage/Customer/Model/Resource/Form/Attribute.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Resource/Form/Attribute.php
+++ b/app/code/core/Mage/Customer/Model/Resource/Form/Attribute.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Model/Resource/Form/Attribute.php
+++ b/app/code/core/Mage/Customer/Model/Resource/Form/Attribute.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Resource/Form/Attribute/Collection.php
+++ b/app/code/core/Mage/Customer/Model/Resource/Form/Attribute/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Resource/Form/Attribute/Collection.php
+++ b/app/code/core/Mage/Customer/Model/Resource/Form/Attribute/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Model/Resource/Form/Attribute/Collection.php
+++ b/app/code/core/Mage/Customer/Model/Resource/Form/Attribute/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Resource/Group.php
+++ b/app/code/core/Mage/Customer/Model/Resource/Group.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Resource/Group.php
+++ b/app/code/core/Mage/Customer/Model/Resource/Group.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Model/Resource/Group.php
+++ b/app/code/core/Mage/Customer/Model/Resource/Group.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Resource/Group/Collection.php
+++ b/app/code/core/Mage/Customer/Model/Resource/Group/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Resource/Group/Collection.php
+++ b/app/code/core/Mage/Customer/Model/Resource/Group/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Model/Resource/Group/Collection.php
+++ b/app/code/core/Mage/Customer/Model/Resource/Group/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Resource/Setup.php
+++ b/app/code/core/Mage/Customer/Model/Resource/Setup.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Resource/Setup.php
+++ b/app/code/core/Mage/Customer/Model/Resource/Setup.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Model/Resource/Setup.php
+++ b/app/code/core/Mage/Customer/Model/Resource/Setup.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Resource/Wishlist/Collection.php
+++ b/app/code/core/Mage/Customer/Model/Resource/Wishlist/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Resource/Wishlist/Collection.php
+++ b/app/code/core/Mage/Customer/Model/Resource/Wishlist/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Model/Resource/Wishlist/Collection.php
+++ b/app/code/core/Mage/Customer/Model/Resource/Wishlist/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Session.php
+++ b/app/code/core/Mage/Customer/Model/Session.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/Model/Session.php
+++ b/app/code/core/Mage/Customer/Model/Session.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/Model/Session.php
+++ b/app/code/core/Mage/Customer/Model/Session.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/controllers/AccountController.php
+++ b/app/code/core/Mage/Customer/controllers/AccountController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/controllers/AccountController.php
+++ b/app/code/core/Mage/Customer/controllers/AccountController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/controllers/AccountController.php
+++ b/app/code/core/Mage/Customer/controllers/AccountController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/controllers/AddressController.php
+++ b/app/code/core/Mage/Customer/controllers/AddressController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/controllers/AddressController.php
+++ b/app/code/core/Mage/Customer/controllers/AddressController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/controllers/AddressController.php
+++ b/app/code/core/Mage/Customer/controllers/AddressController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/controllers/ReviewController.php
+++ b/app/code/core/Mage/Customer/controllers/ReviewController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/controllers/ReviewController.php
+++ b/app/code/core/Mage/Customer/controllers/ReviewController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/controllers/ReviewController.php
+++ b/app/code/core/Mage/Customer/controllers/ReviewController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/data/customer_setup/data-upgrade-1.6.2.0.2-1.6.2.0.3.php
+++ b/app/code/core/Mage/Customer/data/customer_setup/data-upgrade-1.6.2.0.2-1.6.2.0.3.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/data/customer_setup/data-upgrade-1.6.2.0.2-1.6.2.0.3.php
+++ b/app/code/core/Mage/Customer/data/customer_setup/data-upgrade-1.6.2.0.2-1.6.2.0.3.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/data/customer_setup/data-upgrade-1.6.2.0.2-1.6.2.0.3.php
+++ b/app/code/core/Mage/Customer/data/customer_setup/data-upgrade-1.6.2.0.2-1.6.2.0.3.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/data/customer_setup/data-upgrade-1.6.2.0.4-1.6.2.0.5.php
+++ b/app/code/core/Mage/Customer/data/customer_setup/data-upgrade-1.6.2.0.4-1.6.2.0.5.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/data/customer_setup/data-upgrade-1.6.2.0.4-1.6.2.0.5.php
+++ b/app/code/core/Mage/Customer/data/customer_setup/data-upgrade-1.6.2.0.4-1.6.2.0.5.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/data/customer_setup/data-upgrade-1.6.2.0.4-1.6.2.0.5.php
+++ b/app/code/core/Mage/Customer/data/customer_setup/data-upgrade-1.6.2.0.4-1.6.2.0.5.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/etc/adminhtml.xml
+++ b/app/code/core/Mage/Customer/etc/adminhtml.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/etc/adminhtml.xml
+++ b/app/code/core/Mage/Customer/etc/adminhtml.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/etc/adminhtml.xml
+++ b/app/code/core/Mage/Customer/etc/adminhtml.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/etc/api.xml
+++ b/app/code/core/Mage/Customer/etc/api.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/etc/api.xml
+++ b/app/code/core/Mage/Customer/etc/api.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/etc/api.xml
+++ b/app/code/core/Mage/Customer/etc/api.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/etc/api2.xml
+++ b/app/code/core/Mage/Customer/etc/api2.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/etc/api2.xml
+++ b/app/code/core/Mage/Customer/etc/api2.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/etc/api2.xml
+++ b/app/code/core/Mage/Customer/etc/api2.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/etc/config.xml
+++ b/app/code/core/Mage/Customer/etc/config.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/etc/config.xml
+++ b/app/code/core/Mage/Customer/etc/config.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/etc/config.xml
+++ b/app/code/core/Mage/Customer/etc/config.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/etc/system.xml
+++ b/app/code/core/Mage/Customer/etc/system.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/etc/system.xml
+++ b/app/code/core/Mage/Customer/etc/system.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/etc/system.xml
+++ b/app/code/core/Mage/Customer/etc/system.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/sql/customer_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/install-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/sql/customer_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/install-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/sql/customer_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/install-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-data-upgrade-1.4.0.0.11-1.4.0.0.12.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-data-upgrade-1.4.0.0.11-1.4.0.0.12.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-data-upgrade-1.4.0.0.11-1.4.0.0.12.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-data-upgrade-1.4.0.0.11-1.4.0.0.12.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-data-upgrade-1.4.0.0.11-1.4.0.0.12.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-data-upgrade-1.4.0.0.11-1.4.0.0.12.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-data-upgrade-1.4.0.0.13-1.4.0.0.14.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-data-upgrade-1.4.0.0.13-1.4.0.0.14.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-data-upgrade-1.4.0.0.13-1.4.0.0.14.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-data-upgrade-1.4.0.0.13-1.4.0.0.14.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-data-upgrade-1.4.0.0.13-1.4.0.0.14.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-data-upgrade-1.4.0.0.13-1.4.0.0.14.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-data-upgrade-1.4.0.0.7-1.4.0.0.8.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-data-upgrade-1.4.0.0.7-1.4.0.0.8.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-data-upgrade-1.4.0.0.7-1.4.0.0.8.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-data-upgrade-1.4.0.0.7-1.4.0.0.8.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-data-upgrade-1.4.0.0.7-1.4.0.0.8.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-data-upgrade-1.4.0.0.7-1.4.0.0.8.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-data-upgrade-1.4.0.0.8-1.4.0.0.9.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-data-upgrade-1.4.0.0.8-1.4.0.0.9.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-data-upgrade-1.4.0.0.8-1.4.0.0.9.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-data-upgrade-1.4.0.0.8-1.4.0.0.9.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-data-upgrade-1.4.0.0.8-1.4.0.0.9.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-data-upgrade-1.4.0.0.8-1.4.0.0.9.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-install-0.7.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-install-0.7.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-install-0.7.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-install-0.8.0.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-install-0.8.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-install-0.8.0.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-install-0.8.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-install-0.8.0.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-install-0.8.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-install-1.4.0.0.0.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-install-1.4.0.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-install-1.4.0.0.0.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-install-1.4.0.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-install-1.4.0.0.0.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-install-1.4.0.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-0.6.1-0.7.0.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-0.6.1-0.7.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-0.6.1-0.7.0.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-0.6.1-0.7.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-0.6.1-0.7.0.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-0.6.1-0.7.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-0.7.1-0.7.2.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-0.7.1-0.7.2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-0.7.1-0.7.2.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-0.7.1-0.7.2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-0.7.1-0.7.2.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-0.7.1-0.7.2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-0.7.2-0.7.3.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-0.7.2-0.7.3.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-0.7.2-0.7.3.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-0.7.2-0.7.3.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-0.7.2-0.7.3.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-0.7.2-0.7.3.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-0.8.0-0.8.1.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-0.8.0-0.8.1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-0.8.0-0.8.1.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-0.8.0-0.8.1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-0.8.0-0.8.1.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-0.8.0-0.8.1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-0.8.10-0.8.11.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-0.8.10-0.8.11.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-0.8.10-0.8.11.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-0.8.10-0.8.11.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-0.8.10-0.8.11.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-0.8.10-0.8.11.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-0.8.11-0.8.12.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-0.8.11-0.8.12.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-0.8.11-0.8.12.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-0.8.11-0.8.12.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-0.8.11-0.8.12.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-0.8.11-0.8.12.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-0.8.12-1.4.0.0.0.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-0.8.12-1.4.0.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-0.8.12-1.4.0.0.0.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-0.8.12-1.4.0.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-0.8.12-1.4.0.0.0.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-0.8.12-1.4.0.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-0.8.4-0.8.5.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-0.8.4-0.8.5.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-0.8.4-0.8.5.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-0.8.4-0.8.5.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-0.8.4-0.8.5.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-0.8.4-0.8.5.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-0.8.5-0.8.6.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-0.8.5-0.8.6.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-0.8.5-0.8.6.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-0.8.5-0.8.6.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-0.8.5-0.8.6.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-0.8.5-0.8.6.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-0.8.6-0.8.7.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-0.8.6-0.8.7.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-0.8.6-0.8.7.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-0.8.6-0.8.7.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-0.8.6-0.8.7.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-0.8.6-0.8.7.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-0.8.7-0.8.8.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-0.8.7-0.8.8.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-0.8.7-0.8.8.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-0.8.7-0.8.8.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-0.8.7-0.8.8.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-0.8.7-0.8.8.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-0.8.8-0.8.9.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-0.8.8-0.8.9.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-0.8.8-0.8.9.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-0.8.8-0.8.9.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-0.8.8-0.8.9.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-0.8.8-0.8.9.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-0.8.9-0.8.10.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-0.8.9-0.8.10.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-0.8.9-0.8.10.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-0.8.9-0.8.10.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-0.8.9-0.8.10.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-0.8.9-0.8.10.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-1.4.0.0.0-1.4.0.0.1.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-1.4.0.0.0-1.4.0.0.1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-1.4.0.0.0-1.4.0.0.1.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-1.4.0.0.0-1.4.0.0.1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-1.4.0.0.0-1.4.0.0.1.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-1.4.0.0.0-1.4.0.0.1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-1.4.0.0.1-1.4.0.0.2.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-1.4.0.0.1-1.4.0.0.2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-1.4.0.0.1-1.4.0.0.2.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-1.4.0.0.1-1.4.0.0.2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-1.4.0.0.1-1.4.0.0.2.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-1.4.0.0.1-1.4.0.0.2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-1.4.0.0.10-1.4.0.0.11.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-1.4.0.0.10-1.4.0.0.11.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-1.4.0.0.10-1.4.0.0.11.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-1.4.0.0.10-1.4.0.0.11.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-1.4.0.0.10-1.4.0.0.11.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-1.4.0.0.10-1.4.0.0.11.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-1.4.0.0.12-1.4.0.0.13.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-1.4.0.0.12-1.4.0.0.13.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-1.4.0.0.12-1.4.0.0.13.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-1.4.0.0.12-1.4.0.0.13.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-1.4.0.0.12-1.4.0.0.13.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-1.4.0.0.12-1.4.0.0.13.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-1.4.0.0.2-1.4.0.0.3.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-1.4.0.0.2-1.4.0.0.3.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-1.4.0.0.2-1.4.0.0.3.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-1.4.0.0.2-1.4.0.0.3.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-1.4.0.0.2-1.4.0.0.3.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-1.4.0.0.2-1.4.0.0.3.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-1.4.0.0.3-1.4.0.0.4.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-1.4.0.0.3-1.4.0.0.4.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-1.4.0.0.3-1.4.0.0.4.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-1.4.0.0.3-1.4.0.0.4.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-1.4.0.0.3-1.4.0.0.4.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-1.4.0.0.3-1.4.0.0.4.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-1.4.0.0.5-1.4.0.0.6.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-1.4.0.0.5-1.4.0.0.6.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-1.4.0.0.5-1.4.0.0.6.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-1.4.0.0.5-1.4.0.0.6.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-1.4.0.0.5-1.4.0.0.6.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-1.4.0.0.5-1.4.0.0.6.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-1.4.0.0.6-1.4.0.0.7.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-1.4.0.0.6-1.4.0.0.7.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-1.4.0.0.6-1.4.0.0.7.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-1.4.0.0.6-1.4.0.0.7.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-1.4.0.0.6-1.4.0.0.7.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-1.4.0.0.6-1.4.0.0.7.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-1.4.0.0.7-1.4.0.0.8.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-1.4.0.0.7-1.4.0.0.8.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-1.4.0.0.7-1.4.0.0.8.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-1.4.0.0.7-1.4.0.0.8.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-1.4.0.0.7-1.4.0.0.8.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-1.4.0.0.7-1.4.0.0.8.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-1.4.0.0.8-1.4.0.0.9.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-1.4.0.0.8-1.4.0.0.9.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-1.4.0.0.8-1.4.0.0.9.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-1.4.0.0.8-1.4.0.0.9.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-1.4.0.0.8-1.4.0.0.9.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-1.4.0.0.8-1.4.0.0.9.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-1.4.0.0.9-1.4.0.0.10.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-1.4.0.0.9-1.4.0.0.10.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-1.4.0.0.9-1.4.0.0.10.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-1.4.0.0.9-1.4.0.0.10.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-1.4.0.0.9-1.4.0.0.10.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-1.4.0.0.9-1.4.0.0.10.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-1.6.0.0-1.6.1.0.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-1.6.0.0-1.6.1.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-1.6.0.0-1.6.1.0.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-1.6.0.0-1.6.1.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-1.6.0.0-1.6.1.0.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/mysql4-upgrade-1.6.0.0-1.6.1.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/sql/customer_setup/upgrade-1.6.1.0-1.6.2.0.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/upgrade-1.6.1.0-1.6.2.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/sql/customer_setup/upgrade-1.6.1.0-1.6.2.0.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/upgrade-1.6.1.0-1.6.2.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/sql/customer_setup/upgrade-1.6.1.0-1.6.2.0.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/upgrade-1.6.1.0-1.6.2.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/sql/customer_setup/upgrade-1.6.2.0-1.6.2.0.1.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/upgrade-1.6.2.0-1.6.2.0.1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/sql/customer_setup/upgrade-1.6.2.0-1.6.2.0.1.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/upgrade-1.6.2.0-1.6.2.0.1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/sql/customer_setup/upgrade-1.6.2.0-1.6.2.0.1.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/upgrade-1.6.2.0-1.6.2.0.1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/sql/customer_setup/upgrade-1.6.2.0.1-1.6.2.0.2.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/upgrade-1.6.2.0.1-1.6.2.0.2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/sql/customer_setup/upgrade-1.6.2.0.1-1.6.2.0.2.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/upgrade-1.6.2.0.1-1.6.2.0.2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/sql/customer_setup/upgrade-1.6.2.0.1-1.6.2.0.2.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/upgrade-1.6.2.0.1-1.6.2.0.2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/sql/customer_setup/upgrade-1.6.2.0.3-1.6.2.0.4.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/upgrade-1.6.2.0.3-1.6.2.0.4.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/sql/customer_setup/upgrade-1.6.2.0.3-1.6.2.0.4.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/upgrade-1.6.2.0.3-1.6.2.0.4.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/sql/customer_setup/upgrade-1.6.2.0.3-1.6.2.0.4.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/upgrade-1.6.2.0.3-1.6.2.0.4.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/sql/customer_setup/upgrade-1.6.2.0.4-1.6.2.0.5.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/upgrade-1.6.2.0.4-1.6.2.0.5.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/sql/customer_setup/upgrade-1.6.2.0.4-1.6.2.0.5.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/upgrade-1.6.2.0.4-1.6.2.0.5.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/sql/customer_setup/upgrade-1.6.2.0.4-1.6.2.0.5.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/upgrade-1.6.2.0.4-1.6.2.0.5.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/sql/customer_setup/upgrade-1.6.2.0.5-1.6.2.0.6.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/upgrade-1.6.2.0.5-1.6.2.0.6.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/sql/customer_setup/upgrade-1.6.2.0.5-1.6.2.0.6.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/upgrade-1.6.2.0.5-1.6.2.0.6.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/sql/customer_setup/upgrade-1.6.2.0.5-1.6.2.0.6.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/upgrade-1.6.2.0.5-1.6.2.0.6.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/sql/customer_setup/upgrade-1.6.2.0.6-1.6.2.0.7.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/upgrade-1.6.2.0.6-1.6.2.0.7.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Customer/sql/customer_setup/upgrade-1.6.2.0.6-1.6.2.0.7.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/upgrade-1.6.2.0.6-1.6.2.0.7.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Customer/sql/customer_setup/upgrade-1.6.2.0.6-1.6.2.0.7.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/upgrade-1.6.2.0.6-1.6.2.0.7.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/code/core/Mage/Dataflow/Helper/Data.php
+++ b/app/code/core/Mage/Dataflow/Helper/Data.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Dataflow/Helper/Data.php
+++ b/app/code/core/Mage/Dataflow/Helper/Data.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Helper/Data.php
+++ b/app/code/core/Mage/Dataflow/Helper/Data.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Batch.php
+++ b/app/code/core/Mage/Dataflow/Model/Batch.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Dataflow/Model/Batch.php
+++ b/app/code/core/Mage/Dataflow/Model/Batch.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Batch.php
+++ b/app/code/core/Mage/Dataflow/Model/Batch.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Batch/Abstract.php
+++ b/app/code/core/Mage/Dataflow/Model/Batch/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Dataflow/Model/Batch/Abstract.php
+++ b/app/code/core/Mage/Dataflow/Model/Batch/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Batch/Abstract.php
+++ b/app/code/core/Mage/Dataflow/Model/Batch/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Batch/Export.php
+++ b/app/code/core/Mage/Dataflow/Model/Batch/Export.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Dataflow/Model/Batch/Export.php
+++ b/app/code/core/Mage/Dataflow/Model/Batch/Export.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Batch/Export.php
+++ b/app/code/core/Mage/Dataflow/Model/Batch/Export.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Batch/Import.php
+++ b/app/code/core/Mage/Dataflow/Model/Batch/Import.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Dataflow/Model/Batch/Import.php
+++ b/app/code/core/Mage/Dataflow/Model/Batch/Import.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Batch/Import.php
+++ b/app/code/core/Mage/Dataflow/Model/Batch/Import.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Batch/Io.php
+++ b/app/code/core/Mage/Dataflow/Model/Batch/Io.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Dataflow/Model/Batch/Io.php
+++ b/app/code/core/Mage/Dataflow/Model/Batch/Io.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Batch/Io.php
+++ b/app/code/core/Mage/Dataflow/Model/Batch/Io.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Convert.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Dataflow/Model/Convert.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Convert.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Convert/Action.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Action.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Dataflow/Model/Convert/Action.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Action.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Convert/Action.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Action.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Convert/Action/Abstract.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Action/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Dataflow/Model/Convert/Action/Abstract.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Action/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Convert/Action/Abstract.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Action/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Convert/Action/Interface.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Action/Interface.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Dataflow/Model/Convert/Action/Interface.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Action/Interface.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Convert/Action/Interface.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Action/Interface.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Convert/Adapter/Abstract.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Adapter/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Dataflow/Model/Convert/Adapter/Abstract.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Adapter/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Convert/Adapter/Abstract.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Adapter/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Convert/Adapter/Db/Table.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Adapter/Db/Table.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Dataflow/Model/Convert/Adapter/Db/Table.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Adapter/Db/Table.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Convert/Adapter/Db/Table.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Adapter/Db/Table.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Convert/Adapter/Http.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Adapter/Http.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Dataflow/Model/Convert/Adapter/Http.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Adapter/Http.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Convert/Adapter/Http.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Adapter/Http.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Convert/Adapter/Http/Curl.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Adapter/Http/Curl.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Dataflow/Model/Convert/Adapter/Http/Curl.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Adapter/Http/Curl.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Convert/Adapter/Http/Curl.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Adapter/Http/Curl.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Convert/Adapter/Interface.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Adapter/Interface.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Dataflow/Model/Convert/Adapter/Interface.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Adapter/Interface.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Convert/Adapter/Interface.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Adapter/Interface.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Convert/Adapter/Io.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Adapter/Io.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Dataflow/Model/Convert/Adapter/Io.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Adapter/Io.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Convert/Adapter/Io.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Adapter/Io.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Convert/Adapter/Soap.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Adapter/Soap.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Dataflow/Model/Convert/Adapter/Soap.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Adapter/Soap.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Convert/Adapter/Soap.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Adapter/Soap.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Convert/Adapter/Std.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Adapter/Std.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Dataflow/Model/Convert/Adapter/Std.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Adapter/Std.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Convert/Adapter/Std.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Adapter/Std.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Convert/Adapter/Zend/Cache.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Adapter/Zend/Cache.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Dataflow/Model/Convert/Adapter/Zend/Cache.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Adapter/Zend/Cache.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Convert/Adapter/Zend/Cache.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Adapter/Zend/Cache.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Convert/Adapter/Zend/Db.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Adapter/Zend/Db.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Dataflow/Model/Convert/Adapter/Zend/Db.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Adapter/Zend/Db.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Convert/Adapter/Zend/Db.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Adapter/Zend/Db.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Convert/Container/Abstract.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Container/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Dataflow/Model/Convert/Container/Abstract.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Container/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Convert/Container/Abstract.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Container/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Convert/Container/Collection.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Container/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Dataflow/Model/Convert/Container/Collection.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Container/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Convert/Container/Collection.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Container/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Convert/Container/Generic.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Container/Generic.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Dataflow/Model/Convert/Container/Generic.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Container/Generic.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Convert/Container/Generic.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Container/Generic.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Convert/Container/Interface.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Container/Interface.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Dataflow/Model/Convert/Container/Interface.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Container/Interface.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Convert/Container/Interface.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Container/Interface.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Convert/Exception.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Exception.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Dataflow/Model/Convert/Exception.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Exception.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Convert/Exception.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Exception.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Convert/Iterator.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Iterator.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Dataflow/Model/Convert/Iterator.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Iterator.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Convert/Iterator.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Iterator.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Convert/Iterator/File/Csv.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Iterator/File/Csv.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Dataflow/Model/Convert/Iterator/File/Csv.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Iterator/File/Csv.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Convert/Iterator/File/Csv.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Iterator/File/Csv.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Convert/Iterator/Http.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Iterator/Http.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Dataflow/Model/Convert/Iterator/Http.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Iterator/Http.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Convert/Iterator/Http.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Iterator/Http.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Convert/Iterator/Interface.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Iterator/Interface.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Dataflow/Model/Convert/Iterator/Interface.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Iterator/Interface.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Convert/Iterator/Interface.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Iterator/Interface.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Convert/Mapper/Abstract.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Mapper/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Dataflow/Model/Convert/Mapper/Abstract.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Mapper/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Convert/Mapper/Abstract.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Mapper/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Convert/Mapper/Column.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Mapper/Column.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Dataflow/Model/Convert/Mapper/Column.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Mapper/Column.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Convert/Mapper/Column.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Mapper/Column.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Convert/Mapper/Interface.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Mapper/Interface.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Dataflow/Model/Convert/Mapper/Interface.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Mapper/Interface.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Convert/Mapper/Interface.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Mapper/Interface.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Convert/Parser/Abstract.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Parser/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Dataflow/Model/Convert/Parser/Abstract.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Parser/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Convert/Parser/Abstract.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Parser/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Convert/Parser/Csv.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Parser/Csv.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Dataflow/Model/Convert/Parser/Csv.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Parser/Csv.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Convert/Parser/Csv.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Parser/Csv.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Convert/Parser/Interface.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Parser/Interface.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Dataflow/Model/Convert/Parser/Interface.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Parser/Interface.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Convert/Parser/Interface.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Parser/Interface.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Convert/Parser/Serialize.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Parser/Serialize.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Dataflow/Model/Convert/Parser/Serialize.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Parser/Serialize.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Convert/Parser/Serialize.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Parser/Serialize.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Convert/Parser/Xml/Excel.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Parser/Xml/Excel.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Dataflow/Model/Convert/Parser/Xml/Excel.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Parser/Xml/Excel.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Convert/Parser/Xml/Excel.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Parser/Xml/Excel.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Convert/Profile.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Profile.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Dataflow/Model/Convert/Profile.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Profile.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Convert/Profile.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Profile.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Convert/Profile/Abstract.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Profile/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Dataflow/Model/Convert/Profile/Abstract.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Profile/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Convert/Profile/Abstract.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Profile/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Convert/Profile/Collection.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Profile/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Dataflow/Model/Convert/Profile/Collection.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Profile/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Convert/Profile/Collection.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Profile/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Convert/Profile/Interface.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Profile/Interface.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Dataflow/Model/Convert/Profile/Interface.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Profile/Interface.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Convert/Profile/Interface.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Profile/Interface.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Convert/Validator/Abstract.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Validator/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Dataflow/Model/Convert/Validator/Abstract.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Validator/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Convert/Validator/Abstract.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Validator/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Convert/Validator/Column.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Validator/Column.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Dataflow/Model/Convert/Validator/Column.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Validator/Column.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Convert/Validator/Column.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Validator/Column.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Convert/Validator/Dryrun.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Validator/Dryrun.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Dataflow/Model/Convert/Validator/Dryrun.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Validator/Dryrun.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Convert/Validator/Dryrun.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Validator/Dryrun.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Convert/Validator/Interface.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Validator/Interface.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Dataflow/Model/Convert/Validator/Interface.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Validator/Interface.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Convert/Validator/Interface.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Validator/Interface.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Import.php
+++ b/app/code/core/Mage/Dataflow/Model/Import.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Dataflow/Model/Import.php
+++ b/app/code/core/Mage/Dataflow/Model/Import.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Import.php
+++ b/app/code/core/Mage/Dataflow/Model/Import.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Mysql4/Batch.php
+++ b/app/code/core/Mage/Dataflow/Model/Mysql4/Batch.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Dataflow/Model/Mysql4/Batch.php
+++ b/app/code/core/Mage/Dataflow/Model/Mysql4/Batch.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Mysql4/Batch.php
+++ b/app/code/core/Mage/Dataflow/Model/Mysql4/Batch.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Mysql4/Batch/Abstract.php
+++ b/app/code/core/Mage/Dataflow/Model/Mysql4/Batch/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Dataflow/Model/Mysql4/Batch/Abstract.php
+++ b/app/code/core/Mage/Dataflow/Model/Mysql4/Batch/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Mysql4/Batch/Abstract.php
+++ b/app/code/core/Mage/Dataflow/Model/Mysql4/Batch/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Mysql4/Batch/Collection.php
+++ b/app/code/core/Mage/Dataflow/Model/Mysql4/Batch/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Dataflow/Model/Mysql4/Batch/Collection.php
+++ b/app/code/core/Mage/Dataflow/Model/Mysql4/Batch/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Mysql4/Batch/Collection.php
+++ b/app/code/core/Mage/Dataflow/Model/Mysql4/Batch/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Mysql4/Batch/Export.php
+++ b/app/code/core/Mage/Dataflow/Model/Mysql4/Batch/Export.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Dataflow/Model/Mysql4/Batch/Export.php
+++ b/app/code/core/Mage/Dataflow/Model/Mysql4/Batch/Export.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Mysql4/Batch/Export.php
+++ b/app/code/core/Mage/Dataflow/Model/Mysql4/Batch/Export.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Mysql4/Batch/Import.php
+++ b/app/code/core/Mage/Dataflow/Model/Mysql4/Batch/Import.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Dataflow/Model/Mysql4/Batch/Import.php
+++ b/app/code/core/Mage/Dataflow/Model/Mysql4/Batch/Import.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Mysql4/Batch/Import.php
+++ b/app/code/core/Mage/Dataflow/Model/Mysql4/Batch/Import.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Mysql4/Catalogold.php
+++ b/app/code/core/Mage/Dataflow/Model/Mysql4/Catalogold.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Dataflow/Model/Mysql4/Catalogold.php
+++ b/app/code/core/Mage/Dataflow/Model/Mysql4/Catalogold.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Mysql4/Catalogold.php
+++ b/app/code/core/Mage/Dataflow/Model/Mysql4/Catalogold.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Mysql4/Import.php
+++ b/app/code/core/Mage/Dataflow/Model/Mysql4/Import.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Dataflow/Model/Mysql4/Import.php
+++ b/app/code/core/Mage/Dataflow/Model/Mysql4/Import.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Mysql4/Import.php
+++ b/app/code/core/Mage/Dataflow/Model/Mysql4/Import.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Mysql4/Import/Collection.php
+++ b/app/code/core/Mage/Dataflow/Model/Mysql4/Import/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Dataflow/Model/Mysql4/Import/Collection.php
+++ b/app/code/core/Mage/Dataflow/Model/Mysql4/Import/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Mysql4/Import/Collection.php
+++ b/app/code/core/Mage/Dataflow/Model/Mysql4/Import/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Mysql4/Profile.php
+++ b/app/code/core/Mage/Dataflow/Model/Mysql4/Profile.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Dataflow/Model/Mysql4/Profile.php
+++ b/app/code/core/Mage/Dataflow/Model/Mysql4/Profile.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Mysql4/Profile.php
+++ b/app/code/core/Mage/Dataflow/Model/Mysql4/Profile.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Mysql4/Profile/Collection.php
+++ b/app/code/core/Mage/Dataflow/Model/Mysql4/Profile/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Dataflow/Model/Mysql4/Profile/Collection.php
+++ b/app/code/core/Mage/Dataflow/Model/Mysql4/Profile/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Mysql4/Profile/Collection.php
+++ b/app/code/core/Mage/Dataflow/Model/Mysql4/Profile/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Mysql4/Profile/History.php
+++ b/app/code/core/Mage/Dataflow/Model/Mysql4/Profile/History.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Dataflow/Model/Mysql4/Profile/History.php
+++ b/app/code/core/Mage/Dataflow/Model/Mysql4/Profile/History.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Mysql4/Profile/History.php
+++ b/app/code/core/Mage/Dataflow/Model/Mysql4/Profile/History.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Mysql4/Profile/History/Collection.php
+++ b/app/code/core/Mage/Dataflow/Model/Mysql4/Profile/History/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Dataflow/Model/Mysql4/Profile/History/Collection.php
+++ b/app/code/core/Mage/Dataflow/Model/Mysql4/Profile/History/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Mysql4/Profile/History/Collection.php
+++ b/app/code/core/Mage/Dataflow/Model/Mysql4/Profile/History/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Mysql4/Session.php
+++ b/app/code/core/Mage/Dataflow/Model/Mysql4/Session.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Dataflow/Model/Mysql4/Session.php
+++ b/app/code/core/Mage/Dataflow/Model/Mysql4/Session.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Mysql4/Session.php
+++ b/app/code/core/Mage/Dataflow/Model/Mysql4/Session.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Profile.php
+++ b/app/code/core/Mage/Dataflow/Model/Profile.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Dataflow/Model/Profile.php
+++ b/app/code/core/Mage/Dataflow/Model/Profile.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Profile.php
+++ b/app/code/core/Mage/Dataflow/Model/Profile.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Profile/History.php
+++ b/app/code/core/Mage/Dataflow/Model/Profile/History.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Dataflow/Model/Profile/History.php
+++ b/app/code/core/Mage/Dataflow/Model/Profile/History.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Profile/History.php
+++ b/app/code/core/Mage/Dataflow/Model/Profile/History.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Resource/Batch.php
+++ b/app/code/core/Mage/Dataflow/Model/Resource/Batch.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Dataflow/Model/Resource/Batch.php
+++ b/app/code/core/Mage/Dataflow/Model/Resource/Batch.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Resource/Batch.php
+++ b/app/code/core/Mage/Dataflow/Model/Resource/Batch.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Resource/Batch/Abstract.php
+++ b/app/code/core/Mage/Dataflow/Model/Resource/Batch/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Dataflow/Model/Resource/Batch/Abstract.php
+++ b/app/code/core/Mage/Dataflow/Model/Resource/Batch/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Resource/Batch/Abstract.php
+++ b/app/code/core/Mage/Dataflow/Model/Resource/Batch/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Resource/Batch/Collection.php
+++ b/app/code/core/Mage/Dataflow/Model/Resource/Batch/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Dataflow/Model/Resource/Batch/Collection.php
+++ b/app/code/core/Mage/Dataflow/Model/Resource/Batch/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Resource/Batch/Collection.php
+++ b/app/code/core/Mage/Dataflow/Model/Resource/Batch/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Resource/Batch/Export.php
+++ b/app/code/core/Mage/Dataflow/Model/Resource/Batch/Export.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Dataflow/Model/Resource/Batch/Export.php
+++ b/app/code/core/Mage/Dataflow/Model/Resource/Batch/Export.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Resource/Batch/Export.php
+++ b/app/code/core/Mage/Dataflow/Model/Resource/Batch/Export.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Resource/Batch/Import.php
+++ b/app/code/core/Mage/Dataflow/Model/Resource/Batch/Import.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Dataflow/Model/Resource/Batch/Import.php
+++ b/app/code/core/Mage/Dataflow/Model/Resource/Batch/Import.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Resource/Batch/Import.php
+++ b/app/code/core/Mage/Dataflow/Model/Resource/Batch/Import.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Resource/Import.php
+++ b/app/code/core/Mage/Dataflow/Model/Resource/Import.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Dataflow/Model/Resource/Import.php
+++ b/app/code/core/Mage/Dataflow/Model/Resource/Import.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Resource/Import.php
+++ b/app/code/core/Mage/Dataflow/Model/Resource/Import.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Resource/Import/Collection.php
+++ b/app/code/core/Mage/Dataflow/Model/Resource/Import/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Dataflow/Model/Resource/Import/Collection.php
+++ b/app/code/core/Mage/Dataflow/Model/Resource/Import/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Resource/Import/Collection.php
+++ b/app/code/core/Mage/Dataflow/Model/Resource/Import/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Resource/Profile.php
+++ b/app/code/core/Mage/Dataflow/Model/Resource/Profile.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Dataflow/Model/Resource/Profile.php
+++ b/app/code/core/Mage/Dataflow/Model/Resource/Profile.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Resource/Profile.php
+++ b/app/code/core/Mage/Dataflow/Model/Resource/Profile.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Resource/Profile/Collection.php
+++ b/app/code/core/Mage/Dataflow/Model/Resource/Profile/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Dataflow/Model/Resource/Profile/Collection.php
+++ b/app/code/core/Mage/Dataflow/Model/Resource/Profile/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Resource/Profile/Collection.php
+++ b/app/code/core/Mage/Dataflow/Model/Resource/Profile/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Resource/Profile/History.php
+++ b/app/code/core/Mage/Dataflow/Model/Resource/Profile/History.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Dataflow/Model/Resource/Profile/History.php
+++ b/app/code/core/Mage/Dataflow/Model/Resource/Profile/History.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Resource/Profile/History.php
+++ b/app/code/core/Mage/Dataflow/Model/Resource/Profile/History.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Resource/Profile/History/Collection.php
+++ b/app/code/core/Mage/Dataflow/Model/Resource/Profile/History/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Dataflow/Model/Resource/Profile/History/Collection.php
+++ b/app/code/core/Mage/Dataflow/Model/Resource/Profile/History/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Resource/Profile/History/Collection.php
+++ b/app/code/core/Mage/Dataflow/Model/Resource/Profile/History/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Resource/Session.php
+++ b/app/code/core/Mage/Dataflow/Model/Resource/Session.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Dataflow/Model/Resource/Session.php
+++ b/app/code/core/Mage/Dataflow/Model/Resource/Session.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Resource/Session.php
+++ b/app/code/core/Mage/Dataflow/Model/Resource/Session.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Session.php
+++ b/app/code/core/Mage/Dataflow/Model/Session.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Dataflow/Model/Session.php
+++ b/app/code/core/Mage/Dataflow/Model/Session.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Session.php
+++ b/app/code/core/Mage/Dataflow/Model/Session.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Session/Adapter/Http.php
+++ b/app/code/core/Mage/Dataflow/Model/Session/Adapter/Http.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Dataflow/Model/Session/Adapter/Http.php
+++ b/app/code/core/Mage/Dataflow/Model/Session/Adapter/Http.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Session/Adapter/Http.php
+++ b/app/code/core/Mage/Dataflow/Model/Session/Adapter/Http.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Session/Parser/Csv.php
+++ b/app/code/core/Mage/Dataflow/Model/Session/Parser/Csv.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Dataflow/Model/Session/Parser/Csv.php
+++ b/app/code/core/Mage/Dataflow/Model/Session/Parser/Csv.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/Model/Session/Parser/Csv.php
+++ b/app/code/core/Mage/Dataflow/Model/Session/Parser/Csv.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/data/dataflow_setup/data-install-1.6.0.0.php
+++ b/app/code/core/Mage/Dataflow/data/dataflow_setup/data-install-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Dataflow/data/dataflow_setup/data-install-1.6.0.0.php
+++ b/app/code/core/Mage/Dataflow/data/dataflow_setup/data-install-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/data/dataflow_setup/data-install-1.6.0.0.php
+++ b/app/code/core/Mage/Dataflow/data/dataflow_setup/data-install-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/etc/config.xml
+++ b/app/code/core/Mage/Dataflow/etc/config.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/etc/config.xml
+++ b/app/code/core/Mage/Dataflow/etc/config.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/etc/config.xml
+++ b/app/code/core/Mage/Dataflow/etc/config.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Dataflow/sql/dataflow_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Dataflow/sql/dataflow_setup/install-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Dataflow/sql/dataflow_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Dataflow/sql/dataflow_setup/install-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/sql/dataflow_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Dataflow/sql/dataflow_setup/install-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/sql/dataflow_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/Dataflow/sql/dataflow_setup/mysql4-install-0.7.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Dataflow/sql/dataflow_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/Dataflow/sql/dataflow_setup/mysql4-install-0.7.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/sql/dataflow_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/Dataflow/sql/dataflow_setup/mysql4-install-0.7.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/sql/dataflow_setup/mysql4-upgrade-0.7.0-0.7.1.php
+++ b/app/code/core/Mage/Dataflow/sql/dataflow_setup/mysql4-upgrade-0.7.0-0.7.1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Dataflow/sql/dataflow_setup/mysql4-upgrade-0.7.0-0.7.1.php
+++ b/app/code/core/Mage/Dataflow/sql/dataflow_setup/mysql4-upgrade-0.7.0-0.7.1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/sql/dataflow_setup/mysql4-upgrade-0.7.0-0.7.1.php
+++ b/app/code/core/Mage/Dataflow/sql/dataflow_setup/mysql4-upgrade-0.7.0-0.7.1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/sql/dataflow_setup/mysql4-upgrade-0.7.1-0.7.2.php
+++ b/app/code/core/Mage/Dataflow/sql/dataflow_setup/mysql4-upgrade-0.7.1-0.7.2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Dataflow/sql/dataflow_setup/mysql4-upgrade-0.7.1-0.7.2.php
+++ b/app/code/core/Mage/Dataflow/sql/dataflow_setup/mysql4-upgrade-0.7.1-0.7.2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/sql/dataflow_setup/mysql4-upgrade-0.7.1-0.7.2.php
+++ b/app/code/core/Mage/Dataflow/sql/dataflow_setup/mysql4-upgrade-0.7.1-0.7.2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/sql/dataflow_setup/mysql4-upgrade-0.7.2-0.7.3.php
+++ b/app/code/core/Mage/Dataflow/sql/dataflow_setup/mysql4-upgrade-0.7.2-0.7.3.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Dataflow/sql/dataflow_setup/mysql4-upgrade-0.7.2-0.7.3.php
+++ b/app/code/core/Mage/Dataflow/sql/dataflow_setup/mysql4-upgrade-0.7.2-0.7.3.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/sql/dataflow_setup/mysql4-upgrade-0.7.2-0.7.3.php
+++ b/app/code/core/Mage/Dataflow/sql/dataflow_setup/mysql4-upgrade-0.7.2-0.7.3.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/sql/dataflow_setup/mysql4-upgrade-0.7.3-0.7.4.php
+++ b/app/code/core/Mage/Dataflow/sql/dataflow_setup/mysql4-upgrade-0.7.3-0.7.4.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Dataflow/sql/dataflow_setup/mysql4-upgrade-0.7.3-0.7.4.php
+++ b/app/code/core/Mage/Dataflow/sql/dataflow_setup/mysql4-upgrade-0.7.3-0.7.4.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/sql/dataflow_setup/mysql4-upgrade-0.7.3-0.7.4.php
+++ b/app/code/core/Mage/Dataflow/sql/dataflow_setup/mysql4-upgrade-0.7.3-0.7.4.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/sql/dataflow_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/Dataflow/sql/dataflow_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Dataflow/sql/dataflow_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/Dataflow/sql/dataflow_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Dataflow/sql/dataflow_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/Dataflow/sql/dataflow_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/code/core/Mage/Directory/Block/Adminhtml/Frontend/Currency/Base.php
+++ b/app/code/core/Mage/Directory/Block/Adminhtml/Frontend/Currency/Base.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Directory/Block/Adminhtml/Frontend/Currency/Base.php
+++ b/app/code/core/Mage/Directory/Block/Adminhtml/Frontend/Currency/Base.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/Block/Adminhtml/Frontend/Currency/Base.php
+++ b/app/code/core/Mage/Directory/Block/Adminhtml/Frontend/Currency/Base.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/Block/Adminhtml/Frontend/Region/Updater.php
+++ b/app/code/core/Mage/Directory/Block/Adminhtml/Frontend/Region/Updater.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Directory/Block/Adminhtml/Frontend/Region/Updater.php
+++ b/app/code/core/Mage/Directory/Block/Adminhtml/Frontend/Region/Updater.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/Block/Adminhtml/Frontend/Region/Updater.php
+++ b/app/code/core/Mage/Directory/Block/Adminhtml/Frontend/Region/Updater.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/Block/Currency.php
+++ b/app/code/core/Mage/Directory/Block/Currency.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Directory/Block/Currency.php
+++ b/app/code/core/Mage/Directory/Block/Currency.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/Block/Currency.php
+++ b/app/code/core/Mage/Directory/Block/Currency.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/Block/Data.php
+++ b/app/code/core/Mage/Directory/Block/Data.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Directory/Block/Data.php
+++ b/app/code/core/Mage/Directory/Block/Data.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/Block/Data.php
+++ b/app/code/core/Mage/Directory/Block/Data.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/Exception.php
+++ b/app/code/core/Mage/Directory/Exception.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Directory/Exception.php
+++ b/app/code/core/Mage/Directory/Exception.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/Exception.php
+++ b/app/code/core/Mage/Directory/Exception.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/Helper/Data.php
+++ b/app/code/core/Mage/Directory/Helper/Data.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Directory/Helper/Data.php
+++ b/app/code/core/Mage/Directory/Helper/Data.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/Helper/Data.php
+++ b/app/code/core/Mage/Directory/Helper/Data.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/Helper/Url.php
+++ b/app/code/core/Mage/Directory/Helper/Url.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Directory/Helper/Url.php
+++ b/app/code/core/Mage/Directory/Helper/Url.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/Helper/Url.php
+++ b/app/code/core/Mage/Directory/Helper/Url.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/Model/Country.php
+++ b/app/code/core/Mage/Directory/Model/Country.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Directory/Model/Country.php
+++ b/app/code/core/Mage/Directory/Model/Country.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/Model/Country.php
+++ b/app/code/core/Mage/Directory/Model/Country.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/Model/Country/Api.php
+++ b/app/code/core/Mage/Directory/Model/Country/Api.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Directory/Model/Country/Api.php
+++ b/app/code/core/Mage/Directory/Model/Country/Api.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/Model/Country/Api.php
+++ b/app/code/core/Mage/Directory/Model/Country/Api.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/Model/Country/Api/V2.php
+++ b/app/code/core/Mage/Directory/Model/Country/Api/V2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Directory/Model/Country/Api/V2.php
+++ b/app/code/core/Mage/Directory/Model/Country/Api/V2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/Model/Country/Api/V2.php
+++ b/app/code/core/Mage/Directory/Model/Country/Api/V2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/Model/Country/Format.php
+++ b/app/code/core/Mage/Directory/Model/Country/Format.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Directory/Model/Country/Format.php
+++ b/app/code/core/Mage/Directory/Model/Country/Format.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/Model/Country/Format.php
+++ b/app/code/core/Mage/Directory/Model/Country/Format.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/Model/Currency.php
+++ b/app/code/core/Mage/Directory/Model/Currency.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Directory/Model/Currency.php
+++ b/app/code/core/Mage/Directory/Model/Currency.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/Model/Currency.php
+++ b/app/code/core/Mage/Directory/Model/Currency.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/Model/Currency/Filter.php
+++ b/app/code/core/Mage/Directory/Model/Currency/Filter.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Directory/Model/Currency/Filter.php
+++ b/app/code/core/Mage/Directory/Model/Currency/Filter.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/Model/Currency/Filter.php
+++ b/app/code/core/Mage/Directory/Model/Currency/Filter.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/Model/Currency/Import/Abstract.php
+++ b/app/code/core/Mage/Directory/Model/Currency/Import/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Directory/Model/Currency/Import/Abstract.php
+++ b/app/code/core/Mage/Directory/Model/Currency/Import/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/Model/Currency/Import/Abstract.php
+++ b/app/code/core/Mage/Directory/Model/Currency/Import/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/Model/Currency/Import/Currencyconverterapi.php
+++ b/app/code/core/Mage/Directory/Model/Currency/Import/Currencyconverterapi.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Directory/Model/Currency/Import/Currencyconverterapi.php
+++ b/app/code/core/Mage/Directory/Model/Currency/Import/Currencyconverterapi.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/Model/Currency/Import/Currencyconverterapi.php
+++ b/app/code/core/Mage/Directory/Model/Currency/Import/Currencyconverterapi.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/Model/Currency/Import/Fixerio.php
+++ b/app/code/core/Mage/Directory/Model/Currency/Import/Fixerio.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Directory/Model/Currency/Import/Fixerio.php
+++ b/app/code/core/Mage/Directory/Model/Currency/Import/Fixerio.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/Model/Currency/Import/Fixerio.php
+++ b/app/code/core/Mage/Directory/Model/Currency/Import/Fixerio.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/Model/Currency/Import/Webservicex.php
+++ b/app/code/core/Mage/Directory/Model/Currency/Import/Webservicex.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Directory/Model/Currency/Import/Webservicex.php
+++ b/app/code/core/Mage/Directory/Model/Currency/Import/Webservicex.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/Model/Currency/Import/Webservicex.php
+++ b/app/code/core/Mage/Directory/Model/Currency/Import/Webservicex.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/Model/Mysql4/Country.php
+++ b/app/code/core/Mage/Directory/Model/Mysql4/Country.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Directory/Model/Mysql4/Country.php
+++ b/app/code/core/Mage/Directory/Model/Mysql4/Country.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/Model/Mysql4/Country.php
+++ b/app/code/core/Mage/Directory/Model/Mysql4/Country.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/Model/Mysql4/Country/Collection.php
+++ b/app/code/core/Mage/Directory/Model/Mysql4/Country/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Directory/Model/Mysql4/Country/Collection.php
+++ b/app/code/core/Mage/Directory/Model/Mysql4/Country/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/Model/Mysql4/Country/Collection.php
+++ b/app/code/core/Mage/Directory/Model/Mysql4/Country/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/Model/Mysql4/Country/Format.php
+++ b/app/code/core/Mage/Directory/Model/Mysql4/Country/Format.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Directory/Model/Mysql4/Country/Format.php
+++ b/app/code/core/Mage/Directory/Model/Mysql4/Country/Format.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/Model/Mysql4/Country/Format.php
+++ b/app/code/core/Mage/Directory/Model/Mysql4/Country/Format.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/Model/Mysql4/Country/Format/Collection.php
+++ b/app/code/core/Mage/Directory/Model/Mysql4/Country/Format/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Directory/Model/Mysql4/Country/Format/Collection.php
+++ b/app/code/core/Mage/Directory/Model/Mysql4/Country/Format/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/Model/Mysql4/Country/Format/Collection.php
+++ b/app/code/core/Mage/Directory/Model/Mysql4/Country/Format/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/Model/Mysql4/Currency.php
+++ b/app/code/core/Mage/Directory/Model/Mysql4/Currency.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Directory/Model/Mysql4/Currency.php
+++ b/app/code/core/Mage/Directory/Model/Mysql4/Currency.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/Model/Mysql4/Currency.php
+++ b/app/code/core/Mage/Directory/Model/Mysql4/Currency.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/Model/Mysql4/Currency/Collection.php
+++ b/app/code/core/Mage/Directory/Model/Mysql4/Currency/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Directory/Model/Mysql4/Currency/Collection.php
+++ b/app/code/core/Mage/Directory/Model/Mysql4/Currency/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/Model/Mysql4/Currency/Collection.php
+++ b/app/code/core/Mage/Directory/Model/Mysql4/Currency/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/Model/Mysql4/Region.php
+++ b/app/code/core/Mage/Directory/Model/Mysql4/Region.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Directory/Model/Mysql4/Region.php
+++ b/app/code/core/Mage/Directory/Model/Mysql4/Region.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/Model/Mysql4/Region.php
+++ b/app/code/core/Mage/Directory/Model/Mysql4/Region.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/Model/Mysql4/Region/Collection.php
+++ b/app/code/core/Mage/Directory/Model/Mysql4/Region/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Directory/Model/Mysql4/Region/Collection.php
+++ b/app/code/core/Mage/Directory/Model/Mysql4/Region/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/Model/Mysql4/Region/Collection.php
+++ b/app/code/core/Mage/Directory/Model/Mysql4/Region/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/Model/Observer.php
+++ b/app/code/core/Mage/Directory/Model/Observer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Directory/Model/Observer.php
+++ b/app/code/core/Mage/Directory/Model/Observer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/Model/Observer.php
+++ b/app/code/core/Mage/Directory/Model/Observer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/Model/Region.php
+++ b/app/code/core/Mage/Directory/Model/Region.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Directory/Model/Region.php
+++ b/app/code/core/Mage/Directory/Model/Region.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/Model/Region.php
+++ b/app/code/core/Mage/Directory/Model/Region.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/Model/Region/Api.php
+++ b/app/code/core/Mage/Directory/Model/Region/Api.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Directory/Model/Region/Api.php
+++ b/app/code/core/Mage/Directory/Model/Region/Api.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/Model/Region/Api.php
+++ b/app/code/core/Mage/Directory/Model/Region/Api.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/Model/Region/Api/V2.php
+++ b/app/code/core/Mage/Directory/Model/Region/Api/V2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Directory/Model/Region/Api/V2.php
+++ b/app/code/core/Mage/Directory/Model/Region/Api/V2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/Model/Region/Api/V2.php
+++ b/app/code/core/Mage/Directory/Model/Region/Api/V2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/Model/Resource/Country.php
+++ b/app/code/core/Mage/Directory/Model/Resource/Country.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Directory/Model/Resource/Country.php
+++ b/app/code/core/Mage/Directory/Model/Resource/Country.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/Model/Resource/Country.php
+++ b/app/code/core/Mage/Directory/Model/Resource/Country.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/Model/Resource/Country/Collection.php
+++ b/app/code/core/Mage/Directory/Model/Resource/Country/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Directory/Model/Resource/Country/Collection.php
+++ b/app/code/core/Mage/Directory/Model/Resource/Country/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/Model/Resource/Country/Collection.php
+++ b/app/code/core/Mage/Directory/Model/Resource/Country/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/Model/Resource/Country/Format.php
+++ b/app/code/core/Mage/Directory/Model/Resource/Country/Format.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Directory/Model/Resource/Country/Format.php
+++ b/app/code/core/Mage/Directory/Model/Resource/Country/Format.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/Model/Resource/Country/Format.php
+++ b/app/code/core/Mage/Directory/Model/Resource/Country/Format.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/Model/Resource/Country/Format/Collection.php
+++ b/app/code/core/Mage/Directory/Model/Resource/Country/Format/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Directory/Model/Resource/Country/Format/Collection.php
+++ b/app/code/core/Mage/Directory/Model/Resource/Country/Format/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/Model/Resource/Country/Format/Collection.php
+++ b/app/code/core/Mage/Directory/Model/Resource/Country/Format/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/Model/Resource/Currency.php
+++ b/app/code/core/Mage/Directory/Model/Resource/Currency.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Directory/Model/Resource/Currency.php
+++ b/app/code/core/Mage/Directory/Model/Resource/Currency.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/Model/Resource/Currency.php
+++ b/app/code/core/Mage/Directory/Model/Resource/Currency.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/Model/Resource/Currency/Collection.php
+++ b/app/code/core/Mage/Directory/Model/Resource/Currency/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Directory/Model/Resource/Currency/Collection.php
+++ b/app/code/core/Mage/Directory/Model/Resource/Currency/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/Model/Resource/Currency/Collection.php
+++ b/app/code/core/Mage/Directory/Model/Resource/Currency/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/Model/Resource/Region.php
+++ b/app/code/core/Mage/Directory/Model/Resource/Region.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Directory/Model/Resource/Region.php
+++ b/app/code/core/Mage/Directory/Model/Resource/Region.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/Model/Resource/Region.php
+++ b/app/code/core/Mage/Directory/Model/Resource/Region.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/Model/Resource/Region/Collection.php
+++ b/app/code/core/Mage/Directory/Model/Resource/Region/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Directory/Model/Resource/Region/Collection.php
+++ b/app/code/core/Mage/Directory/Model/Resource/Region/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/Model/Resource/Region/Collection.php
+++ b/app/code/core/Mage/Directory/Model/Resource/Region/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/controllers/CurrencyController.php
+++ b/app/code/core/Mage/Directory/controllers/CurrencyController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Directory/controllers/CurrencyController.php
+++ b/app/code/core/Mage/Directory/controllers/CurrencyController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/controllers/CurrencyController.php
+++ b/app/code/core/Mage/Directory/controllers/CurrencyController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/data/directory_setup/data-install-1.6.0.0.php
+++ b/app/code/core/Mage/Directory/data/directory_setup/data-install-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Directory/data/directory_setup/data-install-1.6.0.0.php
+++ b/app/code/core/Mage/Directory/data/directory_setup/data-install-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/data/directory_setup/data-install-1.6.0.0.php
+++ b/app/code/core/Mage/Directory/data/directory_setup/data-install-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/data/directory_setup/data-upgrade-1.6.0.0-1.6.0.1.php
+++ b/app/code/core/Mage/Directory/data/directory_setup/data-upgrade-1.6.0.0-1.6.0.1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Directory/data/directory_setup/data-upgrade-1.6.0.0-1.6.0.1.php
+++ b/app/code/core/Mage/Directory/data/directory_setup/data-upgrade-1.6.0.0-1.6.0.1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/data/directory_setup/data-upgrade-1.6.0.0-1.6.0.1.php
+++ b/app/code/core/Mage/Directory/data/directory_setup/data-upgrade-1.6.0.0-1.6.0.1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/data/directory_setup/data-upgrade-1.6.0.2-1.6.0.3.php
+++ b/app/code/core/Mage/Directory/data/directory_setup/data-upgrade-1.6.0.2-1.6.0.3.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Directory/data/directory_setup/data-upgrade-1.6.0.2-1.6.0.3.php
+++ b/app/code/core/Mage/Directory/data/directory_setup/data-upgrade-1.6.0.2-1.6.0.3.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/data/directory_setup/data-upgrade-1.6.0.2-1.6.0.3.php
+++ b/app/code/core/Mage/Directory/data/directory_setup/data-upgrade-1.6.0.2-1.6.0.3.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/etc/api.xml
+++ b/app/code/core/Mage/Directory/etc/api.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/etc/api.xml
+++ b/app/code/core/Mage/Directory/etc/api.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Directory/etc/api.xml
+++ b/app/code/core/Mage/Directory/etc/api.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/etc/config.xml
+++ b/app/code/core/Mage/Directory/etc/config.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/etc/config.xml
+++ b/app/code/core/Mage/Directory/etc/config.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Directory/etc/config.xml
+++ b/app/code/core/Mage/Directory/etc/config.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/etc/system.xml
+++ b/app/code/core/Mage/Directory/etc/system.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/etc/system.xml
+++ b/app/code/core/Mage/Directory/etc/system.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Directory/etc/system.xml
+++ b/app/code/core/Mage/Directory/etc/system.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/sql/directory_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Directory/sql/directory_setup/install-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Directory/sql/directory_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Directory/sql/directory_setup/install-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/sql/directory_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Directory/sql/directory_setup/install-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/sql/directory_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/Directory/sql/directory_setup/mysql4-install-0.7.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Directory/sql/directory_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/Directory/sql/directory_setup/mysql4-install-0.7.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/sql/directory_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/Directory/sql/directory_setup/mysql4-install-0.7.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/sql/directory_setup/mysql4-install-0.8.0.php
+++ b/app/code/core/Mage/Directory/sql/directory_setup/mysql4-install-0.8.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Directory/sql/directory_setup/mysql4-install-0.8.0.php
+++ b/app/code/core/Mage/Directory/sql/directory_setup/mysql4-install-0.8.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/sql/directory_setup/mysql4-install-0.8.0.php
+++ b/app/code/core/Mage/Directory/sql/directory_setup/mysql4-install-0.8.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/sql/directory_setup/mysql4-upgrade-0.7.0-0.7.1.php
+++ b/app/code/core/Mage/Directory/sql/directory_setup/mysql4-upgrade-0.7.0-0.7.1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Directory/sql/directory_setup/mysql4-upgrade-0.7.0-0.7.1.php
+++ b/app/code/core/Mage/Directory/sql/directory_setup/mysql4-upgrade-0.7.0-0.7.1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/sql/directory_setup/mysql4-upgrade-0.7.0-0.7.1.php
+++ b/app/code/core/Mage/Directory/sql/directory_setup/mysql4-upgrade-0.7.0-0.7.1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/sql/directory_setup/mysql4-upgrade-0.7.1-0.7.2.php
+++ b/app/code/core/Mage/Directory/sql/directory_setup/mysql4-upgrade-0.7.1-0.7.2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Directory/sql/directory_setup/mysql4-upgrade-0.7.1-0.7.2.php
+++ b/app/code/core/Mage/Directory/sql/directory_setup/mysql4-upgrade-0.7.1-0.7.2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/sql/directory_setup/mysql4-upgrade-0.7.1-0.7.2.php
+++ b/app/code/core/Mage/Directory/sql/directory_setup/mysql4-upgrade-0.7.1-0.7.2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/sql/directory_setup/mysql4-upgrade-0.8.0-0.8.1.php
+++ b/app/code/core/Mage/Directory/sql/directory_setup/mysql4-upgrade-0.8.0-0.8.1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Directory/sql/directory_setup/mysql4-upgrade-0.8.0-0.8.1.php
+++ b/app/code/core/Mage/Directory/sql/directory_setup/mysql4-upgrade-0.8.0-0.8.1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/sql/directory_setup/mysql4-upgrade-0.8.0-0.8.1.php
+++ b/app/code/core/Mage/Directory/sql/directory_setup/mysql4-upgrade-0.8.0-0.8.1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/sql/directory_setup/mysql4-upgrade-0.8.1-0.8.2.php
+++ b/app/code/core/Mage/Directory/sql/directory_setup/mysql4-upgrade-0.8.1-0.8.2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Directory/sql/directory_setup/mysql4-upgrade-0.8.1-0.8.2.php
+++ b/app/code/core/Mage/Directory/sql/directory_setup/mysql4-upgrade-0.8.1-0.8.2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/sql/directory_setup/mysql4-upgrade-0.8.1-0.8.2.php
+++ b/app/code/core/Mage/Directory/sql/directory_setup/mysql4-upgrade-0.8.1-0.8.2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/sql/directory_setup/mysql4-upgrade-0.8.10-0.8.11.php
+++ b/app/code/core/Mage/Directory/sql/directory_setup/mysql4-upgrade-0.8.10-0.8.11.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Directory/sql/directory_setup/mysql4-upgrade-0.8.10-0.8.11.php
+++ b/app/code/core/Mage/Directory/sql/directory_setup/mysql4-upgrade-0.8.10-0.8.11.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/sql/directory_setup/mysql4-upgrade-0.8.10-0.8.11.php
+++ b/app/code/core/Mage/Directory/sql/directory_setup/mysql4-upgrade-0.8.10-0.8.11.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/sql/directory_setup/mysql4-upgrade-0.8.2-0.8.3.php
+++ b/app/code/core/Mage/Directory/sql/directory_setup/mysql4-upgrade-0.8.2-0.8.3.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Directory/sql/directory_setup/mysql4-upgrade-0.8.2-0.8.3.php
+++ b/app/code/core/Mage/Directory/sql/directory_setup/mysql4-upgrade-0.8.2-0.8.3.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/sql/directory_setup/mysql4-upgrade-0.8.2-0.8.3.php
+++ b/app/code/core/Mage/Directory/sql/directory_setup/mysql4-upgrade-0.8.2-0.8.3.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/sql/directory_setup/mysql4-upgrade-0.8.3-0.8.4.php
+++ b/app/code/core/Mage/Directory/sql/directory_setup/mysql4-upgrade-0.8.3-0.8.4.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Directory/sql/directory_setup/mysql4-upgrade-0.8.3-0.8.4.php
+++ b/app/code/core/Mage/Directory/sql/directory_setup/mysql4-upgrade-0.8.3-0.8.4.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/sql/directory_setup/mysql4-upgrade-0.8.3-0.8.4.php
+++ b/app/code/core/Mage/Directory/sql/directory_setup/mysql4-upgrade-0.8.3-0.8.4.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/sql/directory_setup/mysql4-upgrade-0.8.4-0.8.5.php
+++ b/app/code/core/Mage/Directory/sql/directory_setup/mysql4-upgrade-0.8.4-0.8.5.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Directory/sql/directory_setup/mysql4-upgrade-0.8.4-0.8.5.php
+++ b/app/code/core/Mage/Directory/sql/directory_setup/mysql4-upgrade-0.8.4-0.8.5.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/sql/directory_setup/mysql4-upgrade-0.8.4-0.8.5.php
+++ b/app/code/core/Mage/Directory/sql/directory_setup/mysql4-upgrade-0.8.4-0.8.5.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/sql/directory_setup/mysql4-upgrade-0.8.5-0.8.6.php
+++ b/app/code/core/Mage/Directory/sql/directory_setup/mysql4-upgrade-0.8.5-0.8.6.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Directory/sql/directory_setup/mysql4-upgrade-0.8.5-0.8.6.php
+++ b/app/code/core/Mage/Directory/sql/directory_setup/mysql4-upgrade-0.8.5-0.8.6.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/sql/directory_setup/mysql4-upgrade-0.8.5-0.8.6.php
+++ b/app/code/core/Mage/Directory/sql/directory_setup/mysql4-upgrade-0.8.5-0.8.6.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/sql/directory_setup/mysql4-upgrade-0.8.6-0.8.7.php
+++ b/app/code/core/Mage/Directory/sql/directory_setup/mysql4-upgrade-0.8.6-0.8.7.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Directory/sql/directory_setup/mysql4-upgrade-0.8.6-0.8.7.php
+++ b/app/code/core/Mage/Directory/sql/directory_setup/mysql4-upgrade-0.8.6-0.8.7.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/sql/directory_setup/mysql4-upgrade-0.8.6-0.8.7.php
+++ b/app/code/core/Mage/Directory/sql/directory_setup/mysql4-upgrade-0.8.6-0.8.7.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/sql/directory_setup/mysql4-upgrade-0.8.7-0.8.8.php
+++ b/app/code/core/Mage/Directory/sql/directory_setup/mysql4-upgrade-0.8.7-0.8.8.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Directory/sql/directory_setup/mysql4-upgrade-0.8.7-0.8.8.php
+++ b/app/code/core/Mage/Directory/sql/directory_setup/mysql4-upgrade-0.8.7-0.8.8.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/sql/directory_setup/mysql4-upgrade-0.8.7-0.8.8.php
+++ b/app/code/core/Mage/Directory/sql/directory_setup/mysql4-upgrade-0.8.7-0.8.8.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/sql/directory_setup/mysql4-upgrade-0.8.8-0.8.9.php
+++ b/app/code/core/Mage/Directory/sql/directory_setup/mysql4-upgrade-0.8.8-0.8.9.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Directory/sql/directory_setup/mysql4-upgrade-0.8.8-0.8.9.php
+++ b/app/code/core/Mage/Directory/sql/directory_setup/mysql4-upgrade-0.8.8-0.8.9.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/sql/directory_setup/mysql4-upgrade-0.8.8-0.8.9.php
+++ b/app/code/core/Mage/Directory/sql/directory_setup/mysql4-upgrade-0.8.8-0.8.9.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/sql/directory_setup/mysql4-upgrade-0.8.9-0.8.10.php
+++ b/app/code/core/Mage/Directory/sql/directory_setup/mysql4-upgrade-0.8.9-0.8.10.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Directory/sql/directory_setup/mysql4-upgrade-0.8.9-0.8.10.php
+++ b/app/code/core/Mage/Directory/sql/directory_setup/mysql4-upgrade-0.8.9-0.8.10.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/sql/directory_setup/mysql4-upgrade-0.8.9-0.8.10.php
+++ b/app/code/core/Mage/Directory/sql/directory_setup/mysql4-upgrade-0.8.9-0.8.10.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/sql/directory_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/Directory/sql/directory_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Directory/sql/directory_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/Directory/sql/directory_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/sql/directory_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/Directory/sql/directory_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/sql/directory_setup/mysql4-upgrade-1.6.0.1-1.6.0.2.php
+++ b/app/code/core/Mage/Directory/sql/directory_setup/mysql4-upgrade-1.6.0.1-1.6.0.2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Directory/sql/directory_setup/mysql4-upgrade-1.6.0.1-1.6.0.2.php
+++ b/app/code/core/Mage/Directory/sql/directory_setup/mysql4-upgrade-1.6.0.1-1.6.0.2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/sql/directory_setup/mysql4-upgrade-1.6.0.1-1.6.0.2.php
+++ b/app/code/core/Mage/Directory/sql/directory_setup/mysql4-upgrade-1.6.0.1-1.6.0.2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/sql/directory_setup/upgrade-1.6.0.1-1.6.0.2.php
+++ b/app/code/core/Mage/Directory/sql/directory_setup/upgrade-1.6.0.1-1.6.0.2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Directory/sql/directory_setup/upgrade-1.6.0.1-1.6.0.2.php
+++ b/app/code/core/Mage/Directory/sql/directory_setup/upgrade-1.6.0.1-1.6.0.2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Directory/sql/directory_setup/upgrade-1.6.0.1-1.6.0.2.php
+++ b/app/code/core/Mage/Directory/sql/directory_setup/upgrade-1.6.0.1-1.6.0.2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/code/core/Mage/Downloadable/Block/Adminhtml/Catalog/Product/Composite/Fieldset/Downloadable.php
+++ b/app/code/core/Mage/Downloadable/Block/Adminhtml/Catalog/Product/Composite/Fieldset/Downloadable.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Block/Adminhtml/Catalog/Product/Composite/Fieldset/Downloadable.php
+++ b/app/code/core/Mage/Downloadable/Block/Adminhtml/Catalog/Product/Composite/Fieldset/Downloadable.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Downloadable/Block/Adminhtml/Catalog/Product/Composite/Fieldset/Downloadable.php
+++ b/app/code/core/Mage/Downloadable/Block/Adminhtml/Catalog/Product/Composite/Fieldset/Downloadable.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable.php
+++ b/app/code/core/Mage/Downloadable/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable.php
+++ b/app/code/core/Mage/Downloadable/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Downloadable/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable.php
+++ b/app/code/core/Mage/Downloadable/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/Links.php
+++ b/app/code/core/Mage/Downloadable/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/Links.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/Links.php
+++ b/app/code/core/Mage/Downloadable/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/Links.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Downloadable/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/Links.php
+++ b/app/code/core/Mage/Downloadable/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/Links.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/Samples.php
+++ b/app/code/core/Mage/Downloadable/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/Samples.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/Samples.php
+++ b/app/code/core/Mage/Downloadable/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/Samples.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Downloadable/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/Samples.php
+++ b/app/code/core/Mage/Downloadable/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/Samples.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Block/Adminhtml/Sales/Items/Column/Downloadable/Name.php
+++ b/app/code/core/Mage/Downloadable/Block/Adminhtml/Sales/Items/Column/Downloadable/Name.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Block/Adminhtml/Sales/Items/Column/Downloadable/Name.php
+++ b/app/code/core/Mage/Downloadable/Block/Adminhtml/Sales/Items/Column/Downloadable/Name.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Downloadable/Block/Adminhtml/Sales/Items/Column/Downloadable/Name.php
+++ b/app/code/core/Mage/Downloadable/Block/Adminhtml/Sales/Items/Column/Downloadable/Name.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Block/Catalog/Product/Links.php
+++ b/app/code/core/Mage/Downloadable/Block/Catalog/Product/Links.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Block/Catalog/Product/Links.php
+++ b/app/code/core/Mage/Downloadable/Block/Catalog/Product/Links.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Downloadable/Block/Catalog/Product/Links.php
+++ b/app/code/core/Mage/Downloadable/Block/Catalog/Product/Links.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Block/Catalog/Product/Samples.php
+++ b/app/code/core/Mage/Downloadable/Block/Catalog/Product/Samples.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Block/Catalog/Product/Samples.php
+++ b/app/code/core/Mage/Downloadable/Block/Catalog/Product/Samples.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Downloadable/Block/Catalog/Product/Samples.php
+++ b/app/code/core/Mage/Downloadable/Block/Catalog/Product/Samples.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Block/Catalog/Product/View/Type.php
+++ b/app/code/core/Mage/Downloadable/Block/Catalog/Product/View/Type.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Block/Catalog/Product/View/Type.php
+++ b/app/code/core/Mage/Downloadable/Block/Catalog/Product/View/Type.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Downloadable/Block/Catalog/Product/View/Type.php
+++ b/app/code/core/Mage/Downloadable/Block/Catalog/Product/View/Type.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Block/Checkout/Cart/Item/Renderer.php
+++ b/app/code/core/Mage/Downloadable/Block/Checkout/Cart/Item/Renderer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Block/Checkout/Cart/Item/Renderer.php
+++ b/app/code/core/Mage/Downloadable/Block/Checkout/Cart/Item/Renderer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Downloadable/Block/Checkout/Cart/Item/Renderer.php
+++ b/app/code/core/Mage/Downloadable/Block/Checkout/Cart/Item/Renderer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Block/Checkout/Success.php
+++ b/app/code/core/Mage/Downloadable/Block/Checkout/Success.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Block/Checkout/Success.php
+++ b/app/code/core/Mage/Downloadable/Block/Checkout/Success.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Downloadable/Block/Checkout/Success.php
+++ b/app/code/core/Mage/Downloadable/Block/Checkout/Success.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Block/Customer/Products/List.php
+++ b/app/code/core/Mage/Downloadable/Block/Customer/Products/List.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Block/Customer/Products/List.php
+++ b/app/code/core/Mage/Downloadable/Block/Customer/Products/List.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Downloadable/Block/Customer/Products/List.php
+++ b/app/code/core/Mage/Downloadable/Block/Customer/Products/List.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Block/Sales/Order/Email/Items/Downloadable.php
+++ b/app/code/core/Mage/Downloadable/Block/Sales/Order/Email/Items/Downloadable.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Block/Sales/Order/Email/Items/Downloadable.php
+++ b/app/code/core/Mage/Downloadable/Block/Sales/Order/Email/Items/Downloadable.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Downloadable/Block/Sales/Order/Email/Items/Downloadable.php
+++ b/app/code/core/Mage/Downloadable/Block/Sales/Order/Email/Items/Downloadable.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Block/Sales/Order/Email/Items/Order/Downloadable.php
+++ b/app/code/core/Mage/Downloadable/Block/Sales/Order/Email/Items/Order/Downloadable.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Block/Sales/Order/Email/Items/Order/Downloadable.php
+++ b/app/code/core/Mage/Downloadable/Block/Sales/Order/Email/Items/Order/Downloadable.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Downloadable/Block/Sales/Order/Email/Items/Order/Downloadable.php
+++ b/app/code/core/Mage/Downloadable/Block/Sales/Order/Email/Items/Order/Downloadable.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Block/Sales/Order/Item/Renderer/Downloadable.php
+++ b/app/code/core/Mage/Downloadable/Block/Sales/Order/Item/Renderer/Downloadable.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Block/Sales/Order/Item/Renderer/Downloadable.php
+++ b/app/code/core/Mage/Downloadable/Block/Sales/Order/Item/Renderer/Downloadable.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Downloadable/Block/Sales/Order/Item/Renderer/Downloadable.php
+++ b/app/code/core/Mage/Downloadable/Block/Sales/Order/Item/Renderer/Downloadable.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Helper/Catalog/Product/Configuration.php
+++ b/app/code/core/Mage/Downloadable/Helper/Catalog/Product/Configuration.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Helper/Catalog/Product/Configuration.php
+++ b/app/code/core/Mage/Downloadable/Helper/Catalog/Product/Configuration.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Downloadable/Helper/Catalog/Product/Configuration.php
+++ b/app/code/core/Mage/Downloadable/Helper/Catalog/Product/Configuration.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Helper/Data.php
+++ b/app/code/core/Mage/Downloadable/Helper/Data.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Helper/Data.php
+++ b/app/code/core/Mage/Downloadable/Helper/Data.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Downloadable/Helper/Data.php
+++ b/app/code/core/Mage/Downloadable/Helper/Data.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Helper/Download.php
+++ b/app/code/core/Mage/Downloadable/Helper/Download.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Helper/Download.php
+++ b/app/code/core/Mage/Downloadable/Helper/Download.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Downloadable/Helper/Download.php
+++ b/app/code/core/Mage/Downloadable/Helper/Download.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Helper/File.php
+++ b/app/code/core/Mage/Downloadable/Helper/File.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Helper/File.php
+++ b/app/code/core/Mage/Downloadable/Helper/File.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Downloadable/Helper/File.php
+++ b/app/code/core/Mage/Downloadable/Helper/File.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Model/CatalogIndex/Data/Downloadable.php
+++ b/app/code/core/Mage/Downloadable/Model/CatalogIndex/Data/Downloadable.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Model/CatalogIndex/Data/Downloadable.php
+++ b/app/code/core/Mage/Downloadable/Model/CatalogIndex/Data/Downloadable.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Downloadable/Model/CatalogIndex/Data/Downloadable.php
+++ b/app/code/core/Mage/Downloadable/Model/CatalogIndex/Data/Downloadable.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Model/Link.php
+++ b/app/code/core/Mage/Downloadable/Model/Link.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Model/Link.php
+++ b/app/code/core/Mage/Downloadable/Model/Link.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Downloadable/Model/Link.php
+++ b/app/code/core/Mage/Downloadable/Model/Link.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Model/Link/Api.php
+++ b/app/code/core/Mage/Downloadable/Model/Link/Api.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Model/Link/Api.php
+++ b/app/code/core/Mage/Downloadable/Model/Link/Api.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Downloadable/Model/Link/Api.php
+++ b/app/code/core/Mage/Downloadable/Model/Link/Api.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Model/Link/Api/Uploader.php
+++ b/app/code/core/Mage/Downloadable/Model/Link/Api/Uploader.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Model/Link/Api/Uploader.php
+++ b/app/code/core/Mage/Downloadable/Model/Link/Api/Uploader.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Downloadable/Model/Link/Api/Uploader.php
+++ b/app/code/core/Mage/Downloadable/Model/Link/Api/Uploader.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Model/Link/Api/V2.php
+++ b/app/code/core/Mage/Downloadable/Model/Link/Api/V2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Model/Link/Api/V2.php
+++ b/app/code/core/Mage/Downloadable/Model/Link/Api/V2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Downloadable/Model/Link/Api/V2.php
+++ b/app/code/core/Mage/Downloadable/Model/Link/Api/V2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Model/Link/Api/Validator.php
+++ b/app/code/core/Mage/Downloadable/Model/Link/Api/Validator.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Model/Link/Api/Validator.php
+++ b/app/code/core/Mage/Downloadable/Model/Link/Api/Validator.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Downloadable/Model/Link/Api/Validator.php
+++ b/app/code/core/Mage/Downloadable/Model/Link/Api/Validator.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Model/Link/Purchased.php
+++ b/app/code/core/Mage/Downloadable/Model/Link/Purchased.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Model/Link/Purchased.php
+++ b/app/code/core/Mage/Downloadable/Model/Link/Purchased.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Downloadable/Model/Link/Purchased.php
+++ b/app/code/core/Mage/Downloadable/Model/Link/Purchased.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Model/Link/Purchased/Item.php
+++ b/app/code/core/Mage/Downloadable/Model/Link/Purchased/Item.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Model/Link/Purchased/Item.php
+++ b/app/code/core/Mage/Downloadable/Model/Link/Purchased/Item.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Downloadable/Model/Link/Purchased/Item.php
+++ b/app/code/core/Mage/Downloadable/Model/Link/Purchased/Item.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Model/Mysql4/Indexer/Price.php
+++ b/app/code/core/Mage/Downloadable/Model/Mysql4/Indexer/Price.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Model/Mysql4/Indexer/Price.php
+++ b/app/code/core/Mage/Downloadable/Model/Mysql4/Indexer/Price.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Downloadable/Model/Mysql4/Indexer/Price.php
+++ b/app/code/core/Mage/Downloadable/Model/Mysql4/Indexer/Price.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Model/Mysql4/Link.php
+++ b/app/code/core/Mage/Downloadable/Model/Mysql4/Link.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Model/Mysql4/Link.php
+++ b/app/code/core/Mage/Downloadable/Model/Mysql4/Link.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Downloadable/Model/Mysql4/Link.php
+++ b/app/code/core/Mage/Downloadable/Model/Mysql4/Link.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Model/Mysql4/Link/Collection.php
+++ b/app/code/core/Mage/Downloadable/Model/Mysql4/Link/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Model/Mysql4/Link/Collection.php
+++ b/app/code/core/Mage/Downloadable/Model/Mysql4/Link/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Downloadable/Model/Mysql4/Link/Collection.php
+++ b/app/code/core/Mage/Downloadable/Model/Mysql4/Link/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Model/Mysql4/Link/Purchased.php
+++ b/app/code/core/Mage/Downloadable/Model/Mysql4/Link/Purchased.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Model/Mysql4/Link/Purchased.php
+++ b/app/code/core/Mage/Downloadable/Model/Mysql4/Link/Purchased.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Downloadable/Model/Mysql4/Link/Purchased.php
+++ b/app/code/core/Mage/Downloadable/Model/Mysql4/Link/Purchased.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Model/Mysql4/Link/Purchased/Collection.php
+++ b/app/code/core/Mage/Downloadable/Model/Mysql4/Link/Purchased/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Model/Mysql4/Link/Purchased/Collection.php
+++ b/app/code/core/Mage/Downloadable/Model/Mysql4/Link/Purchased/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Downloadable/Model/Mysql4/Link/Purchased/Collection.php
+++ b/app/code/core/Mage/Downloadable/Model/Mysql4/Link/Purchased/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Model/Mysql4/Link/Purchased/Item.php
+++ b/app/code/core/Mage/Downloadable/Model/Mysql4/Link/Purchased/Item.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Model/Mysql4/Link/Purchased/Item.php
+++ b/app/code/core/Mage/Downloadable/Model/Mysql4/Link/Purchased/Item.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Downloadable/Model/Mysql4/Link/Purchased/Item.php
+++ b/app/code/core/Mage/Downloadable/Model/Mysql4/Link/Purchased/Item.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Model/Mysql4/Link/Purchased/Item/Collection.php
+++ b/app/code/core/Mage/Downloadable/Model/Mysql4/Link/Purchased/Item/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Model/Mysql4/Link/Purchased/Item/Collection.php
+++ b/app/code/core/Mage/Downloadable/Model/Mysql4/Link/Purchased/Item/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Downloadable/Model/Mysql4/Link/Purchased/Item/Collection.php
+++ b/app/code/core/Mage/Downloadable/Model/Mysql4/Link/Purchased/Item/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Model/Mysql4/Sample.php
+++ b/app/code/core/Mage/Downloadable/Model/Mysql4/Sample.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Model/Mysql4/Sample.php
+++ b/app/code/core/Mage/Downloadable/Model/Mysql4/Sample.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Downloadable/Model/Mysql4/Sample.php
+++ b/app/code/core/Mage/Downloadable/Model/Mysql4/Sample.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Model/Mysql4/Sample/Collection.php
+++ b/app/code/core/Mage/Downloadable/Model/Mysql4/Sample/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Model/Mysql4/Sample/Collection.php
+++ b/app/code/core/Mage/Downloadable/Model/Mysql4/Sample/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Downloadable/Model/Mysql4/Sample/Collection.php
+++ b/app/code/core/Mage/Downloadable/Model/Mysql4/Sample/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Model/Observer.php
+++ b/app/code/core/Mage/Downloadable/Model/Observer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Model/Observer.php
+++ b/app/code/core/Mage/Downloadable/Model/Observer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Downloadable/Model/Observer.php
+++ b/app/code/core/Mage/Downloadable/Model/Observer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Model/Product/Price.php
+++ b/app/code/core/Mage/Downloadable/Model/Product/Price.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Model/Product/Price.php
+++ b/app/code/core/Mage/Downloadable/Model/Product/Price.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Downloadable/Model/Product/Price.php
+++ b/app/code/core/Mage/Downloadable/Model/Product/Price.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Model/Product/Type.php
+++ b/app/code/core/Mage/Downloadable/Model/Product/Type.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Model/Product/Type.php
+++ b/app/code/core/Mage/Downloadable/Model/Product/Type.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Downloadable/Model/Product/Type.php
+++ b/app/code/core/Mage/Downloadable/Model/Product/Type.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Model/Resource/Indexer/Price.php
+++ b/app/code/core/Mage/Downloadable/Model/Resource/Indexer/Price.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Model/Resource/Indexer/Price.php
+++ b/app/code/core/Mage/Downloadable/Model/Resource/Indexer/Price.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Downloadable/Model/Resource/Indexer/Price.php
+++ b/app/code/core/Mage/Downloadable/Model/Resource/Indexer/Price.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Model/Resource/Link.php
+++ b/app/code/core/Mage/Downloadable/Model/Resource/Link.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Model/Resource/Link.php
+++ b/app/code/core/Mage/Downloadable/Model/Resource/Link.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Downloadable/Model/Resource/Link.php
+++ b/app/code/core/Mage/Downloadable/Model/Resource/Link.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Model/Resource/Link/Collection.php
+++ b/app/code/core/Mage/Downloadable/Model/Resource/Link/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Model/Resource/Link/Collection.php
+++ b/app/code/core/Mage/Downloadable/Model/Resource/Link/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Downloadable/Model/Resource/Link/Collection.php
+++ b/app/code/core/Mage/Downloadable/Model/Resource/Link/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Model/Resource/Link/Purchased.php
+++ b/app/code/core/Mage/Downloadable/Model/Resource/Link/Purchased.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Model/Resource/Link/Purchased.php
+++ b/app/code/core/Mage/Downloadable/Model/Resource/Link/Purchased.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Downloadable/Model/Resource/Link/Purchased.php
+++ b/app/code/core/Mage/Downloadable/Model/Resource/Link/Purchased.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Model/Resource/Link/Purchased/Collection.php
+++ b/app/code/core/Mage/Downloadable/Model/Resource/Link/Purchased/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Model/Resource/Link/Purchased/Collection.php
+++ b/app/code/core/Mage/Downloadable/Model/Resource/Link/Purchased/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Downloadable/Model/Resource/Link/Purchased/Collection.php
+++ b/app/code/core/Mage/Downloadable/Model/Resource/Link/Purchased/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Model/Resource/Link/Purchased/Item.php
+++ b/app/code/core/Mage/Downloadable/Model/Resource/Link/Purchased/Item.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Model/Resource/Link/Purchased/Item.php
+++ b/app/code/core/Mage/Downloadable/Model/Resource/Link/Purchased/Item.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Downloadable/Model/Resource/Link/Purchased/Item.php
+++ b/app/code/core/Mage/Downloadable/Model/Resource/Link/Purchased/Item.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Model/Resource/Link/Purchased/Item/Collection.php
+++ b/app/code/core/Mage/Downloadable/Model/Resource/Link/Purchased/Item/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Model/Resource/Link/Purchased/Item/Collection.php
+++ b/app/code/core/Mage/Downloadable/Model/Resource/Link/Purchased/Item/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Downloadable/Model/Resource/Link/Purchased/Item/Collection.php
+++ b/app/code/core/Mage/Downloadable/Model/Resource/Link/Purchased/Item/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Model/Resource/Sample.php
+++ b/app/code/core/Mage/Downloadable/Model/Resource/Sample.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Model/Resource/Sample.php
+++ b/app/code/core/Mage/Downloadable/Model/Resource/Sample.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Downloadable/Model/Resource/Sample.php
+++ b/app/code/core/Mage/Downloadable/Model/Resource/Sample.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Model/Resource/Sample/Collection.php
+++ b/app/code/core/Mage/Downloadable/Model/Resource/Sample/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Model/Resource/Sample/Collection.php
+++ b/app/code/core/Mage/Downloadable/Model/Resource/Sample/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Downloadable/Model/Resource/Sample/Collection.php
+++ b/app/code/core/Mage/Downloadable/Model/Resource/Sample/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Model/Sales/Order/Pdf/Items/Abstract.php
+++ b/app/code/core/Mage/Downloadable/Model/Sales/Order/Pdf/Items/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Model/Sales/Order/Pdf/Items/Abstract.php
+++ b/app/code/core/Mage/Downloadable/Model/Sales/Order/Pdf/Items/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Downloadable/Model/Sales/Order/Pdf/Items/Abstract.php
+++ b/app/code/core/Mage/Downloadable/Model/Sales/Order/Pdf/Items/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Model/Sales/Order/Pdf/Items/Creditmemo.php
+++ b/app/code/core/Mage/Downloadable/Model/Sales/Order/Pdf/Items/Creditmemo.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Model/Sales/Order/Pdf/Items/Creditmemo.php
+++ b/app/code/core/Mage/Downloadable/Model/Sales/Order/Pdf/Items/Creditmemo.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Downloadable/Model/Sales/Order/Pdf/Items/Creditmemo.php
+++ b/app/code/core/Mage/Downloadable/Model/Sales/Order/Pdf/Items/Creditmemo.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Model/Sales/Order/Pdf/Items/Invoice.php
+++ b/app/code/core/Mage/Downloadable/Model/Sales/Order/Pdf/Items/Invoice.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Model/Sales/Order/Pdf/Items/Invoice.php
+++ b/app/code/core/Mage/Downloadable/Model/Sales/Order/Pdf/Items/Invoice.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Downloadable/Model/Sales/Order/Pdf/Items/Invoice.php
+++ b/app/code/core/Mage/Downloadable/Model/Sales/Order/Pdf/Items/Invoice.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Model/Sample.php
+++ b/app/code/core/Mage/Downloadable/Model/Sample.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Model/Sample.php
+++ b/app/code/core/Mage/Downloadable/Model/Sample.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Downloadable/Model/Sample.php
+++ b/app/code/core/Mage/Downloadable/Model/Sample.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Model/System/Config/Source/Contentdisposition.php
+++ b/app/code/core/Mage/Downloadable/Model/System/Config/Source/Contentdisposition.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Model/System/Config/Source/Contentdisposition.php
+++ b/app/code/core/Mage/Downloadable/Model/System/Config/Source/Contentdisposition.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Downloadable/Model/System/Config/Source/Contentdisposition.php
+++ b/app/code/core/Mage/Downloadable/Model/System/Config/Source/Contentdisposition.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Model/System/Config/Source/Orderitemstatus.php
+++ b/app/code/core/Mage/Downloadable/Model/System/Config/Source/Orderitemstatus.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/Model/System/Config/Source/Orderitemstatus.php
+++ b/app/code/core/Mage/Downloadable/Model/System/Config/Source/Orderitemstatus.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Downloadable/Model/System/Config/Source/Orderitemstatus.php
+++ b/app/code/core/Mage/Downloadable/Model/System/Config/Source/Orderitemstatus.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/controllers/Adminhtml/Downloadable/FileController.php
+++ b/app/code/core/Mage/Downloadable/controllers/Adminhtml/Downloadable/FileController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/controllers/Adminhtml/Downloadable/FileController.php
+++ b/app/code/core/Mage/Downloadable/controllers/Adminhtml/Downloadable/FileController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Downloadable/controllers/Adminhtml/Downloadable/FileController.php
+++ b/app/code/core/Mage/Downloadable/controllers/Adminhtml/Downloadable/FileController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/controllers/Adminhtml/Downloadable/Product/EditController.php
+++ b/app/code/core/Mage/Downloadable/controllers/Adminhtml/Downloadable/Product/EditController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/controllers/Adminhtml/Downloadable/Product/EditController.php
+++ b/app/code/core/Mage/Downloadable/controllers/Adminhtml/Downloadable/Product/EditController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Downloadable/controllers/Adminhtml/Downloadable/Product/EditController.php
+++ b/app/code/core/Mage/Downloadable/controllers/Adminhtml/Downloadable/Product/EditController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/controllers/CustomerController.php
+++ b/app/code/core/Mage/Downloadable/controllers/CustomerController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/controllers/CustomerController.php
+++ b/app/code/core/Mage/Downloadable/controllers/CustomerController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Downloadable/controllers/CustomerController.php
+++ b/app/code/core/Mage/Downloadable/controllers/CustomerController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/controllers/DownloadController.php
+++ b/app/code/core/Mage/Downloadable/controllers/DownloadController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/controllers/DownloadController.php
+++ b/app/code/core/Mage/Downloadable/controllers/DownloadController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Downloadable/controllers/DownloadController.php
+++ b/app/code/core/Mage/Downloadable/controllers/DownloadController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/controllers/FileController.php
+++ b/app/code/core/Mage/Downloadable/controllers/FileController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/controllers/FileController.php
+++ b/app/code/core/Mage/Downloadable/controllers/FileController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Downloadable/controllers/FileController.php
+++ b/app/code/core/Mage/Downloadable/controllers/FileController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/controllers/Product/EditController.php
+++ b/app/code/core/Mage/Downloadable/controllers/Product/EditController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/controllers/Product/EditController.php
+++ b/app/code/core/Mage/Downloadable/controllers/Product/EditController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Downloadable/controllers/Product/EditController.php
+++ b/app/code/core/Mage/Downloadable/controllers/Product/EditController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/data/downloadable_setup/data-install-1.6.0.0.php
+++ b/app/code/core/Mage/Downloadable/data/downloadable_setup/data-install-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/data/downloadable_setup/data-install-1.6.0.0.php
+++ b/app/code/core/Mage/Downloadable/data/downloadable_setup/data-install-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Downloadable/data/downloadable_setup/data-install-1.6.0.0.php
+++ b/app/code/core/Mage/Downloadable/data/downloadable_setup/data-install-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/etc/adminhtml.xml
+++ b/app/code/core/Mage/Downloadable/etc/adminhtml.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/etc/adminhtml.xml
+++ b/app/code/core/Mage/Downloadable/etc/adminhtml.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/etc/adminhtml.xml
+++ b/app/code/core/Mage/Downloadable/etc/adminhtml.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Downloadable/etc/api.xml
+++ b/app/code/core/Mage/Downloadable/etc/api.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/etc/api.xml
+++ b/app/code/core/Mage/Downloadable/etc/api.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/etc/api.xml
+++ b/app/code/core/Mage/Downloadable/etc/api.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Downloadable/etc/config.xml
+++ b/app/code/core/Mage/Downloadable/etc/config.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/etc/config.xml
+++ b/app/code/core/Mage/Downloadable/etc/config.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/etc/config.xml
+++ b/app/code/core/Mage/Downloadable/etc/config.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Downloadable/etc/system.xml
+++ b/app/code/core/Mage/Downloadable/etc/system.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/etc/system.xml
+++ b/app/code/core/Mage/Downloadable/etc/system.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/etc/system.xml
+++ b/app/code/core/Mage/Downloadable/etc/system.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Downloadable/sql/downloadable_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Downloadable/sql/downloadable_setup/install-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/sql/downloadable_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Downloadable/sql/downloadable_setup/install-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Downloadable/sql/downloadable_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Downloadable/sql/downloadable_setup/install-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-install-0.1.0.php
+++ b/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-install-0.1.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-install-0.1.0.php
+++ b/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-install-0.1.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-install-0.1.0.php
+++ b/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-install-0.1.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-install-1.4.0.0.php
+++ b/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-install-1.4.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-install-1.4.0.0.php
+++ b/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-install-1.4.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-install-1.4.0.0.php
+++ b/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-install-1.4.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.0-0.1.1.php
+++ b/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.0-0.1.1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.0-0.1.1.php
+++ b/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.0-0.1.1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.0-0.1.1.php
+++ b/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.0-0.1.1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.1-0.1.2.php
+++ b/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.1-0.1.2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.1-0.1.2.php
+++ b/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.1-0.1.2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.1-0.1.2.php
+++ b/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.1-0.1.2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.10-0.1.11.php
+++ b/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.10-0.1.11.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.10-0.1.11.php
+++ b/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.10-0.1.11.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.10-0.1.11.php
+++ b/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.10-0.1.11.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.11-0.1.12.php
+++ b/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.11-0.1.12.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.11-0.1.12.php
+++ b/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.11-0.1.12.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.11-0.1.12.php
+++ b/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.11-0.1.12.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.12-0.1.13.php
+++ b/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.12-0.1.13.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.12-0.1.13.php
+++ b/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.12-0.1.13.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.12-0.1.13.php
+++ b/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.12-0.1.13.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.13-0.1.14.php
+++ b/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.13-0.1.14.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.13-0.1.14.php
+++ b/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.13-0.1.14.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.13-0.1.14.php
+++ b/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.13-0.1.14.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.14-0.1.15.php
+++ b/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.14-0.1.15.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.14-0.1.15.php
+++ b/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.14-0.1.15.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.14-0.1.15.php
+++ b/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.14-0.1.15.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.15-0.1.16.php
+++ b/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.15-0.1.16.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.15-0.1.16.php
+++ b/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.15-0.1.16.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.15-0.1.16.php
+++ b/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.15-0.1.16.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.2-0.1.3.php
+++ b/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.2-0.1.3.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.2-0.1.3.php
+++ b/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.2-0.1.3.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.2-0.1.3.php
+++ b/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.2-0.1.3.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.3-0.1.4.php
+++ b/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.3-0.1.4.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.3-0.1.4.php
+++ b/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.3-0.1.4.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.3-0.1.4.php
+++ b/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.3-0.1.4.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.4-0.1.5.php
+++ b/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.4-0.1.5.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.4-0.1.5.php
+++ b/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.4-0.1.5.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.4-0.1.5.php
+++ b/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.4-0.1.5.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.5-0.1.6.php
+++ b/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.5-0.1.6.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.5-0.1.6.php
+++ b/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.5-0.1.6.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.5-0.1.6.php
+++ b/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.5-0.1.6.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.6-0.1.7.php
+++ b/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.6-0.1.7.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.6-0.1.7.php
+++ b/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.6-0.1.7.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.6-0.1.7.php
+++ b/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.6-0.1.7.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.7-0.1.8.php
+++ b/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.7-0.1.8.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.7-0.1.8.php
+++ b/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.7-0.1.8.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.7-0.1.8.php
+++ b/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.7-0.1.8.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.8-0.1.9.php
+++ b/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.8-0.1.9.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.8-0.1.9.php
+++ b/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.8-0.1.9.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.8-0.1.9.php
+++ b/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.8-0.1.9.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.9-0.1.10.php
+++ b/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.9-0.1.10.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.9-0.1.10.php
+++ b/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.9-0.1.10.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.9-0.1.10.php
+++ b/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-0.1.9-0.1.10.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-1.3.9-1.4.0.0.php
+++ b/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-1.3.9-1.4.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-1.3.9-1.4.0.0.php
+++ b/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-1.3.9-1.4.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-1.3.9-1.4.0.0.php
+++ b/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-1.3.9-1.4.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-1.4.0.0-1.4.0.1.php
+++ b/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-1.4.0.0-1.4.0.1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-1.4.0.0-1.4.0.1.php
+++ b/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-1.4.0.0-1.4.0.1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-1.4.0.0-1.4.0.1.php
+++ b/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-1.4.0.0-1.4.0.1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-1.4.0.1-1.4.0.2.php
+++ b/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-1.4.0.1-1.4.0.2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-1.4.0.1-1.4.0.2.php
+++ b/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-1.4.0.1-1.4.0.2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-1.4.0.1-1.4.0.2.php
+++ b/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-1.4.0.1-1.4.0.2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-1.4.0.2-1.4.0.3.php
+++ b/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-1.4.0.2-1.4.0.3.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-1.4.0.2-1.4.0.3.php
+++ b/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-1.4.0.2-1.4.0.3.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-1.4.0.2-1.4.0.3.php
+++ b/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-1.4.0.2-1.4.0.3.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-1.6.0.0.1-1.6.0.0.2.php
+++ b/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-1.6.0.0.1-1.6.0.0.2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-1.6.0.0.1-1.6.0.0.2.php
+++ b/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-1.6.0.0.1-1.6.0.0.2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-1.6.0.0.1-1.6.0.0.2.php
+++ b/app/code/core/Mage/Downloadable/sql/downloadable_setup/mysql4-upgrade-1.6.0.0.1-1.6.0.0.2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/sql/downloadable_setup/upgrade-1.6.0.0-1.6.0.0.1.php
+++ b/app/code/core/Mage/Downloadable/sql/downloadable_setup/upgrade-1.6.0.0-1.6.0.0.1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/sql/downloadable_setup/upgrade-1.6.0.0-1.6.0.0.1.php
+++ b/app/code/core/Mage/Downloadable/sql/downloadable_setup/upgrade-1.6.0.0-1.6.0.0.1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Downloadable/sql/downloadable_setup/upgrade-1.6.0.0-1.6.0.0.1.php
+++ b/app/code/core/Mage/Downloadable/sql/downloadable_setup/upgrade-1.6.0.0-1.6.0.0.1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/sql/downloadable_setup/upgrade-1.6.0.0.1-1.6.0.0.2.php
+++ b/app/code/core/Mage/Downloadable/sql/downloadable_setup/upgrade-1.6.0.0.1-1.6.0.0.2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/sql/downloadable_setup/upgrade-1.6.0.0.1-1.6.0.0.2.php
+++ b/app/code/core/Mage/Downloadable/sql/downloadable_setup/upgrade-1.6.0.0.1-1.6.0.0.2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Downloadable/sql/downloadable_setup/upgrade-1.6.0.0.1-1.6.0.0.2.php
+++ b/app/code/core/Mage/Downloadable/sql/downloadable_setup/upgrade-1.6.0.0.1-1.6.0.0.2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/sql/downloadable_setup/upgrade-1.6.0.0.2-1.6.0.0.3.php
+++ b/app/code/core/Mage/Downloadable/sql/downloadable_setup/upgrade-1.6.0.0.2-1.6.0.0.3.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Downloadable/sql/downloadable_setup/upgrade-1.6.0.0.2-1.6.0.0.3.php
+++ b/app/code/core/Mage/Downloadable/sql/downloadable_setup/upgrade-1.6.0.0.2-1.6.0.0.3.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Downloadable/sql/downloadable_setup/upgrade-1.6.0.0.2-1.6.0.0.3.php
+++ b/app/code/core/Mage/Downloadable/sql/downloadable_setup/upgrade-1.6.0.0.2-1.6.0.0.3.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/code/core/Mage/Eav/Block/Adminhtml/Attribute/Edit/Js.php
+++ b/app/code/core/Mage/Eav/Block/Adminhtml/Attribute/Edit/Js.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Block/Adminhtml/Attribute/Edit/Js.php
+++ b/app/code/core/Mage/Eav/Block/Adminhtml/Attribute/Edit/Js.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Block/Adminhtml/Attribute/Edit/Js.php
+++ b/app/code/core/Mage/Eav/Block/Adminhtml/Attribute/Edit/Js.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Block/Adminhtml/Attribute/Edit/Main/Abstract.php
+++ b/app/code/core/Mage/Eav/Block/Adminhtml/Attribute/Edit/Main/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Block/Adminhtml/Attribute/Edit/Main/Abstract.php
+++ b/app/code/core/Mage/Eav/Block/Adminhtml/Attribute/Edit/Main/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Block/Adminhtml/Attribute/Edit/Main/Abstract.php
+++ b/app/code/core/Mage/Eav/Block/Adminhtml/Attribute/Edit/Main/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Block/Adminhtml/Attribute/Edit/Options/Abstract.php
+++ b/app/code/core/Mage/Eav/Block/Adminhtml/Attribute/Edit/Options/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Block/Adminhtml/Attribute/Edit/Options/Abstract.php
+++ b/app/code/core/Mage/Eav/Block/Adminhtml/Attribute/Edit/Options/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Block/Adminhtml/Attribute/Edit/Options/Abstract.php
+++ b/app/code/core/Mage/Eav/Block/Adminhtml/Attribute/Edit/Options/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Block/Adminhtml/Attribute/Grid/Abstract.php
+++ b/app/code/core/Mage/Eav/Block/Adminhtml/Attribute/Grid/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Block/Adminhtml/Attribute/Grid/Abstract.php
+++ b/app/code/core/Mage/Eav/Block/Adminhtml/Attribute/Grid/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Block/Adminhtml/Attribute/Grid/Abstract.php
+++ b/app/code/core/Mage/Eav/Block/Adminhtml/Attribute/Grid/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Exception.php
+++ b/app/code/core/Mage/Eav/Exception.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Exception.php
+++ b/app/code/core/Mage/Eav/Exception.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Exception.php
+++ b/app/code/core/Mage/Eav/Exception.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Helper/Data.php
+++ b/app/code/core/Mage/Eav/Helper/Data.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Helper/Data.php
+++ b/app/code/core/Mage/Eav/Helper/Data.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Helper/Data.php
+++ b/app/code/core/Mage/Eav/Helper/Data.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Adminhtml/System/Config/Source/Inputtype.php
+++ b/app/code/core/Mage/Eav/Model/Adminhtml/System/Config/Source/Inputtype.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Adminhtml/System/Config/Source/Inputtype.php
+++ b/app/code/core/Mage/Eav/Model/Adminhtml/System/Config/Source/Inputtype.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Adminhtml/System/Config/Source/Inputtype.php
+++ b/app/code/core/Mage/Eav/Model/Adminhtml/System/Config/Source/Inputtype.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Adminhtml/System/Config/Source/Inputtype/Validator.php
+++ b/app/code/core/Mage/Eav/Model/Adminhtml/System/Config/Source/Inputtype/Validator.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Adminhtml/System/Config/Source/Inputtype/Validator.php
+++ b/app/code/core/Mage/Eav/Model/Adminhtml/System/Config/Source/Inputtype/Validator.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Adminhtml/System/Config/Source/Inputtype/Validator.php
+++ b/app/code/core/Mage/Eav/Model/Adminhtml/System/Config/Source/Inputtype/Validator.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Attribute.php
+++ b/app/code/core/Mage/Eav/Model/Attribute.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Attribute.php
+++ b/app/code/core/Mage/Eav/Model/Attribute.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Attribute.php
+++ b/app/code/core/Mage/Eav/Model/Attribute.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Attribute/Data.php
+++ b/app/code/core/Mage/Eav/Model/Attribute/Data.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Attribute/Data.php
+++ b/app/code/core/Mage/Eav/Model/Attribute/Data.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Attribute/Data.php
+++ b/app/code/core/Mage/Eav/Model/Attribute/Data.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Attribute/Data/Abstract.php
+++ b/app/code/core/Mage/Eav/Model/Attribute/Data/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Attribute/Data/Abstract.php
+++ b/app/code/core/Mage/Eav/Model/Attribute/Data/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Attribute/Data/Abstract.php
+++ b/app/code/core/Mage/Eav/Model/Attribute/Data/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Attribute/Data/Boolean.php
+++ b/app/code/core/Mage/Eav/Model/Attribute/Data/Boolean.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Attribute/Data/Boolean.php
+++ b/app/code/core/Mage/Eav/Model/Attribute/Data/Boolean.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Attribute/Data/Boolean.php
+++ b/app/code/core/Mage/Eav/Model/Attribute/Data/Boolean.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Attribute/Data/Date.php
+++ b/app/code/core/Mage/Eav/Model/Attribute/Data/Date.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Attribute/Data/Date.php
+++ b/app/code/core/Mage/Eav/Model/Attribute/Data/Date.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Attribute/Data/Date.php
+++ b/app/code/core/Mage/Eav/Model/Attribute/Data/Date.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Attribute/Data/Datetime.php
+++ b/app/code/core/Mage/Eav/Model/Attribute/Data/Datetime.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Attribute/Data/Datetime.php
+++ b/app/code/core/Mage/Eav/Model/Attribute/Data/Datetime.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Attribute/Data/Datetime.php
+++ b/app/code/core/Mage/Eav/Model/Attribute/Data/Datetime.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Attribute/Data/File.php
+++ b/app/code/core/Mage/Eav/Model/Attribute/Data/File.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Attribute/Data/File.php
+++ b/app/code/core/Mage/Eav/Model/Attribute/Data/File.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Attribute/Data/File.php
+++ b/app/code/core/Mage/Eav/Model/Attribute/Data/File.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Attribute/Data/Hidden.php
+++ b/app/code/core/Mage/Eav/Model/Attribute/Data/Hidden.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Attribute/Data/Hidden.php
+++ b/app/code/core/Mage/Eav/Model/Attribute/Data/Hidden.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Attribute/Data/Hidden.php
+++ b/app/code/core/Mage/Eav/Model/Attribute/Data/Hidden.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Attribute/Data/Image.php
+++ b/app/code/core/Mage/Eav/Model/Attribute/Data/Image.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Attribute/Data/Image.php
+++ b/app/code/core/Mage/Eav/Model/Attribute/Data/Image.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Attribute/Data/Image.php
+++ b/app/code/core/Mage/Eav/Model/Attribute/Data/Image.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Attribute/Data/Multiline.php
+++ b/app/code/core/Mage/Eav/Model/Attribute/Data/Multiline.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Attribute/Data/Multiline.php
+++ b/app/code/core/Mage/Eav/Model/Attribute/Data/Multiline.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Attribute/Data/Multiline.php
+++ b/app/code/core/Mage/Eav/Model/Attribute/Data/Multiline.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Attribute/Data/Multiselect.php
+++ b/app/code/core/Mage/Eav/Model/Attribute/Data/Multiselect.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Attribute/Data/Multiselect.php
+++ b/app/code/core/Mage/Eav/Model/Attribute/Data/Multiselect.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Attribute/Data/Multiselect.php
+++ b/app/code/core/Mage/Eav/Model/Attribute/Data/Multiselect.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Attribute/Data/Select.php
+++ b/app/code/core/Mage/Eav/Model/Attribute/Data/Select.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Attribute/Data/Select.php
+++ b/app/code/core/Mage/Eav/Model/Attribute/Data/Select.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Attribute/Data/Select.php
+++ b/app/code/core/Mage/Eav/Model/Attribute/Data/Select.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Attribute/Data/Text.php
+++ b/app/code/core/Mage/Eav/Model/Attribute/Data/Text.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Attribute/Data/Text.php
+++ b/app/code/core/Mage/Eav/Model/Attribute/Data/Text.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Attribute/Data/Text.php
+++ b/app/code/core/Mage/Eav/Model/Attribute/Data/Text.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Attribute/Data/Textarea.php
+++ b/app/code/core/Mage/Eav/Model/Attribute/Data/Textarea.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Attribute/Data/Textarea.php
+++ b/app/code/core/Mage/Eav/Model/Attribute/Data/Textarea.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Attribute/Data/Textarea.php
+++ b/app/code/core/Mage/Eav/Model/Attribute/Data/Textarea.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Config.php
+++ b/app/code/core/Mage/Eav/Model/Config.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Config.php
+++ b/app/code/core/Mage/Eav/Model/Config.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Config.php
+++ b/app/code/core/Mage/Eav/Model/Config.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Convert/Adapter/Entity.php
+++ b/app/code/core/Mage/Eav/Model/Convert/Adapter/Entity.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Convert/Adapter/Entity.php
+++ b/app/code/core/Mage/Eav/Model/Convert/Adapter/Entity.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Convert/Adapter/Entity.php
+++ b/app/code/core/Mage/Eav/Model/Convert/Adapter/Entity.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Convert/Adapter/Grid.php
+++ b/app/code/core/Mage/Eav/Model/Convert/Adapter/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Convert/Adapter/Grid.php
+++ b/app/code/core/Mage/Eav/Model/Convert/Adapter/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Convert/Adapter/Grid.php
+++ b/app/code/core/Mage/Eav/Model/Convert/Adapter/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Convert/Parser/Abstract.php
+++ b/app/code/core/Mage/Eav/Model/Convert/Parser/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Convert/Parser/Abstract.php
+++ b/app/code/core/Mage/Eav/Model/Convert/Parser/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Convert/Parser/Abstract.php
+++ b/app/code/core/Mage/Eav/Model/Convert/Parser/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Entity.php
+++ b/app/code/core/Mage/Eav/Model/Entity.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Entity.php
+++ b/app/code/core/Mage/Eav/Model/Entity.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Entity.php
+++ b/app/code/core/Mage/Eav/Model/Entity.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Entity/Abstract.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Entity/Abstract.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Entity/Abstract.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Abstract.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Abstract.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Abstract.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Abstract.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Abstract.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Abstract.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Array.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Array.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Array.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Array.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Array.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Array.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Datetime.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Datetime.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Datetime.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Datetime.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Datetime.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Datetime.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Default.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Default.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Default.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Default.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Default.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Default.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Increment.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Increment.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Increment.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Increment.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Increment.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Increment.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Interface.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Interface.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Interface.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Interface.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Interface.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Interface.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Serialized.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Serialized.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Serialized.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Serialized.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Serialized.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Serialized.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Store.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Store.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Store.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Store.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Store.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Store.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Time/Created.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Time/Created.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Time/Created.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Time/Created.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Time/Created.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Time/Created.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Time/Updated.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Time/Updated.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Time/Updated.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Time/Updated.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Time/Updated.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Time/Updated.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Exception.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Exception.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Exception.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Exception.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Exception.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Exception.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Frontend/Abstract.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Frontend/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Frontend/Abstract.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Frontend/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Frontend/Abstract.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Frontend/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Frontend/Datetime.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Frontend/Datetime.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Frontend/Datetime.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Frontend/Datetime.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Frontend/Datetime.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Frontend/Datetime.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Frontend/Default.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Frontend/Default.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Frontend/Default.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Frontend/Default.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Frontend/Default.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Frontend/Default.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Frontend/Interface.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Frontend/Interface.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Frontend/Interface.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Frontend/Interface.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Frontend/Interface.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Frontend/Interface.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Group.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Group.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Group.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Group.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Group.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Group.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Interface.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Interface.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Interface.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Interface.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Interface.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Interface.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Option.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Option.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Option.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Option.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Option.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Option.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Set.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Set.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Set.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Set.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Set.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Set.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Source/Abstract.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Source/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Source/Abstract.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Source/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Source/Abstract.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Source/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Source/Boolean.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Source/Boolean.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Source/Boolean.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Source/Boolean.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Source/Boolean.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Source/Boolean.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Source/Config.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Source/Config.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Source/Config.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Source/Config.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Source/Config.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Source/Config.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Source/Interface.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Source/Interface.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Source/Interface.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Source/Interface.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Source/Interface.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Source/Interface.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Source/Store.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Source/Store.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Source/Store.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Source/Store.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Source/Store.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Source/Store.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Source/Table.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Source/Table.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Source/Table.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Source/Table.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Source/Table.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Source/Table.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Entity/Collection.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Entity/Collection.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Entity/Collection.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Entity/Collection/Abstract.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Collection/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Entity/Collection/Abstract.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Collection/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Entity/Collection/Abstract.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Collection/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Entity/Increment/Abstract.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Increment/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Entity/Increment/Abstract.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Increment/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Entity/Increment/Abstract.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Increment/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Entity/Increment/Alphanum.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Increment/Alphanum.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Entity/Increment/Alphanum.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Increment/Alphanum.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Entity/Increment/Alphanum.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Increment/Alphanum.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Entity/Increment/Interface.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Increment/Interface.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Entity/Increment/Interface.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Increment/Interface.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Entity/Increment/Interface.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Increment/Interface.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Entity/Increment/Numeric.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Increment/Numeric.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Entity/Increment/Numeric.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Increment/Numeric.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Entity/Increment/Numeric.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Increment/Numeric.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Entity/Interface.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Interface.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Entity/Interface.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Interface.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Entity/Interface.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Interface.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Entity/Setup.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Setup.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Entity/Setup.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Setup.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Entity/Setup.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Setup.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Entity/Store.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Store.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Entity/Store.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Store.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Entity/Store.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Store.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Entity/Type.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Type.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Entity/Type.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Type.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Entity/Type.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Type.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Form.php
+++ b/app/code/core/Mage/Eav/Model/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Form.php
+++ b/app/code/core/Mage/Eav/Model/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Form.php
+++ b/app/code/core/Mage/Eav/Model/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Form/Element.php
+++ b/app/code/core/Mage/Eav/Model/Form/Element.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Form/Element.php
+++ b/app/code/core/Mage/Eav/Model/Form/Element.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Form/Element.php
+++ b/app/code/core/Mage/Eav/Model/Form/Element.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Form/Fieldset.php
+++ b/app/code/core/Mage/Eav/Model/Form/Fieldset.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Form/Fieldset.php
+++ b/app/code/core/Mage/Eav/Model/Form/Fieldset.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Form/Fieldset.php
+++ b/app/code/core/Mage/Eav/Model/Form/Fieldset.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Form/Type.php
+++ b/app/code/core/Mage/Eav/Model/Form/Type.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Form/Type.php
+++ b/app/code/core/Mage/Eav/Model/Form/Type.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Form/Type.php
+++ b/app/code/core/Mage/Eav/Model/Form/Type.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Mysql4/Config.php
+++ b/app/code/core/Mage/Eav/Model/Mysql4/Config.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Mysql4/Config.php
+++ b/app/code/core/Mage/Eav/Model/Mysql4/Config.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Mysql4/Config.php
+++ b/app/code/core/Mage/Eav/Model/Mysql4/Config.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Mysql4/Entity/Attribute.php
+++ b/app/code/core/Mage/Eav/Model/Mysql4/Entity/Attribute.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Mysql4/Entity/Attribute.php
+++ b/app/code/core/Mage/Eav/Model/Mysql4/Entity/Attribute.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Mysql4/Entity/Attribute.php
+++ b/app/code/core/Mage/Eav/Model/Mysql4/Entity/Attribute.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Mysql4/Entity/Attribute/Collection.php
+++ b/app/code/core/Mage/Eav/Model/Mysql4/Entity/Attribute/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Mysql4/Entity/Attribute/Collection.php
+++ b/app/code/core/Mage/Eav/Model/Mysql4/Entity/Attribute/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Mysql4/Entity/Attribute/Collection.php
+++ b/app/code/core/Mage/Eav/Model/Mysql4/Entity/Attribute/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Mysql4/Entity/Attribute/Group.php
+++ b/app/code/core/Mage/Eav/Model/Mysql4/Entity/Attribute/Group.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Mysql4/Entity/Attribute/Group.php
+++ b/app/code/core/Mage/Eav/Model/Mysql4/Entity/Attribute/Group.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Mysql4/Entity/Attribute/Group.php
+++ b/app/code/core/Mage/Eav/Model/Mysql4/Entity/Attribute/Group.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Mysql4/Entity/Attribute/Group/Collection.php
+++ b/app/code/core/Mage/Eav/Model/Mysql4/Entity/Attribute/Group/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Mysql4/Entity/Attribute/Group/Collection.php
+++ b/app/code/core/Mage/Eav/Model/Mysql4/Entity/Attribute/Group/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Mysql4/Entity/Attribute/Group/Collection.php
+++ b/app/code/core/Mage/Eav/Model/Mysql4/Entity/Attribute/Group/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Mysql4/Entity/Attribute/Option.php
+++ b/app/code/core/Mage/Eav/Model/Mysql4/Entity/Attribute/Option.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Mysql4/Entity/Attribute/Option.php
+++ b/app/code/core/Mage/Eav/Model/Mysql4/Entity/Attribute/Option.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Mysql4/Entity/Attribute/Option.php
+++ b/app/code/core/Mage/Eav/Model/Mysql4/Entity/Attribute/Option.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Mysql4/Entity/Attribute/Option/Collection.php
+++ b/app/code/core/Mage/Eav/Model/Mysql4/Entity/Attribute/Option/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Mysql4/Entity/Attribute/Option/Collection.php
+++ b/app/code/core/Mage/Eav/Model/Mysql4/Entity/Attribute/Option/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Mysql4/Entity/Attribute/Option/Collection.php
+++ b/app/code/core/Mage/Eav/Model/Mysql4/Entity/Attribute/Option/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Mysql4/Entity/Attribute/Set.php
+++ b/app/code/core/Mage/Eav/Model/Mysql4/Entity/Attribute/Set.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Mysql4/Entity/Attribute/Set.php
+++ b/app/code/core/Mage/Eav/Model/Mysql4/Entity/Attribute/Set.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Mysql4/Entity/Attribute/Set.php
+++ b/app/code/core/Mage/Eav/Model/Mysql4/Entity/Attribute/Set.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Mysql4/Entity/Attribute/Set/Collection.php
+++ b/app/code/core/Mage/Eav/Model/Mysql4/Entity/Attribute/Set/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Mysql4/Entity/Attribute/Set/Collection.php
+++ b/app/code/core/Mage/Eav/Model/Mysql4/Entity/Attribute/Set/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Mysql4/Entity/Attribute/Set/Collection.php
+++ b/app/code/core/Mage/Eav/Model/Mysql4/Entity/Attribute/Set/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Mysql4/Entity/Store.php
+++ b/app/code/core/Mage/Eav/Model/Mysql4/Entity/Store.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Mysql4/Entity/Store.php
+++ b/app/code/core/Mage/Eav/Model/Mysql4/Entity/Store.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Mysql4/Entity/Store.php
+++ b/app/code/core/Mage/Eav/Model/Mysql4/Entity/Store.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Mysql4/Entity/Type.php
+++ b/app/code/core/Mage/Eav/Model/Mysql4/Entity/Type.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Mysql4/Entity/Type.php
+++ b/app/code/core/Mage/Eav/Model/Mysql4/Entity/Type.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Mysql4/Entity/Type.php
+++ b/app/code/core/Mage/Eav/Model/Mysql4/Entity/Type.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Mysql4/Entity/Type/Collection.php
+++ b/app/code/core/Mage/Eav/Model/Mysql4/Entity/Type/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Mysql4/Entity/Type/Collection.php
+++ b/app/code/core/Mage/Eav/Model/Mysql4/Entity/Type/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Mysql4/Entity/Type/Collection.php
+++ b/app/code/core/Mage/Eav/Model/Mysql4/Entity/Type/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Mysql4/Form/Element.php
+++ b/app/code/core/Mage/Eav/Model/Mysql4/Form/Element.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Mysql4/Form/Element.php
+++ b/app/code/core/Mage/Eav/Model/Mysql4/Form/Element.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Mysql4/Form/Element.php
+++ b/app/code/core/Mage/Eav/Model/Mysql4/Form/Element.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Mysql4/Form/Element/Collection.php
+++ b/app/code/core/Mage/Eav/Model/Mysql4/Form/Element/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Mysql4/Form/Element/Collection.php
+++ b/app/code/core/Mage/Eav/Model/Mysql4/Form/Element/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Mysql4/Form/Element/Collection.php
+++ b/app/code/core/Mage/Eav/Model/Mysql4/Form/Element/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Mysql4/Form/Fieldset.php
+++ b/app/code/core/Mage/Eav/Model/Mysql4/Form/Fieldset.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Mysql4/Form/Fieldset.php
+++ b/app/code/core/Mage/Eav/Model/Mysql4/Form/Fieldset.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Mysql4/Form/Fieldset.php
+++ b/app/code/core/Mage/Eav/Model/Mysql4/Form/Fieldset.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Mysql4/Form/Fieldset/Collection.php
+++ b/app/code/core/Mage/Eav/Model/Mysql4/Form/Fieldset/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Mysql4/Form/Fieldset/Collection.php
+++ b/app/code/core/Mage/Eav/Model/Mysql4/Form/Fieldset/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Mysql4/Form/Fieldset/Collection.php
+++ b/app/code/core/Mage/Eav/Model/Mysql4/Form/Fieldset/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Mysql4/Form/Type.php
+++ b/app/code/core/Mage/Eav/Model/Mysql4/Form/Type.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Mysql4/Form/Type.php
+++ b/app/code/core/Mage/Eav/Model/Mysql4/Form/Type.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Mysql4/Form/Type.php
+++ b/app/code/core/Mage/Eav/Model/Mysql4/Form/Type.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Mysql4/Form/Type/Collection.php
+++ b/app/code/core/Mage/Eav/Model/Mysql4/Form/Type/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Mysql4/Form/Type/Collection.php
+++ b/app/code/core/Mage/Eav/Model/Mysql4/Form/Type/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Mysql4/Form/Type/Collection.php
+++ b/app/code/core/Mage/Eav/Model/Mysql4/Form/Type/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Resource/Attribute.php
+++ b/app/code/core/Mage/Eav/Model/Resource/Attribute.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Resource/Attribute.php
+++ b/app/code/core/Mage/Eav/Model/Resource/Attribute.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Resource/Attribute.php
+++ b/app/code/core/Mage/Eav/Model/Resource/Attribute.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Resource/Attribute/Collection.php
+++ b/app/code/core/Mage/Eav/Model/Resource/Attribute/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Resource/Attribute/Collection.php
+++ b/app/code/core/Mage/Eav/Model/Resource/Attribute/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Resource/Attribute/Collection.php
+++ b/app/code/core/Mage/Eav/Model/Resource/Attribute/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Resource/Config.php
+++ b/app/code/core/Mage/Eav/Model/Resource/Config.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Resource/Config.php
+++ b/app/code/core/Mage/Eav/Model/Resource/Config.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Resource/Config.php
+++ b/app/code/core/Mage/Eav/Model/Resource/Config.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Resource/Entity/Attribute.php
+++ b/app/code/core/Mage/Eav/Model/Resource/Entity/Attribute.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Resource/Entity/Attribute.php
+++ b/app/code/core/Mage/Eav/Model/Resource/Entity/Attribute.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Resource/Entity/Attribute.php
+++ b/app/code/core/Mage/Eav/Model/Resource/Entity/Attribute.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Resource/Entity/Attribute/Collection.php
+++ b/app/code/core/Mage/Eav/Model/Resource/Entity/Attribute/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Resource/Entity/Attribute/Collection.php
+++ b/app/code/core/Mage/Eav/Model/Resource/Entity/Attribute/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Resource/Entity/Attribute/Collection.php
+++ b/app/code/core/Mage/Eav/Model/Resource/Entity/Attribute/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Resource/Entity/Attribute/Group.php
+++ b/app/code/core/Mage/Eav/Model/Resource/Entity/Attribute/Group.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Resource/Entity/Attribute/Group.php
+++ b/app/code/core/Mage/Eav/Model/Resource/Entity/Attribute/Group.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Resource/Entity/Attribute/Group.php
+++ b/app/code/core/Mage/Eav/Model/Resource/Entity/Attribute/Group.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Resource/Entity/Attribute/Group/Collection.php
+++ b/app/code/core/Mage/Eav/Model/Resource/Entity/Attribute/Group/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Resource/Entity/Attribute/Group/Collection.php
+++ b/app/code/core/Mage/Eav/Model/Resource/Entity/Attribute/Group/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Resource/Entity/Attribute/Group/Collection.php
+++ b/app/code/core/Mage/Eav/Model/Resource/Entity/Attribute/Group/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Resource/Entity/Attribute/Option.php
+++ b/app/code/core/Mage/Eav/Model/Resource/Entity/Attribute/Option.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Resource/Entity/Attribute/Option.php
+++ b/app/code/core/Mage/Eav/Model/Resource/Entity/Attribute/Option.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Resource/Entity/Attribute/Option.php
+++ b/app/code/core/Mage/Eav/Model/Resource/Entity/Attribute/Option.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Resource/Entity/Attribute/Option/Collection.php
+++ b/app/code/core/Mage/Eav/Model/Resource/Entity/Attribute/Option/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Resource/Entity/Attribute/Option/Collection.php
+++ b/app/code/core/Mage/Eav/Model/Resource/Entity/Attribute/Option/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Resource/Entity/Attribute/Option/Collection.php
+++ b/app/code/core/Mage/Eav/Model/Resource/Entity/Attribute/Option/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Resource/Entity/Attribute/Set.php
+++ b/app/code/core/Mage/Eav/Model/Resource/Entity/Attribute/Set.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Resource/Entity/Attribute/Set.php
+++ b/app/code/core/Mage/Eav/Model/Resource/Entity/Attribute/Set.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Resource/Entity/Attribute/Set.php
+++ b/app/code/core/Mage/Eav/Model/Resource/Entity/Attribute/Set.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Resource/Entity/Attribute/Set/Collection.php
+++ b/app/code/core/Mage/Eav/Model/Resource/Entity/Attribute/Set/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Resource/Entity/Attribute/Set/Collection.php
+++ b/app/code/core/Mage/Eav/Model/Resource/Entity/Attribute/Set/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Resource/Entity/Attribute/Set/Collection.php
+++ b/app/code/core/Mage/Eav/Model/Resource/Entity/Attribute/Set/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Resource/Entity/Store.php
+++ b/app/code/core/Mage/Eav/Model/Resource/Entity/Store.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Resource/Entity/Store.php
+++ b/app/code/core/Mage/Eav/Model/Resource/Entity/Store.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Resource/Entity/Store.php
+++ b/app/code/core/Mage/Eav/Model/Resource/Entity/Store.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Resource/Entity/Type.php
+++ b/app/code/core/Mage/Eav/Model/Resource/Entity/Type.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Resource/Entity/Type.php
+++ b/app/code/core/Mage/Eav/Model/Resource/Entity/Type.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Resource/Entity/Type.php
+++ b/app/code/core/Mage/Eav/Model/Resource/Entity/Type.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Resource/Entity/Type/Collection.php
+++ b/app/code/core/Mage/Eav/Model/Resource/Entity/Type/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Resource/Entity/Type/Collection.php
+++ b/app/code/core/Mage/Eav/Model/Resource/Entity/Type/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Resource/Entity/Type/Collection.php
+++ b/app/code/core/Mage/Eav/Model/Resource/Entity/Type/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Resource/Form/Attribute.php
+++ b/app/code/core/Mage/Eav/Model/Resource/Form/Attribute.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Resource/Form/Attribute.php
+++ b/app/code/core/Mage/Eav/Model/Resource/Form/Attribute.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Resource/Form/Attribute.php
+++ b/app/code/core/Mage/Eav/Model/Resource/Form/Attribute.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Resource/Form/Attribute/Collection.php
+++ b/app/code/core/Mage/Eav/Model/Resource/Form/Attribute/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Resource/Form/Attribute/Collection.php
+++ b/app/code/core/Mage/Eav/Model/Resource/Form/Attribute/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Resource/Form/Attribute/Collection.php
+++ b/app/code/core/Mage/Eav/Model/Resource/Form/Attribute/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Resource/Form/Element.php
+++ b/app/code/core/Mage/Eav/Model/Resource/Form/Element.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Resource/Form/Element.php
+++ b/app/code/core/Mage/Eav/Model/Resource/Form/Element.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Resource/Form/Element.php
+++ b/app/code/core/Mage/Eav/Model/Resource/Form/Element.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Resource/Form/Element/Collection.php
+++ b/app/code/core/Mage/Eav/Model/Resource/Form/Element/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Resource/Form/Element/Collection.php
+++ b/app/code/core/Mage/Eav/Model/Resource/Form/Element/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Resource/Form/Element/Collection.php
+++ b/app/code/core/Mage/Eav/Model/Resource/Form/Element/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Resource/Form/Fieldset.php
+++ b/app/code/core/Mage/Eav/Model/Resource/Form/Fieldset.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Resource/Form/Fieldset.php
+++ b/app/code/core/Mage/Eav/Model/Resource/Form/Fieldset.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Resource/Form/Fieldset.php
+++ b/app/code/core/Mage/Eav/Model/Resource/Form/Fieldset.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Resource/Form/Fieldset/Collection.php
+++ b/app/code/core/Mage/Eav/Model/Resource/Form/Fieldset/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Resource/Form/Fieldset/Collection.php
+++ b/app/code/core/Mage/Eav/Model/Resource/Form/Fieldset/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Resource/Form/Fieldset/Collection.php
+++ b/app/code/core/Mage/Eav/Model/Resource/Form/Fieldset/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Resource/Form/Type.php
+++ b/app/code/core/Mage/Eav/Model/Resource/Form/Type.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Resource/Form/Type.php
+++ b/app/code/core/Mage/Eav/Model/Resource/Form/Type.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Resource/Form/Type.php
+++ b/app/code/core/Mage/Eav/Model/Resource/Form/Type.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Resource/Form/Type/Collection.php
+++ b/app/code/core/Mage/Eav/Model/Resource/Form/Type/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Resource/Form/Type/Collection.php
+++ b/app/code/core/Mage/Eav/Model/Resource/Form/Type/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Resource/Form/Type/Collection.php
+++ b/app/code/core/Mage/Eav/Model/Resource/Form/Type/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Resource/Helper/Mysql4.php
+++ b/app/code/core/Mage/Eav/Model/Resource/Helper/Mysql4.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/Model/Resource/Helper/Mysql4.php
+++ b/app/code/core/Mage/Eav/Model/Resource/Helper/Mysql4.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/Model/Resource/Helper/Mysql4.php
+++ b/app/code/core/Mage/Eav/Model/Resource/Helper/Mysql4.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/etc/config.xml
+++ b/app/code/core/Mage/Eav/etc/config.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/etc/config.xml
+++ b/app/code/core/Mage/Eav/etc/config.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/etc/config.xml
+++ b/app/code/core/Mage/Eav/etc/config.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/sql/eav_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Eav/sql/eav_setup/install-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/sql/eav_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Eav/sql/eav_setup/install-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/sql/eav_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Eav/sql/eav_setup/install-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/sql/eav_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/Eav/sql/eav_setup/mysql4-install-0.7.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/sql/eav_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/Eav/sql/eav_setup/mysql4-install-0.7.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/sql/eav_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/Eav/sql/eav_setup/mysql4-install-0.7.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.0-0.7.1.php
+++ b/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.0-0.7.1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.0-0.7.1.php
+++ b/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.0-0.7.1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.0-0.7.1.php
+++ b/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.0-0.7.1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.1-0.7.2.php
+++ b/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.1-0.7.2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.1-0.7.2.php
+++ b/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.1-0.7.2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.1-0.7.2.php
+++ b/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.1-0.7.2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.10-0.7.11.php
+++ b/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.10-0.7.11.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.10-0.7.11.php
+++ b/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.10-0.7.11.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.10-0.7.11.php
+++ b/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.10-0.7.11.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.11-0.7.12.php
+++ b/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.11-0.7.12.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.11-0.7.12.php
+++ b/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.11-0.7.12.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.11-0.7.12.php
+++ b/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.11-0.7.12.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.12-0.7.13.php
+++ b/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.12-0.7.13.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.12-0.7.13.php
+++ b/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.12-0.7.13.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.12-0.7.13.php
+++ b/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.12-0.7.13.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.13-0.7.14.php
+++ b/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.13-0.7.14.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.13-0.7.14.php
+++ b/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.13-0.7.14.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.13-0.7.14.php
+++ b/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.13-0.7.14.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.14-0.7.15.php
+++ b/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.14-0.7.15.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.14-0.7.15.php
+++ b/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.14-0.7.15.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.14-0.7.15.php
+++ b/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.14-0.7.15.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.15-0.7.16.php
+++ b/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.15-0.7.16.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.15-0.7.16.php
+++ b/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.15-0.7.16.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.15-0.7.16.php
+++ b/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.15-0.7.16.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.2-0.7.3.php
+++ b/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.2-0.7.3.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.2-0.7.3.php
+++ b/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.2-0.7.3.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.2-0.7.3.php
+++ b/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.2-0.7.3.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.3-0.7.4.php
+++ b/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.3-0.7.4.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.3-0.7.4.php
+++ b/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.3-0.7.4.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.3-0.7.4.php
+++ b/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.3-0.7.4.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.4-0.7.5.php
+++ b/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.4-0.7.5.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.4-0.7.5.php
+++ b/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.4-0.7.5.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.4-0.7.5.php
+++ b/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.4-0.7.5.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.5-0.7.6.php
+++ b/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.5-0.7.6.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.5-0.7.6.php
+++ b/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.5-0.7.6.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.5-0.7.6.php
+++ b/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.5-0.7.6.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.6-0.7.7.php
+++ b/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.6-0.7.7.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.6-0.7.7.php
+++ b/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.6-0.7.7.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.6-0.7.7.php
+++ b/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.6-0.7.7.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.7-0.7.8.php
+++ b/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.7-0.7.8.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.7-0.7.8.php
+++ b/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.7-0.7.8.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.7-0.7.8.php
+++ b/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.7-0.7.8.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.8-0.7.9.php
+++ b/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.8-0.7.9.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.8-0.7.9.php
+++ b/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.8-0.7.9.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.8-0.7.9.php
+++ b/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.8-0.7.9.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.9-0.7.10.php
+++ b/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.9-0.7.10.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.9-0.7.10.php
+++ b/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.9-0.7.10.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.9-0.7.10.php
+++ b/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-0.7.9-0.7.10.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/Eav/sql/eav_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/sql/eav_setup/upgrade-1.6.0.0-1.6.0.1.php
+++ b/app/code/core/Mage/Eav/sql/eav_setup/upgrade-1.6.0.0-1.6.0.1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/Eav/sql/eav_setup/upgrade-1.6.0.0-1.6.0.1.php
+++ b/app/code/core/Mage/Eav/sql/eav_setup/upgrade-1.6.0.0-1.6.0.1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Eav/sql/eav_setup/upgrade-1.6.0.0-1.6.0.1.php
+++ b/app/code/core/Mage/Eav/sql/eav_setup/upgrade-1.6.0.0-1.6.0.1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/code/core/Mage/GiftMessage/Block/Adminhtml/Product/Helper/Form/Config.php
+++ b/app/code/core/Mage/GiftMessage/Block/Adminhtml/Product/Helper/Form/Config.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/GiftMessage/Block/Adminhtml/Product/Helper/Form/Config.php
+++ b/app/code/core/Mage/GiftMessage/Block/Adminhtml/Product/Helper/Form/Config.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_GiftMessage

--- a/app/code/core/Mage/GiftMessage/Block/Adminhtml/Product/Helper/Form/Config.php
+++ b/app/code/core/Mage/GiftMessage/Block/Adminhtml/Product/Helper/Form/Config.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_GiftMessage

--- a/app/code/core/Mage/GiftMessage/Block/Adminhtml/Sales/Order/Create/Form.php
+++ b/app/code/core/Mage/GiftMessage/Block/Adminhtml/Sales/Order/Create/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/GiftMessage/Block/Adminhtml/Sales/Order/Create/Form.php
+++ b/app/code/core/Mage/GiftMessage/Block/Adminhtml/Sales/Order/Create/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_GiftMessage

--- a/app/code/core/Mage/GiftMessage/Block/Adminhtml/Sales/Order/Create/Form.php
+++ b/app/code/core/Mage/GiftMessage/Block/Adminhtml/Sales/Order/Create/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_GiftMessage

--- a/app/code/core/Mage/GiftMessage/Block/Adminhtml/Sales/Order/Create/Giftoptions.php
+++ b/app/code/core/Mage/GiftMessage/Block/Adminhtml/Sales/Order/Create/Giftoptions.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/GiftMessage/Block/Adminhtml/Sales/Order/Create/Giftoptions.php
+++ b/app/code/core/Mage/GiftMessage/Block/Adminhtml/Sales/Order/Create/Giftoptions.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_GiftMessage

--- a/app/code/core/Mage/GiftMessage/Block/Adminhtml/Sales/Order/Create/Giftoptions.php
+++ b/app/code/core/Mage/GiftMessage/Block/Adminhtml/Sales/Order/Create/Giftoptions.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_GiftMessage

--- a/app/code/core/Mage/GiftMessage/Block/Adminhtml/Sales/Order/Create/Items.php
+++ b/app/code/core/Mage/GiftMessage/Block/Adminhtml/Sales/Order/Create/Items.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/GiftMessage/Block/Adminhtml/Sales/Order/Create/Items.php
+++ b/app/code/core/Mage/GiftMessage/Block/Adminhtml/Sales/Order/Create/Items.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_GiftMessage

--- a/app/code/core/Mage/GiftMessage/Block/Adminhtml/Sales/Order/Create/Items.php
+++ b/app/code/core/Mage/GiftMessage/Block/Adminhtml/Sales/Order/Create/Items.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_GiftMessage

--- a/app/code/core/Mage/GiftMessage/Block/Adminhtml/Sales/Order/View/Form.php
+++ b/app/code/core/Mage/GiftMessage/Block/Adminhtml/Sales/Order/View/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/GiftMessage/Block/Adminhtml/Sales/Order/View/Form.php
+++ b/app/code/core/Mage/GiftMessage/Block/Adminhtml/Sales/Order/View/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_GiftMessage

--- a/app/code/core/Mage/GiftMessage/Block/Adminhtml/Sales/Order/View/Form.php
+++ b/app/code/core/Mage/GiftMessage/Block/Adminhtml/Sales/Order/View/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_GiftMessage

--- a/app/code/core/Mage/GiftMessage/Block/Adminhtml/Sales/Order/View/Giftoptions.php
+++ b/app/code/core/Mage/GiftMessage/Block/Adminhtml/Sales/Order/View/Giftoptions.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/GiftMessage/Block/Adminhtml/Sales/Order/View/Giftoptions.php
+++ b/app/code/core/Mage/GiftMessage/Block/Adminhtml/Sales/Order/View/Giftoptions.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_GiftMessage

--- a/app/code/core/Mage/GiftMessage/Block/Adminhtml/Sales/Order/View/Giftoptions.php
+++ b/app/code/core/Mage/GiftMessage/Block/Adminhtml/Sales/Order/View/Giftoptions.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_GiftMessage

--- a/app/code/core/Mage/GiftMessage/Block/Adminhtml/Sales/Order/View/Items.php
+++ b/app/code/core/Mage/GiftMessage/Block/Adminhtml/Sales/Order/View/Items.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/GiftMessage/Block/Adminhtml/Sales/Order/View/Items.php
+++ b/app/code/core/Mage/GiftMessage/Block/Adminhtml/Sales/Order/View/Items.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_GiftMessage

--- a/app/code/core/Mage/GiftMessage/Block/Adminhtml/Sales/Order/View/Items.php
+++ b/app/code/core/Mage/GiftMessage/Block/Adminhtml/Sales/Order/View/Items.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_GiftMessage

--- a/app/code/core/Mage/GiftMessage/Block/Message/Form.php
+++ b/app/code/core/Mage/GiftMessage/Block/Message/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/GiftMessage/Block/Message/Form.php
+++ b/app/code/core/Mage/GiftMessage/Block/Message/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_GiftMessage

--- a/app/code/core/Mage/GiftMessage/Block/Message/Form.php
+++ b/app/code/core/Mage/GiftMessage/Block/Message/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_GiftMessage

--- a/app/code/core/Mage/GiftMessage/Block/Message/Helper.php
+++ b/app/code/core/Mage/GiftMessage/Block/Message/Helper.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/GiftMessage/Block/Message/Helper.php
+++ b/app/code/core/Mage/GiftMessage/Block/Message/Helper.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_GiftMessage

--- a/app/code/core/Mage/GiftMessage/Block/Message/Helper.php
+++ b/app/code/core/Mage/GiftMessage/Block/Message/Helper.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_GiftMessage

--- a/app/code/core/Mage/GiftMessage/Block/Message/Inline.php
+++ b/app/code/core/Mage/GiftMessage/Block/Message/Inline.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/GiftMessage/Block/Message/Inline.php
+++ b/app/code/core/Mage/GiftMessage/Block/Message/Inline.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_GiftMessage

--- a/app/code/core/Mage/GiftMessage/Block/Message/Inline.php
+++ b/app/code/core/Mage/GiftMessage/Block/Message/Inline.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_GiftMessage

--- a/app/code/core/Mage/GiftMessage/Helper/Data.php
+++ b/app/code/core/Mage/GiftMessage/Helper/Data.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/GiftMessage/Helper/Data.php
+++ b/app/code/core/Mage/GiftMessage/Helper/Data.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_GiftMessage

--- a/app/code/core/Mage/GiftMessage/Helper/Data.php
+++ b/app/code/core/Mage/GiftMessage/Helper/Data.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_GiftMessage

--- a/app/code/core/Mage/GiftMessage/Helper/Message.php
+++ b/app/code/core/Mage/GiftMessage/Helper/Message.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/GiftMessage/Helper/Message.php
+++ b/app/code/core/Mage/GiftMessage/Helper/Message.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_GiftMessage

--- a/app/code/core/Mage/GiftMessage/Helper/Message.php
+++ b/app/code/core/Mage/GiftMessage/Helper/Message.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_GiftMessage

--- a/app/code/core/Mage/GiftMessage/Helper/Url.php
+++ b/app/code/core/Mage/GiftMessage/Helper/Url.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/GiftMessage/Helper/Url.php
+++ b/app/code/core/Mage/GiftMessage/Helper/Url.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_GiftMessage

--- a/app/code/core/Mage/GiftMessage/Helper/Url.php
+++ b/app/code/core/Mage/GiftMessage/Helper/Url.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_GiftMessage

--- a/app/code/core/Mage/GiftMessage/Model/Api.php
+++ b/app/code/core/Mage/GiftMessage/Model/Api.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/GiftMessage/Model/Api.php
+++ b/app/code/core/Mage/GiftMessage/Model/Api.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_GiftMessage

--- a/app/code/core/Mage/GiftMessage/Model/Api.php
+++ b/app/code/core/Mage/GiftMessage/Model/Api.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_GiftMessage

--- a/app/code/core/Mage/GiftMessage/Model/Api/V2.php
+++ b/app/code/core/Mage/GiftMessage/Model/Api/V2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/GiftMessage/Model/Api/V2.php
+++ b/app/code/core/Mage/GiftMessage/Model/Api/V2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_GiftMessage

--- a/app/code/core/Mage/GiftMessage/Model/Api/V2.php
+++ b/app/code/core/Mage/GiftMessage/Model/Api/V2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_GiftMessage

--- a/app/code/core/Mage/GiftMessage/Model/Entity/Attribute/Backend/Boolean/Config.php
+++ b/app/code/core/Mage/GiftMessage/Model/Entity/Attribute/Backend/Boolean/Config.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/GiftMessage/Model/Entity/Attribute/Backend/Boolean/Config.php
+++ b/app/code/core/Mage/GiftMessage/Model/Entity/Attribute/Backend/Boolean/Config.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_GiftMessage

--- a/app/code/core/Mage/GiftMessage/Model/Entity/Attribute/Backend/Boolean/Config.php
+++ b/app/code/core/Mage/GiftMessage/Model/Entity/Attribute/Backend/Boolean/Config.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_GiftMessage

--- a/app/code/core/Mage/GiftMessage/Model/Entity/Attribute/Source/Boolean/Config.php
+++ b/app/code/core/Mage/GiftMessage/Model/Entity/Attribute/Source/Boolean/Config.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/GiftMessage/Model/Entity/Attribute/Source/Boolean/Config.php
+++ b/app/code/core/Mage/GiftMessage/Model/Entity/Attribute/Source/Boolean/Config.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_GiftMessage

--- a/app/code/core/Mage/GiftMessage/Model/Entity/Attribute/Source/Boolean/Config.php
+++ b/app/code/core/Mage/GiftMessage/Model/Entity/Attribute/Source/Boolean/Config.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_GiftMessage

--- a/app/code/core/Mage/GiftMessage/Model/Message.php
+++ b/app/code/core/Mage/GiftMessage/Model/Message.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/GiftMessage/Model/Message.php
+++ b/app/code/core/Mage/GiftMessage/Model/Message.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_GiftMessage

--- a/app/code/core/Mage/GiftMessage/Model/Message.php
+++ b/app/code/core/Mage/GiftMessage/Model/Message.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_GiftMessage

--- a/app/code/core/Mage/GiftMessage/Model/Mysql4/Message.php
+++ b/app/code/core/Mage/GiftMessage/Model/Mysql4/Message.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/GiftMessage/Model/Mysql4/Message.php
+++ b/app/code/core/Mage/GiftMessage/Model/Mysql4/Message.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_GiftMessage

--- a/app/code/core/Mage/GiftMessage/Model/Mysql4/Message.php
+++ b/app/code/core/Mage/GiftMessage/Model/Mysql4/Message.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_GiftMessage

--- a/app/code/core/Mage/GiftMessage/Model/Mysql4/Message/Collection.php
+++ b/app/code/core/Mage/GiftMessage/Model/Mysql4/Message/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/GiftMessage/Model/Mysql4/Message/Collection.php
+++ b/app/code/core/Mage/GiftMessage/Model/Mysql4/Message/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_GiftMessage

--- a/app/code/core/Mage/GiftMessage/Model/Mysql4/Message/Collection.php
+++ b/app/code/core/Mage/GiftMessage/Model/Mysql4/Message/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_GiftMessage

--- a/app/code/core/Mage/GiftMessage/Model/Mysql4/Setup.php
+++ b/app/code/core/Mage/GiftMessage/Model/Mysql4/Setup.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/GiftMessage/Model/Mysql4/Setup.php
+++ b/app/code/core/Mage/GiftMessage/Model/Mysql4/Setup.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_GiftMessage

--- a/app/code/core/Mage/GiftMessage/Model/Mysql4/Setup.php
+++ b/app/code/core/Mage/GiftMessage/Model/Mysql4/Setup.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_GiftMessage

--- a/app/code/core/Mage/GiftMessage/Model/Observer.php
+++ b/app/code/core/Mage/GiftMessage/Model/Observer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/GiftMessage/Model/Observer.php
+++ b/app/code/core/Mage/GiftMessage/Model/Observer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_GiftMessage

--- a/app/code/core/Mage/GiftMessage/Model/Observer.php
+++ b/app/code/core/Mage/GiftMessage/Model/Observer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_GiftMessage

--- a/app/code/core/Mage/GiftMessage/Model/Resource/Message.php
+++ b/app/code/core/Mage/GiftMessage/Model/Resource/Message.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/GiftMessage/Model/Resource/Message.php
+++ b/app/code/core/Mage/GiftMessage/Model/Resource/Message.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_GiftMessage

--- a/app/code/core/Mage/GiftMessage/Model/Resource/Message.php
+++ b/app/code/core/Mage/GiftMessage/Model/Resource/Message.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_GiftMessage

--- a/app/code/core/Mage/GiftMessage/Model/Resource/Message/Collection.php
+++ b/app/code/core/Mage/GiftMessage/Model/Resource/Message/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/GiftMessage/Model/Resource/Message/Collection.php
+++ b/app/code/core/Mage/GiftMessage/Model/Resource/Message/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_GiftMessage

--- a/app/code/core/Mage/GiftMessage/Model/Resource/Message/Collection.php
+++ b/app/code/core/Mage/GiftMessage/Model/Resource/Message/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_GiftMessage

--- a/app/code/core/Mage/GiftMessage/Model/Resource/Setup.php
+++ b/app/code/core/Mage/GiftMessage/Model/Resource/Setup.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/GiftMessage/Model/Resource/Setup.php
+++ b/app/code/core/Mage/GiftMessage/Model/Resource/Setup.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_GiftMessage

--- a/app/code/core/Mage/GiftMessage/Model/Resource/Setup.php
+++ b/app/code/core/Mage/GiftMessage/Model/Resource/Setup.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_GiftMessage

--- a/app/code/core/Mage/GiftMessage/controllers/IndexController.php
+++ b/app/code/core/Mage/GiftMessage/controllers/IndexController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/GiftMessage/controllers/IndexController.php
+++ b/app/code/core/Mage/GiftMessage/controllers/IndexController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_GiftMessage

--- a/app/code/core/Mage/GiftMessage/controllers/IndexController.php
+++ b/app/code/core/Mage/GiftMessage/controllers/IndexController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_GiftMessage

--- a/app/code/core/Mage/GiftMessage/etc/api.xml
+++ b/app/code/core/Mage/GiftMessage/etc/api.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_GiftMessage

--- a/app/code/core/Mage/GiftMessage/etc/api.xml
+++ b/app/code/core/Mage/GiftMessage/etc/api.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/GiftMessage/etc/api.xml
+++ b/app/code/core/Mage/GiftMessage/etc/api.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_GiftMessage

--- a/app/code/core/Mage/GiftMessage/etc/config.xml
+++ b/app/code/core/Mage/GiftMessage/etc/config.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_GiftMessage

--- a/app/code/core/Mage/GiftMessage/etc/config.xml
+++ b/app/code/core/Mage/GiftMessage/etc/config.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/GiftMessage/etc/config.xml
+++ b/app/code/core/Mage/GiftMessage/etc/config.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_GiftMessage

--- a/app/code/core/Mage/GiftMessage/etc/system.xml
+++ b/app/code/core/Mage/GiftMessage/etc/system.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_GiftMessage

--- a/app/code/core/Mage/GiftMessage/etc/system.xml
+++ b/app/code/core/Mage/GiftMessage/etc/system.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/GiftMessage/etc/system.xml
+++ b/app/code/core/Mage/GiftMessage/etc/system.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_GiftMessage

--- a/app/code/core/Mage/GiftMessage/sql/giftmessage_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/GiftMessage/sql/giftmessage_setup/install-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/GiftMessage/sql/giftmessage_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/GiftMessage/sql/giftmessage_setup/install-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_GiftMessage

--- a/app/code/core/Mage/GiftMessage/sql/giftmessage_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/GiftMessage/sql/giftmessage_setup/install-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_GiftMessage

--- a/app/code/core/Mage/GiftMessage/sql/giftmessage_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/GiftMessage/sql/giftmessage_setup/mysql4-install-0.7.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/GiftMessage/sql/giftmessage_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/GiftMessage/sql/giftmessage_setup/mysql4-install-0.7.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_GiftMessage

--- a/app/code/core/Mage/GiftMessage/sql/giftmessage_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/GiftMessage/sql/giftmessage_setup/mysql4-install-0.7.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_GiftMessage

--- a/app/code/core/Mage/GiftMessage/sql/giftmessage_setup/mysql4-upgrade-0.1.3-0.7.0.php
+++ b/app/code/core/Mage/GiftMessage/sql/giftmessage_setup/mysql4-upgrade-0.1.3-0.7.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/GiftMessage/sql/giftmessage_setup/mysql4-upgrade-0.1.3-0.7.0.php
+++ b/app/code/core/Mage/GiftMessage/sql/giftmessage_setup/mysql4-upgrade-0.1.3-0.7.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_GiftMessage

--- a/app/code/core/Mage/GiftMessage/sql/giftmessage_setup/mysql4-upgrade-0.1.3-0.7.0.php
+++ b/app/code/core/Mage/GiftMessage/sql/giftmessage_setup/mysql4-upgrade-0.1.3-0.7.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_GiftMessage

--- a/app/code/core/Mage/GiftMessage/sql/giftmessage_setup/mysql4-upgrade-0.7.0-0.7.1.php
+++ b/app/code/core/Mage/GiftMessage/sql/giftmessage_setup/mysql4-upgrade-0.7.0-0.7.1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/GiftMessage/sql/giftmessage_setup/mysql4-upgrade-0.7.0-0.7.1.php
+++ b/app/code/core/Mage/GiftMessage/sql/giftmessage_setup/mysql4-upgrade-0.7.0-0.7.1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_GiftMessage

--- a/app/code/core/Mage/GiftMessage/sql/giftmessage_setup/mysql4-upgrade-0.7.0-0.7.1.php
+++ b/app/code/core/Mage/GiftMessage/sql/giftmessage_setup/mysql4-upgrade-0.7.0-0.7.1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_GiftMessage

--- a/app/code/core/Mage/GiftMessage/sql/giftmessage_setup/mysql4-upgrade-0.7.1-0.7.2.php
+++ b/app/code/core/Mage/GiftMessage/sql/giftmessage_setup/mysql4-upgrade-0.7.1-0.7.2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/GiftMessage/sql/giftmessage_setup/mysql4-upgrade-0.7.1-0.7.2.php
+++ b/app/code/core/Mage/GiftMessage/sql/giftmessage_setup/mysql4-upgrade-0.7.1-0.7.2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_GiftMessage

--- a/app/code/core/Mage/GiftMessage/sql/giftmessage_setup/mysql4-upgrade-0.7.1-0.7.2.php
+++ b/app/code/core/Mage/GiftMessage/sql/giftmessage_setup/mysql4-upgrade-0.7.1-0.7.2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_GiftMessage

--- a/app/code/core/Mage/GiftMessage/sql/giftmessage_setup/mysql4-upgrade-0.7.2-0.7.3.php
+++ b/app/code/core/Mage/GiftMessage/sql/giftmessage_setup/mysql4-upgrade-0.7.2-0.7.3.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/GiftMessage/sql/giftmessage_setup/mysql4-upgrade-0.7.2-0.7.3.php
+++ b/app/code/core/Mage/GiftMessage/sql/giftmessage_setup/mysql4-upgrade-0.7.2-0.7.3.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_GiftMessage

--- a/app/code/core/Mage/GiftMessage/sql/giftmessage_setup/mysql4-upgrade-0.7.2-0.7.3.php
+++ b/app/code/core/Mage/GiftMessage/sql/giftmessage_setup/mysql4-upgrade-0.7.2-0.7.3.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_GiftMessage

--- a/app/code/core/Mage/GiftMessage/sql/giftmessage_setup/mysql4-upgrade-0.7.3-0.7.4.php
+++ b/app/code/core/Mage/GiftMessage/sql/giftmessage_setup/mysql4-upgrade-0.7.3-0.7.4.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/GiftMessage/sql/giftmessage_setup/mysql4-upgrade-0.7.3-0.7.4.php
+++ b/app/code/core/Mage/GiftMessage/sql/giftmessage_setup/mysql4-upgrade-0.7.3-0.7.4.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_GiftMessage

--- a/app/code/core/Mage/GiftMessage/sql/giftmessage_setup/mysql4-upgrade-0.7.3-0.7.4.php
+++ b/app/code/core/Mage/GiftMessage/sql/giftmessage_setup/mysql4-upgrade-0.7.3-0.7.4.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_GiftMessage

--- a/app/code/core/Mage/GiftMessage/sql/giftmessage_setup/mysql4-upgrade-0.7.4-0.7.5.php
+++ b/app/code/core/Mage/GiftMessage/sql/giftmessage_setup/mysql4-upgrade-0.7.4-0.7.5.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/GiftMessage/sql/giftmessage_setup/mysql4-upgrade-0.7.4-0.7.5.php
+++ b/app/code/core/Mage/GiftMessage/sql/giftmessage_setup/mysql4-upgrade-0.7.4-0.7.5.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_GiftMessage

--- a/app/code/core/Mage/GiftMessage/sql/giftmessage_setup/mysql4-upgrade-0.7.4-0.7.5.php
+++ b/app/code/core/Mage/GiftMessage/sql/giftmessage_setup/mysql4-upgrade-0.7.4-0.7.5.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_GiftMessage

--- a/app/code/core/Mage/GiftMessage/sql/giftmessage_setup/mysql4-upgrade-0.7.5-0.7.6.php
+++ b/app/code/core/Mage/GiftMessage/sql/giftmessage_setup/mysql4-upgrade-0.7.5-0.7.6.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/GiftMessage/sql/giftmessage_setup/mysql4-upgrade-0.7.5-0.7.6.php
+++ b/app/code/core/Mage/GiftMessage/sql/giftmessage_setup/mysql4-upgrade-0.7.5-0.7.6.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_GiftMessage

--- a/app/code/core/Mage/GiftMessage/sql/giftmessage_setup/mysql4-upgrade-0.7.5-0.7.6.php
+++ b/app/code/core/Mage/GiftMessage/sql/giftmessage_setup/mysql4-upgrade-0.7.5-0.7.6.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_GiftMessage

--- a/app/code/core/Mage/GiftMessage/sql/giftmessage_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/GiftMessage/sql/giftmessage_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/GiftMessage/sql/giftmessage_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/GiftMessage/sql/giftmessage_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_GiftMessage

--- a/app/code/core/Mage/GiftMessage/sql/giftmessage_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/GiftMessage/sql/giftmessage_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_GiftMessage

--- a/app/code/core/Mage/GoogleAnalytics/Block/Ga.php
+++ b/app/code/core/Mage/GoogleAnalytics/Block/Ga.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/GoogleAnalytics/Block/Ga.php
+++ b/app/code/core/Mage/GoogleAnalytics/Block/Ga.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_GoogleAnalytics

--- a/app/code/core/Mage/GoogleAnalytics/Block/Ga.php
+++ b/app/code/core/Mage/GoogleAnalytics/Block/Ga.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_GoogleAnalytics

--- a/app/code/core/Mage/GoogleAnalytics/Helper/Data.php
+++ b/app/code/core/Mage/GoogleAnalytics/Helper/Data.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/GoogleAnalytics/Helper/Data.php
+++ b/app/code/core/Mage/GoogleAnalytics/Helper/Data.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_GoogleAnalytics

--- a/app/code/core/Mage/GoogleAnalytics/Helper/Data.php
+++ b/app/code/core/Mage/GoogleAnalytics/Helper/Data.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_GoogleAnalytics

--- a/app/code/core/Mage/GoogleAnalytics/Model/Observer.php
+++ b/app/code/core/Mage/GoogleAnalytics/Model/Observer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/GoogleAnalytics/Model/Observer.php
+++ b/app/code/core/Mage/GoogleAnalytics/Model/Observer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_GoogleAnalytics

--- a/app/code/core/Mage/GoogleAnalytics/Model/Observer.php
+++ b/app/code/core/Mage/GoogleAnalytics/Model/Observer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_GoogleAnalytics

--- a/app/code/core/Mage/GoogleAnalytics/Model/System/Config/Source/Type.php
+++ b/app/code/core/Mage/GoogleAnalytics/Model/System/Config/Source/Type.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/GoogleAnalytics/Model/System/Config/Source/Type.php
+++ b/app/code/core/Mage/GoogleAnalytics/Model/System/Config/Source/Type.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_GoogleAnalytics

--- a/app/code/core/Mage/GoogleAnalytics/Model/System/Config/Source/Type.php
+++ b/app/code/core/Mage/GoogleAnalytics/Model/System/Config/Source/Type.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_GoogleAnalytics

--- a/app/code/core/Mage/GoogleAnalytics/etc/adminhtml.xml
+++ b/app/code/core/Mage/GoogleAnalytics/etc/adminhtml.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_GoogleAnalytics

--- a/app/code/core/Mage/GoogleAnalytics/etc/adminhtml.xml
+++ b/app/code/core/Mage/GoogleAnalytics/etc/adminhtml.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_GoogleAnalytics

--- a/app/code/core/Mage/GoogleAnalytics/etc/adminhtml.xml
+++ b/app/code/core/Mage/GoogleAnalytics/etc/adminhtml.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/GoogleAnalytics/etc/config.xml
+++ b/app/code/core/Mage/GoogleAnalytics/etc/config.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_GoogleAnalytics

--- a/app/code/core/Mage/GoogleAnalytics/etc/config.xml
+++ b/app/code/core/Mage/GoogleAnalytics/etc/config.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_GoogleAnalytics

--- a/app/code/core/Mage/GoogleAnalytics/etc/config.xml
+++ b/app/code/core/Mage/GoogleAnalytics/etc/config.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/GoogleAnalytics/etc/system.xml
+++ b/app/code/core/Mage/GoogleAnalytics/etc/system.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_GoogleAnalytics

--- a/app/code/core/Mage/GoogleAnalytics/etc/system.xml
+++ b/app/code/core/Mage/GoogleAnalytics/etc/system.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_GoogleAnalytics

--- a/app/code/core/Mage/GoogleAnalytics/etc/system.xml
+++ b/app/code/core/Mage/GoogleAnalytics/etc/system.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/GoogleAnalytics/sql/googleanalytics_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/GoogleAnalytics/sql/googleanalytics_setup/install-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/GoogleAnalytics/sql/googleanalytics_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/GoogleAnalytics/sql/googleanalytics_setup/install-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_GoogleAnalytics

--- a/app/code/core/Mage/GoogleAnalytics/sql/googleanalytics_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/GoogleAnalytics/sql/googleanalytics_setup/install-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_GoogleAnalytics

--- a/app/code/core/Mage/GoogleCheckout/Model/Payment.php
+++ b/app/code/core/Mage/GoogleCheckout/Model/Payment.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/GoogleCheckout/Model/Payment.php
+++ b/app/code/core/Mage/GoogleCheckout/Model/Payment.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_GoogleCheckout

--- a/app/code/core/Mage/GoogleCheckout/Model/Payment.php
+++ b/app/code/core/Mage/GoogleCheckout/Model/Payment.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_GoogleCheckout

--- a/app/code/core/Mage/GoogleCheckout/etc/config.xml
+++ b/app/code/core/Mage/GoogleCheckout/etc/config.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_GoogleCheckout

--- a/app/code/core/Mage/GoogleCheckout/etc/config.xml
+++ b/app/code/core/Mage/GoogleCheckout/etc/config.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_GoogleCheckout

--- a/app/code/core/Mage/GoogleCheckout/etc/config.xml
+++ b/app/code/core/Mage/GoogleCheckout/etc/config.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ImportExport/Block/Adminhtml/Export/Edit.php
+++ b/app/code/core/Mage/ImportExport/Block/Adminhtml/Export/Edit.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ImportExport/Block/Adminhtml/Export/Edit.php
+++ b/app/code/core/Mage/ImportExport/Block/Adminhtml/Export/Edit.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/Block/Adminhtml/Export/Edit.php
+++ b/app/code/core/Mage/ImportExport/Block/Adminhtml/Export/Edit.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/Block/Adminhtml/Export/Edit/Form.php
+++ b/app/code/core/Mage/ImportExport/Block/Adminhtml/Export/Edit/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ImportExport/Block/Adminhtml/Export/Edit/Form.php
+++ b/app/code/core/Mage/ImportExport/Block/Adminhtml/Export/Edit/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/Block/Adminhtml/Export/Edit/Form.php
+++ b/app/code/core/Mage/ImportExport/Block/Adminhtml/Export/Edit/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/Block/Adminhtml/Export/Filter.php
+++ b/app/code/core/Mage/ImportExport/Block/Adminhtml/Export/Filter.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ImportExport/Block/Adminhtml/Export/Filter.php
+++ b/app/code/core/Mage/ImportExport/Block/Adminhtml/Export/Filter.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/Block/Adminhtml/Export/Filter.php
+++ b/app/code/core/Mage/ImportExport/Block/Adminhtml/Export/Filter.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/Block/Adminhtml/Import/Edit.php
+++ b/app/code/core/Mage/ImportExport/Block/Adminhtml/Import/Edit.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ImportExport/Block/Adminhtml/Import/Edit.php
+++ b/app/code/core/Mage/ImportExport/Block/Adminhtml/Import/Edit.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/Block/Adminhtml/Import/Edit.php
+++ b/app/code/core/Mage/ImportExport/Block/Adminhtml/Import/Edit.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/Block/Adminhtml/Import/Edit/Form.php
+++ b/app/code/core/Mage/ImportExport/Block/Adminhtml/Import/Edit/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ImportExport/Block/Adminhtml/Import/Edit/Form.php
+++ b/app/code/core/Mage/ImportExport/Block/Adminhtml/Import/Edit/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/Block/Adminhtml/Import/Edit/Form.php
+++ b/app/code/core/Mage/ImportExport/Block/Adminhtml/Import/Edit/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/Block/Adminhtml/Import/Frame/Result.php
+++ b/app/code/core/Mage/ImportExport/Block/Adminhtml/Import/Frame/Result.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ImportExport/Block/Adminhtml/Import/Frame/Result.php
+++ b/app/code/core/Mage/ImportExport/Block/Adminhtml/Import/Frame/Result.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/Block/Adminhtml/Import/Frame/Result.php
+++ b/app/code/core/Mage/ImportExport/Block/Adminhtml/Import/Frame/Result.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/Helper/Data.php
+++ b/app/code/core/Mage/ImportExport/Helper/Data.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ImportExport/Helper/Data.php
+++ b/app/code/core/Mage/ImportExport/Helper/Data.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/Helper/Data.php
+++ b/app/code/core/Mage/ImportExport/Helper/Data.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/Model/Abstract.php
+++ b/app/code/core/Mage/ImportExport/Model/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ImportExport/Model/Abstract.php
+++ b/app/code/core/Mage/ImportExport/Model/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/Model/Abstract.php
+++ b/app/code/core/Mage/ImportExport/Model/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/Model/Config.php
+++ b/app/code/core/Mage/ImportExport/Model/Config.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ImportExport/Model/Config.php
+++ b/app/code/core/Mage/ImportExport/Model/Config.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/Model/Config.php
+++ b/app/code/core/Mage/ImportExport/Model/Config.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/Model/Export.php
+++ b/app/code/core/Mage/ImportExport/Model/Export.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ImportExport/Model/Export.php
+++ b/app/code/core/Mage/ImportExport/Model/Export.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/Model/Export.php
+++ b/app/code/core/Mage/ImportExport/Model/Export.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/Model/Export/Adapter/Abstract.php
+++ b/app/code/core/Mage/ImportExport/Model/Export/Adapter/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ImportExport/Model/Export/Adapter/Abstract.php
+++ b/app/code/core/Mage/ImportExport/Model/Export/Adapter/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/Model/Export/Adapter/Abstract.php
+++ b/app/code/core/Mage/ImportExport/Model/Export/Adapter/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/Model/Export/Adapter/Csv.php
+++ b/app/code/core/Mage/ImportExport/Model/Export/Adapter/Csv.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ImportExport/Model/Export/Adapter/Csv.php
+++ b/app/code/core/Mage/ImportExport/Model/Export/Adapter/Csv.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/Model/Export/Adapter/Csv.php
+++ b/app/code/core/Mage/ImportExport/Model/Export/Adapter/Csv.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/Model/Export/Entity/Abstract.php
+++ b/app/code/core/Mage/ImportExport/Model/Export/Entity/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ImportExport/Model/Export/Entity/Abstract.php
+++ b/app/code/core/Mage/ImportExport/Model/Export/Entity/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/Model/Export/Entity/Abstract.php
+++ b/app/code/core/Mage/ImportExport/Model/Export/Entity/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/Model/Export/Entity/Customer.php
+++ b/app/code/core/Mage/ImportExport/Model/Export/Entity/Customer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ImportExport/Model/Export/Entity/Customer.php
+++ b/app/code/core/Mage/ImportExport/Model/Export/Entity/Customer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/Model/Export/Entity/Customer.php
+++ b/app/code/core/Mage/ImportExport/Model/Export/Entity/Customer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/Model/Export/Entity/Product.php
+++ b/app/code/core/Mage/ImportExport/Model/Export/Entity/Product.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ImportExport/Model/Export/Entity/Product.php
+++ b/app/code/core/Mage/ImportExport/Model/Export/Entity/Product.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/Model/Export/Entity/Product.php
+++ b/app/code/core/Mage/ImportExport/Model/Export/Entity/Product.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/Model/Export/Entity/Product/Type/Abstract.php
+++ b/app/code/core/Mage/ImportExport/Model/Export/Entity/Product/Type/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ImportExport/Model/Export/Entity/Product/Type/Abstract.php
+++ b/app/code/core/Mage/ImportExport/Model/Export/Entity/Product/Type/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/Model/Export/Entity/Product/Type/Abstract.php
+++ b/app/code/core/Mage/ImportExport/Model/Export/Entity/Product/Type/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/Model/Export/Entity/Product/Type/Configurable.php
+++ b/app/code/core/Mage/ImportExport/Model/Export/Entity/Product/Type/Configurable.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ImportExport/Model/Export/Entity/Product/Type/Configurable.php
+++ b/app/code/core/Mage/ImportExport/Model/Export/Entity/Product/Type/Configurable.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/Model/Export/Entity/Product/Type/Configurable.php
+++ b/app/code/core/Mage/ImportExport/Model/Export/Entity/Product/Type/Configurable.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/Model/Export/Entity/Product/Type/Grouped.php
+++ b/app/code/core/Mage/ImportExport/Model/Export/Entity/Product/Type/Grouped.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ImportExport/Model/Export/Entity/Product/Type/Grouped.php
+++ b/app/code/core/Mage/ImportExport/Model/Export/Entity/Product/Type/Grouped.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/Model/Export/Entity/Product/Type/Grouped.php
+++ b/app/code/core/Mage/ImportExport/Model/Export/Entity/Product/Type/Grouped.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/Model/Export/Entity/Product/Type/Simple.php
+++ b/app/code/core/Mage/ImportExport/Model/Export/Entity/Product/Type/Simple.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ImportExport/Model/Export/Entity/Product/Type/Simple.php
+++ b/app/code/core/Mage/ImportExport/Model/Export/Entity/Product/Type/Simple.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/Model/Export/Entity/Product/Type/Simple.php
+++ b/app/code/core/Mage/ImportExport/Model/Export/Entity/Product/Type/Simple.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/Model/Import.php
+++ b/app/code/core/Mage/ImportExport/Model/Import.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ImportExport/Model/Import.php
+++ b/app/code/core/Mage/ImportExport/Model/Import.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/Model/Import.php
+++ b/app/code/core/Mage/ImportExport/Model/Import.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/Model/Import/Adapter.php
+++ b/app/code/core/Mage/ImportExport/Model/Import/Adapter.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ImportExport/Model/Import/Adapter.php
+++ b/app/code/core/Mage/ImportExport/Model/Import/Adapter.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/Model/Import/Adapter.php
+++ b/app/code/core/Mage/ImportExport/Model/Import/Adapter.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/Model/Import/Adapter/Abstract.php
+++ b/app/code/core/Mage/ImportExport/Model/Import/Adapter/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ImportExport/Model/Import/Adapter/Abstract.php
+++ b/app/code/core/Mage/ImportExport/Model/Import/Adapter/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/Model/Import/Adapter/Abstract.php
+++ b/app/code/core/Mage/ImportExport/Model/Import/Adapter/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/Model/Import/Adapter/Csv.php
+++ b/app/code/core/Mage/ImportExport/Model/Import/Adapter/Csv.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ImportExport/Model/Import/Adapter/Csv.php
+++ b/app/code/core/Mage/ImportExport/Model/Import/Adapter/Csv.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/Model/Import/Adapter/Csv.php
+++ b/app/code/core/Mage/ImportExport/Model/Import/Adapter/Csv.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/Model/Import/Entity/Abstract.php
+++ b/app/code/core/Mage/ImportExport/Model/Import/Entity/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ImportExport/Model/Import/Entity/Abstract.php
+++ b/app/code/core/Mage/ImportExport/Model/Import/Entity/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/Model/Import/Entity/Abstract.php
+++ b/app/code/core/Mage/ImportExport/Model/Import/Entity/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/Model/Import/Entity/Customer.php
+++ b/app/code/core/Mage/ImportExport/Model/Import/Entity/Customer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ImportExport/Model/Import/Entity/Customer.php
+++ b/app/code/core/Mage/ImportExport/Model/Import/Entity/Customer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/Model/Import/Entity/Customer.php
+++ b/app/code/core/Mage/ImportExport/Model/Import/Entity/Customer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/Model/Import/Entity/Customer/Address.php
+++ b/app/code/core/Mage/ImportExport/Model/Import/Entity/Customer/Address.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ImportExport/Model/Import/Entity/Customer/Address.php
+++ b/app/code/core/Mage/ImportExport/Model/Import/Entity/Customer/Address.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/Model/Import/Entity/Customer/Address.php
+++ b/app/code/core/Mage/ImportExport/Model/Import/Entity/Customer/Address.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/Model/Import/Entity/Product.php
+++ b/app/code/core/Mage/ImportExport/Model/Import/Entity/Product.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ImportExport/Model/Import/Entity/Product.php
+++ b/app/code/core/Mage/ImportExport/Model/Import/Entity/Product.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/Model/Import/Entity/Product.php
+++ b/app/code/core/Mage/ImportExport/Model/Import/Entity/Product.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/Model/Import/Entity/Product/Type/Abstract.php
+++ b/app/code/core/Mage/ImportExport/Model/Import/Entity/Product/Type/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ImportExport/Model/Import/Entity/Product/Type/Abstract.php
+++ b/app/code/core/Mage/ImportExport/Model/Import/Entity/Product/Type/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/Model/Import/Entity/Product/Type/Abstract.php
+++ b/app/code/core/Mage/ImportExport/Model/Import/Entity/Product/Type/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/Model/Import/Entity/Product/Type/Configurable.php
+++ b/app/code/core/Mage/ImportExport/Model/Import/Entity/Product/Type/Configurable.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ImportExport/Model/Import/Entity/Product/Type/Configurable.php
+++ b/app/code/core/Mage/ImportExport/Model/Import/Entity/Product/Type/Configurable.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/Model/Import/Entity/Product/Type/Configurable.php
+++ b/app/code/core/Mage/ImportExport/Model/Import/Entity/Product/Type/Configurable.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/Model/Import/Entity/Product/Type/Grouped.php
+++ b/app/code/core/Mage/ImportExport/Model/Import/Entity/Product/Type/Grouped.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ImportExport/Model/Import/Entity/Product/Type/Grouped.php
+++ b/app/code/core/Mage/ImportExport/Model/Import/Entity/Product/Type/Grouped.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/Model/Import/Entity/Product/Type/Grouped.php
+++ b/app/code/core/Mage/ImportExport/Model/Import/Entity/Product/Type/Grouped.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/Model/Import/Entity/Product/Type/Simple.php
+++ b/app/code/core/Mage/ImportExport/Model/Import/Entity/Product/Type/Simple.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ImportExport/Model/Import/Entity/Product/Type/Simple.php
+++ b/app/code/core/Mage/ImportExport/Model/Import/Entity/Product/Type/Simple.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/Model/Import/Entity/Product/Type/Simple.php
+++ b/app/code/core/Mage/ImportExport/Model/Import/Entity/Product/Type/Simple.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/Model/Import/Proxy/Product.php
+++ b/app/code/core/Mage/ImportExport/Model/Import/Proxy/Product.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ImportExport/Model/Import/Proxy/Product.php
+++ b/app/code/core/Mage/ImportExport/Model/Import/Proxy/Product.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/Model/Import/Proxy/Product.php
+++ b/app/code/core/Mage/ImportExport/Model/Import/Proxy/Product.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/Model/Import/Proxy/Product/Resource.php
+++ b/app/code/core/Mage/ImportExport/Model/Import/Proxy/Product/Resource.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ImportExport/Model/Import/Proxy/Product/Resource.php
+++ b/app/code/core/Mage/ImportExport/Model/Import/Proxy/Product/Resource.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/Model/Import/Proxy/Product/Resource.php
+++ b/app/code/core/Mage/ImportExport/Model/Import/Proxy/Product/Resource.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/Model/Import/Uploader.php
+++ b/app/code/core/Mage/ImportExport/Model/Import/Uploader.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ImportExport/Model/Import/Uploader.php
+++ b/app/code/core/Mage/ImportExport/Model/Import/Uploader.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/Model/Import/Uploader.php
+++ b/app/code/core/Mage/ImportExport/Model/Import/Uploader.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/Model/Mysql4/Import/Data.php
+++ b/app/code/core/Mage/ImportExport/Model/Mysql4/Import/Data.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ImportExport/Model/Mysql4/Import/Data.php
+++ b/app/code/core/Mage/ImportExport/Model/Mysql4/Import/Data.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/Model/Mysql4/Import/Data.php
+++ b/app/code/core/Mage/ImportExport/Model/Mysql4/Import/Data.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/Model/Mysql4/Setup.php
+++ b/app/code/core/Mage/ImportExport/Model/Mysql4/Setup.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ImportExport/Model/Mysql4/Setup.php
+++ b/app/code/core/Mage/ImportExport/Model/Mysql4/Setup.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/Model/Mysql4/Setup.php
+++ b/app/code/core/Mage/ImportExport/Model/Mysql4/Setup.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/Model/Product/Attribute/Backend/Urlkey.php
+++ b/app/code/core/Mage/ImportExport/Model/Product/Attribute/Backend/Urlkey.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ImportExport/Model/Product/Attribute/Backend/Urlkey.php
+++ b/app/code/core/Mage/ImportExport/Model/Product/Attribute/Backend/Urlkey.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/Model/Product/Attribute/Backend/Urlkey.php
+++ b/app/code/core/Mage/ImportExport/Model/Product/Attribute/Backend/Urlkey.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/Model/Resource/Helper/Mysql4.php
+++ b/app/code/core/Mage/ImportExport/Model/Resource/Helper/Mysql4.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ImportExport/Model/Resource/Helper/Mysql4.php
+++ b/app/code/core/Mage/ImportExport/Model/Resource/Helper/Mysql4.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/Model/Resource/Helper/Mysql4.php
+++ b/app/code/core/Mage/ImportExport/Model/Resource/Helper/Mysql4.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/Model/Resource/Import/Data.php
+++ b/app/code/core/Mage/ImportExport/Model/Resource/Import/Data.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ImportExport/Model/Resource/Import/Data.php
+++ b/app/code/core/Mage/ImportExport/Model/Resource/Import/Data.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/Model/Resource/Import/Data.php
+++ b/app/code/core/Mage/ImportExport/Model/Resource/Import/Data.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/Model/Resource/Setup.php
+++ b/app/code/core/Mage/ImportExport/Model/Resource/Setup.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ImportExport/Model/Resource/Setup.php
+++ b/app/code/core/Mage/ImportExport/Model/Resource/Setup.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/Model/Resource/Setup.php
+++ b/app/code/core/Mage/ImportExport/Model/Resource/Setup.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/Model/Source/Export/Entity.php
+++ b/app/code/core/Mage/ImportExport/Model/Source/Export/Entity.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ImportExport/Model/Source/Export/Entity.php
+++ b/app/code/core/Mage/ImportExport/Model/Source/Export/Entity.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/Model/Source/Export/Entity.php
+++ b/app/code/core/Mage/ImportExport/Model/Source/Export/Entity.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/Model/Source/Export/Format.php
+++ b/app/code/core/Mage/ImportExport/Model/Source/Export/Format.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ImportExport/Model/Source/Export/Format.php
+++ b/app/code/core/Mage/ImportExport/Model/Source/Export/Format.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/Model/Source/Export/Format.php
+++ b/app/code/core/Mage/ImportExport/Model/Source/Export/Format.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/Model/Source/Import/Behavior.php
+++ b/app/code/core/Mage/ImportExport/Model/Source/Import/Behavior.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ImportExport/Model/Source/Import/Behavior.php
+++ b/app/code/core/Mage/ImportExport/Model/Source/Import/Behavior.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/Model/Source/Import/Behavior.php
+++ b/app/code/core/Mage/ImportExport/Model/Source/Import/Behavior.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/Model/Source/Import/Entity.php
+++ b/app/code/core/Mage/ImportExport/Model/Source/Import/Entity.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ImportExport/Model/Source/Import/Entity.php
+++ b/app/code/core/Mage/ImportExport/Model/Source/Import/Entity.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/Model/Source/Import/Entity.php
+++ b/app/code/core/Mage/ImportExport/Model/Source/Import/Entity.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/controllers/Adminhtml/ExportController.php
+++ b/app/code/core/Mage/ImportExport/controllers/Adminhtml/ExportController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ImportExport/controllers/Adminhtml/ExportController.php
+++ b/app/code/core/Mage/ImportExport/controllers/Adminhtml/ExportController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/controllers/Adminhtml/ExportController.php
+++ b/app/code/core/Mage/ImportExport/controllers/Adminhtml/ExportController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/controllers/Adminhtml/ImportController.php
+++ b/app/code/core/Mage/ImportExport/controllers/Adminhtml/ImportController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ImportExport/controllers/Adminhtml/ImportController.php
+++ b/app/code/core/Mage/ImportExport/controllers/Adminhtml/ImportController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/controllers/Adminhtml/ImportController.php
+++ b/app/code/core/Mage/ImportExport/controllers/Adminhtml/ImportController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/etc/adminhtml.xml
+++ b/app/code/core/Mage/ImportExport/etc/adminhtml.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/etc/adminhtml.xml
+++ b/app/code/core/Mage/ImportExport/etc/adminhtml.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/etc/adminhtml.xml
+++ b/app/code/core/Mage/ImportExport/etc/adminhtml.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ImportExport/etc/config.xml
+++ b/app/code/core/Mage/ImportExport/etc/config.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/etc/config.xml
+++ b/app/code/core/Mage/ImportExport/etc/config.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/etc/config.xml
+++ b/app/code/core/Mage/ImportExport/etc/config.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ImportExport/etc/system.xml
+++ b/app/code/core/Mage/ImportExport/etc/system.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/etc/system.xml
+++ b/app/code/core/Mage/ImportExport/etc/system.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/etc/system.xml
+++ b/app/code/core/Mage/ImportExport/etc/system.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ImportExport/sql/importexport_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/ImportExport/sql/importexport_setup/install-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ImportExport/sql/importexport_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/ImportExport/sql/importexport_setup/install-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/sql/importexport_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/ImportExport/sql/importexport_setup/install-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/sql/importexport_setup/mysql4-install-0.1.0.php
+++ b/app/code/core/Mage/ImportExport/sql/importexport_setup/mysql4-install-0.1.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ImportExport/sql/importexport_setup/mysql4-install-0.1.0.php
+++ b/app/code/core/Mage/ImportExport/sql/importexport_setup/mysql4-install-0.1.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/sql/importexport_setup/mysql4-install-0.1.0.php
+++ b/app/code/core/Mage/ImportExport/sql/importexport_setup/mysql4-install-0.1.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/sql/importexport_setup/mysql4-upgrade-1.6.0.1-1.6.0.2.php
+++ b/app/code/core/Mage/ImportExport/sql/importexport_setup/mysql4-upgrade-1.6.0.1-1.6.0.2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ImportExport/sql/importexport_setup/mysql4-upgrade-1.6.0.1-1.6.0.2.php
+++ b/app/code/core/Mage/ImportExport/sql/importexport_setup/mysql4-upgrade-1.6.0.1-1.6.0.2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/ImportExport/sql/importexport_setup/mysql4-upgrade-1.6.0.1-1.6.0.2.php
+++ b/app/code/core/Mage/ImportExport/sql/importexport_setup/mysql4-upgrade-1.6.0.1-1.6.0.2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/code/core/Mage/Index/Block/Adminhtml/Notifications.php
+++ b/app/code/core/Mage/Index/Block/Adminhtml/Notifications.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Index

--- a/app/code/core/Mage/Index/Block/Adminhtml/Notifications.php
+++ b/app/code/core/Mage/Index/Block/Adminhtml/Notifications.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Index/Block/Adminhtml/Notifications.php
+++ b/app/code/core/Mage/Index/Block/Adminhtml/Notifications.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Index

--- a/app/code/core/Mage/Index/Block/Adminhtml/Process.php
+++ b/app/code/core/Mage/Index/Block/Adminhtml/Process.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Index

--- a/app/code/core/Mage/Index/Block/Adminhtml/Process.php
+++ b/app/code/core/Mage/Index/Block/Adminhtml/Process.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Index/Block/Adminhtml/Process.php
+++ b/app/code/core/Mage/Index/Block/Adminhtml/Process.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Index

--- a/app/code/core/Mage/Index/Block/Adminhtml/Process/Edit.php
+++ b/app/code/core/Mage/Index/Block/Adminhtml/Process/Edit.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Index

--- a/app/code/core/Mage/Index/Block/Adminhtml/Process/Edit.php
+++ b/app/code/core/Mage/Index/Block/Adminhtml/Process/Edit.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Index/Block/Adminhtml/Process/Edit.php
+++ b/app/code/core/Mage/Index/Block/Adminhtml/Process/Edit.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Index

--- a/app/code/core/Mage/Index/Block/Adminhtml/Process/Edit/Form.php
+++ b/app/code/core/Mage/Index/Block/Adminhtml/Process/Edit/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Index

--- a/app/code/core/Mage/Index/Block/Adminhtml/Process/Edit/Form.php
+++ b/app/code/core/Mage/Index/Block/Adminhtml/Process/Edit/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Index/Block/Adminhtml/Process/Edit/Form.php
+++ b/app/code/core/Mage/Index/Block/Adminhtml/Process/Edit/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Index

--- a/app/code/core/Mage/Index/Block/Adminhtml/Process/Edit/Tab/Main.php
+++ b/app/code/core/Mage/Index/Block/Adminhtml/Process/Edit/Tab/Main.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Index

--- a/app/code/core/Mage/Index/Block/Adminhtml/Process/Edit/Tab/Main.php
+++ b/app/code/core/Mage/Index/Block/Adminhtml/Process/Edit/Tab/Main.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Index/Block/Adminhtml/Process/Edit/Tab/Main.php
+++ b/app/code/core/Mage/Index/Block/Adminhtml/Process/Edit/Tab/Main.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Index

--- a/app/code/core/Mage/Index/Block/Adminhtml/Process/Edit/Tabs.php
+++ b/app/code/core/Mage/Index/Block/Adminhtml/Process/Edit/Tabs.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Index

--- a/app/code/core/Mage/Index/Block/Adminhtml/Process/Edit/Tabs.php
+++ b/app/code/core/Mage/Index/Block/Adminhtml/Process/Edit/Tabs.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Index/Block/Adminhtml/Process/Edit/Tabs.php
+++ b/app/code/core/Mage/Index/Block/Adminhtml/Process/Edit/Tabs.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Index

--- a/app/code/core/Mage/Index/Block/Adminhtml/Process/Grid.php
+++ b/app/code/core/Mage/Index/Block/Adminhtml/Process/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Index

--- a/app/code/core/Mage/Index/Block/Adminhtml/Process/Grid.php
+++ b/app/code/core/Mage/Index/Block/Adminhtml/Process/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Index/Block/Adminhtml/Process/Grid.php
+++ b/app/code/core/Mage/Index/Block/Adminhtml/Process/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Index

--- a/app/code/core/Mage/Index/Block/Adminhtml/Process/Grid/Massaction.php
+++ b/app/code/core/Mage/Index/Block/Adminhtml/Process/Grid/Massaction.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Index

--- a/app/code/core/Mage/Index/Block/Adminhtml/Process/Grid/Massaction.php
+++ b/app/code/core/Mage/Index/Block/Adminhtml/Process/Grid/Massaction.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Index/Block/Adminhtml/Process/Grid/Massaction.php
+++ b/app/code/core/Mage/Index/Block/Adminhtml/Process/Grid/Massaction.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Index

--- a/app/code/core/Mage/Index/Exception.php
+++ b/app/code/core/Mage/Index/Exception.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Index

--- a/app/code/core/Mage/Index/Exception.php
+++ b/app/code/core/Mage/Index/Exception.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Index/Exception.php
+++ b/app/code/core/Mage/Index/Exception.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Index

--- a/app/code/core/Mage/Index/Helper/Data.php
+++ b/app/code/core/Mage/Index/Helper/Data.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Index

--- a/app/code/core/Mage/Index/Helper/Data.php
+++ b/app/code/core/Mage/Index/Helper/Data.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Index/Helper/Data.php
+++ b/app/code/core/Mage/Index/Helper/Data.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Index

--- a/app/code/core/Mage/Index/Model/Event.php
+++ b/app/code/core/Mage/Index/Model/Event.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Index

--- a/app/code/core/Mage/Index/Model/Event.php
+++ b/app/code/core/Mage/Index/Model/Event.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Index/Model/Event.php
+++ b/app/code/core/Mage/Index/Model/Event.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Index

--- a/app/code/core/Mage/Index/Model/Indexer.php
+++ b/app/code/core/Mage/Index/Model/Indexer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Index

--- a/app/code/core/Mage/Index/Model/Indexer.php
+++ b/app/code/core/Mage/Index/Model/Indexer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Index/Model/Indexer.php
+++ b/app/code/core/Mage/Index/Model/Indexer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Index

--- a/app/code/core/Mage/Index/Model/Indexer/Abstract.php
+++ b/app/code/core/Mage/Index/Model/Indexer/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Index

--- a/app/code/core/Mage/Index/Model/Indexer/Abstract.php
+++ b/app/code/core/Mage/Index/Model/Indexer/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Index/Model/Indexer/Abstract.php
+++ b/app/code/core/Mage/Index/Model/Indexer/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Index

--- a/app/code/core/Mage/Index/Model/Lock.php
+++ b/app/code/core/Mage/Index/Model/Lock.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Index

--- a/app/code/core/Mage/Index/Model/Lock.php
+++ b/app/code/core/Mage/Index/Model/Lock.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Index/Model/Lock.php
+++ b/app/code/core/Mage/Index/Model/Lock.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Index

--- a/app/code/core/Mage/Index/Model/Lock/Storage/Db.php
+++ b/app/code/core/Mage/Index/Model/Lock/Storage/Db.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Index

--- a/app/code/core/Mage/Index/Model/Lock/Storage/Db.php
+++ b/app/code/core/Mage/Index/Model/Lock/Storage/Db.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Index/Model/Lock/Storage/Db.php
+++ b/app/code/core/Mage/Index/Model/Lock/Storage/Db.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Index

--- a/app/code/core/Mage/Index/Model/Lock/Storage/Interface.php
+++ b/app/code/core/Mage/Index/Model/Lock/Storage/Interface.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Index

--- a/app/code/core/Mage/Index/Model/Lock/Storage/Interface.php
+++ b/app/code/core/Mage/Index/Model/Lock/Storage/Interface.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Index/Model/Lock/Storage/Interface.php
+++ b/app/code/core/Mage/Index/Model/Lock/Storage/Interface.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Index

--- a/app/code/core/Mage/Index/Model/Mysql4/Abstract.php
+++ b/app/code/core/Mage/Index/Model/Mysql4/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Index

--- a/app/code/core/Mage/Index/Model/Mysql4/Abstract.php
+++ b/app/code/core/Mage/Index/Model/Mysql4/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Index/Model/Mysql4/Abstract.php
+++ b/app/code/core/Mage/Index/Model/Mysql4/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Index

--- a/app/code/core/Mage/Index/Model/Mysql4/Event.php
+++ b/app/code/core/Mage/Index/Model/Mysql4/Event.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Index

--- a/app/code/core/Mage/Index/Model/Mysql4/Event.php
+++ b/app/code/core/Mage/Index/Model/Mysql4/Event.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Index/Model/Mysql4/Event.php
+++ b/app/code/core/Mage/Index/Model/Mysql4/Event.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Index

--- a/app/code/core/Mage/Index/Model/Mysql4/Event/Collection.php
+++ b/app/code/core/Mage/Index/Model/Mysql4/Event/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Index

--- a/app/code/core/Mage/Index/Model/Mysql4/Event/Collection.php
+++ b/app/code/core/Mage/Index/Model/Mysql4/Event/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Index/Model/Mysql4/Event/Collection.php
+++ b/app/code/core/Mage/Index/Model/Mysql4/Event/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Index

--- a/app/code/core/Mage/Index/Model/Mysql4/Process.php
+++ b/app/code/core/Mage/Index/Model/Mysql4/Process.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Index

--- a/app/code/core/Mage/Index/Model/Mysql4/Process.php
+++ b/app/code/core/Mage/Index/Model/Mysql4/Process.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Index/Model/Mysql4/Process.php
+++ b/app/code/core/Mage/Index/Model/Mysql4/Process.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Index

--- a/app/code/core/Mage/Index/Model/Mysql4/Process/Collection.php
+++ b/app/code/core/Mage/Index/Model/Mysql4/Process/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Index

--- a/app/code/core/Mage/Index/Model/Mysql4/Process/Collection.php
+++ b/app/code/core/Mage/Index/Model/Mysql4/Process/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Index/Model/Mysql4/Process/Collection.php
+++ b/app/code/core/Mage/Index/Model/Mysql4/Process/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Index

--- a/app/code/core/Mage/Index/Model/Mysql4/Setup.php
+++ b/app/code/core/Mage/Index/Model/Mysql4/Setup.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Index

--- a/app/code/core/Mage/Index/Model/Mysql4/Setup.php
+++ b/app/code/core/Mage/Index/Model/Mysql4/Setup.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Index/Model/Mysql4/Setup.php
+++ b/app/code/core/Mage/Index/Model/Mysql4/Setup.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Index

--- a/app/code/core/Mage/Index/Model/Observer.php
+++ b/app/code/core/Mage/Index/Model/Observer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Index

--- a/app/code/core/Mage/Index/Model/Observer.php
+++ b/app/code/core/Mage/Index/Model/Observer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Index/Model/Observer.php
+++ b/app/code/core/Mage/Index/Model/Observer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Index

--- a/app/code/core/Mage/Index/Model/Process.php
+++ b/app/code/core/Mage/Index/Model/Process.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Index

--- a/app/code/core/Mage/Index/Model/Process.php
+++ b/app/code/core/Mage/Index/Model/Process.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Index/Model/Process.php
+++ b/app/code/core/Mage/Index/Model/Process.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Index

--- a/app/code/core/Mage/Index/Model/Resource/Abstract.php
+++ b/app/code/core/Mage/Index/Model/Resource/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Index

--- a/app/code/core/Mage/Index/Model/Resource/Abstract.php
+++ b/app/code/core/Mage/Index/Model/Resource/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Index/Model/Resource/Abstract.php
+++ b/app/code/core/Mage/Index/Model/Resource/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Index

--- a/app/code/core/Mage/Index/Model/Resource/Event.php
+++ b/app/code/core/Mage/Index/Model/Resource/Event.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Index

--- a/app/code/core/Mage/Index/Model/Resource/Event.php
+++ b/app/code/core/Mage/Index/Model/Resource/Event.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Index/Model/Resource/Event.php
+++ b/app/code/core/Mage/Index/Model/Resource/Event.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Index

--- a/app/code/core/Mage/Index/Model/Resource/Event/Collection.php
+++ b/app/code/core/Mage/Index/Model/Resource/Event/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Index

--- a/app/code/core/Mage/Index/Model/Resource/Event/Collection.php
+++ b/app/code/core/Mage/Index/Model/Resource/Event/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Index/Model/Resource/Event/Collection.php
+++ b/app/code/core/Mage/Index/Model/Resource/Event/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Index

--- a/app/code/core/Mage/Index/Model/Resource/Helper/Lock/Interface.php
+++ b/app/code/core/Mage/Index/Model/Resource/Helper/Lock/Interface.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Index

--- a/app/code/core/Mage/Index/Model/Resource/Helper/Lock/Interface.php
+++ b/app/code/core/Mage/Index/Model/Resource/Helper/Lock/Interface.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Index/Model/Resource/Helper/Lock/Interface.php
+++ b/app/code/core/Mage/Index/Model/Resource/Helper/Lock/Interface.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Index

--- a/app/code/core/Mage/Index/Model/Resource/Helper/Mysql4.php
+++ b/app/code/core/Mage/Index/Model/Resource/Helper/Mysql4.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Index

--- a/app/code/core/Mage/Index/Model/Resource/Helper/Mysql4.php
+++ b/app/code/core/Mage/Index/Model/Resource/Helper/Mysql4.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Index/Model/Resource/Helper/Mysql4.php
+++ b/app/code/core/Mage/Index/Model/Resource/Helper/Mysql4.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Index

--- a/app/code/core/Mage/Index/Model/Resource/Lock/Resource.php
+++ b/app/code/core/Mage/Index/Model/Resource/Lock/Resource.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Index

--- a/app/code/core/Mage/Index/Model/Resource/Lock/Resource.php
+++ b/app/code/core/Mage/Index/Model/Resource/Lock/Resource.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Index/Model/Resource/Lock/Resource.php
+++ b/app/code/core/Mage/Index/Model/Resource/Lock/Resource.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Index

--- a/app/code/core/Mage/Index/Model/Resource/Process.php
+++ b/app/code/core/Mage/Index/Model/Resource/Process.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Index

--- a/app/code/core/Mage/Index/Model/Resource/Process.php
+++ b/app/code/core/Mage/Index/Model/Resource/Process.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Index/Model/Resource/Process.php
+++ b/app/code/core/Mage/Index/Model/Resource/Process.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Index

--- a/app/code/core/Mage/Index/Model/Resource/Process/Collection.php
+++ b/app/code/core/Mage/Index/Model/Resource/Process/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Index

--- a/app/code/core/Mage/Index/Model/Resource/Process/Collection.php
+++ b/app/code/core/Mage/Index/Model/Resource/Process/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Index/Model/Resource/Process/Collection.php
+++ b/app/code/core/Mage/Index/Model/Resource/Process/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Index

--- a/app/code/core/Mage/Index/Model/Resource/Setup.php
+++ b/app/code/core/Mage/Index/Model/Resource/Setup.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Index

--- a/app/code/core/Mage/Index/Model/Resource/Setup.php
+++ b/app/code/core/Mage/Index/Model/Resource/Setup.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Index/Model/Resource/Setup.php
+++ b/app/code/core/Mage/Index/Model/Resource/Setup.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Index

--- a/app/code/core/Mage/Index/controllers/Adminhtml/ProcessController.php
+++ b/app/code/core/Mage/Index/controllers/Adminhtml/ProcessController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Index

--- a/app/code/core/Mage/Index/controllers/Adminhtml/ProcessController.php
+++ b/app/code/core/Mage/Index/controllers/Adminhtml/ProcessController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Index/controllers/Adminhtml/ProcessController.php
+++ b/app/code/core/Mage/Index/controllers/Adminhtml/ProcessController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Index

--- a/app/code/core/Mage/Index/etc/adminhtml.xml
+++ b/app/code/core/Mage/Index/etc/adminhtml.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Index

--- a/app/code/core/Mage/Index/etc/adminhtml.xml
+++ b/app/code/core/Mage/Index/etc/adminhtml.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Index

--- a/app/code/core/Mage/Index/etc/adminhtml.xml
+++ b/app/code/core/Mage/Index/etc/adminhtml.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Index/etc/config.xml
+++ b/app/code/core/Mage/Index/etc/config.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Index

--- a/app/code/core/Mage/Index/etc/config.xml
+++ b/app/code/core/Mage/Index/etc/config.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Index

--- a/app/code/core/Mage/Index/etc/config.xml
+++ b/app/code/core/Mage/Index/etc/config.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Index/sql/index_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Index/sql/index_setup/install-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Index

--- a/app/code/core/Mage/Index/sql/index_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Index/sql/index_setup/install-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Index/sql/index_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Index/sql/index_setup/install-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Index

--- a/app/code/core/Mage/Index/sql/index_setup/mysql4-install-1.4.0.0.php
+++ b/app/code/core/Mage/Index/sql/index_setup/mysql4-install-1.4.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Index

--- a/app/code/core/Mage/Index/sql/index_setup/mysql4-install-1.4.0.0.php
+++ b/app/code/core/Mage/Index/sql/index_setup/mysql4-install-1.4.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Index/sql/index_setup/mysql4-install-1.4.0.0.php
+++ b/app/code/core/Mage/Index/sql/index_setup/mysql4-install-1.4.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Index

--- a/app/code/core/Mage/Index/sql/index_setup/mysql4-upgrade-1.4.0.0-1.4.0.1.php
+++ b/app/code/core/Mage/Index/sql/index_setup/mysql4-upgrade-1.4.0.0-1.4.0.1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Index

--- a/app/code/core/Mage/Index/sql/index_setup/mysql4-upgrade-1.4.0.0-1.4.0.1.php
+++ b/app/code/core/Mage/Index/sql/index_setup/mysql4-upgrade-1.4.0.0-1.4.0.1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Index/sql/index_setup/mysql4-upgrade-1.4.0.0-1.4.0.1.php
+++ b/app/code/core/Mage/Index/sql/index_setup/mysql4-upgrade-1.4.0.0-1.4.0.1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Index

--- a/app/code/core/Mage/Index/sql/index_setup/mysql4-upgrade-1.4.0.1-1.4.0.2.php
+++ b/app/code/core/Mage/Index/sql/index_setup/mysql4-upgrade-1.4.0.1-1.4.0.2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Index

--- a/app/code/core/Mage/Index/sql/index_setup/mysql4-upgrade-1.4.0.1-1.4.0.2.php
+++ b/app/code/core/Mage/Index/sql/index_setup/mysql4-upgrade-1.4.0.1-1.4.0.2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Index/sql/index_setup/mysql4-upgrade-1.4.0.1-1.4.0.2.php
+++ b/app/code/core/Mage/Index/sql/index_setup/mysql4-upgrade-1.4.0.1-1.4.0.2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Index

--- a/app/code/core/Mage/Index/sql/index_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/Index/sql/index_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Index

--- a/app/code/core/Mage/Index/sql/index_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/Index/sql/index_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Index/sql/index_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/Index/sql/index_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Index

--- a/app/code/core/Mage/Install/Block/Abstract.php
+++ b/app/code/core/Mage/Install/Block/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Install/Block/Abstract.php
+++ b/app/code/core/Mage/Install/Block/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Install

--- a/app/code/core/Mage/Install/Block/Abstract.php
+++ b/app/code/core/Mage/Install/Block/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Install

--- a/app/code/core/Mage/Install/Block/Admin.php
+++ b/app/code/core/Mage/Install/Block/Admin.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Install/Block/Admin.php
+++ b/app/code/core/Mage/Install/Block/Admin.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Install

--- a/app/code/core/Mage/Install/Block/Admin.php
+++ b/app/code/core/Mage/Install/Block/Admin.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Install

--- a/app/code/core/Mage/Install/Block/Begin.php
+++ b/app/code/core/Mage/Install/Block/Begin.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Install/Block/Begin.php
+++ b/app/code/core/Mage/Install/Block/Begin.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Install

--- a/app/code/core/Mage/Install/Block/Begin.php
+++ b/app/code/core/Mage/Install/Block/Begin.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Install

--- a/app/code/core/Mage/Install/Block/Config.php
+++ b/app/code/core/Mage/Install/Block/Config.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Install/Block/Config.php
+++ b/app/code/core/Mage/Install/Block/Config.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Install

--- a/app/code/core/Mage/Install/Block/Config.php
+++ b/app/code/core/Mage/Install/Block/Config.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Install

--- a/app/code/core/Mage/Install/Block/Db/Main.php
+++ b/app/code/core/Mage/Install/Block/Db/Main.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Install/Block/Db/Main.php
+++ b/app/code/core/Mage/Install/Block/Db/Main.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Install

--- a/app/code/core/Mage/Install/Block/Db/Main.php
+++ b/app/code/core/Mage/Install/Block/Db/Main.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Install

--- a/app/code/core/Mage/Install/Block/Db/Type.php
+++ b/app/code/core/Mage/Install/Block/Db/Type.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Install/Block/Db/Type.php
+++ b/app/code/core/Mage/Install/Block/Db/Type.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Install

--- a/app/code/core/Mage/Install/Block/Db/Type.php
+++ b/app/code/core/Mage/Install/Block/Db/Type.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Install

--- a/app/code/core/Mage/Install/Block/Db/Type/Mysql4.php
+++ b/app/code/core/Mage/Install/Block/Db/Type/Mysql4.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Install/Block/Db/Type/Mysql4.php
+++ b/app/code/core/Mage/Install/Block/Db/Type/Mysql4.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Install

--- a/app/code/core/Mage/Install/Block/Db/Type/Mysql4.php
+++ b/app/code/core/Mage/Install/Block/Db/Type/Mysql4.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Install

--- a/app/code/core/Mage/Install/Block/End.php
+++ b/app/code/core/Mage/Install/Block/End.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Install/Block/End.php
+++ b/app/code/core/Mage/Install/Block/End.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Install

--- a/app/code/core/Mage/Install/Block/End.php
+++ b/app/code/core/Mage/Install/Block/End.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Install

--- a/app/code/core/Mage/Install/Block/Locale.php
+++ b/app/code/core/Mage/Install/Block/Locale.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Install/Block/Locale.php
+++ b/app/code/core/Mage/Install/Block/Locale.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Install

--- a/app/code/core/Mage/Install/Block/Locale.php
+++ b/app/code/core/Mage/Install/Block/Locale.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Install

--- a/app/code/core/Mage/Install/Block/State.php
+++ b/app/code/core/Mage/Install/Block/State.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Install/Block/State.php
+++ b/app/code/core/Mage/Install/Block/State.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Install

--- a/app/code/core/Mage/Install/Block/State.php
+++ b/app/code/core/Mage/Install/Block/State.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Install

--- a/app/code/core/Mage/Install/Controller/Action.php
+++ b/app/code/core/Mage/Install/Controller/Action.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Install/Controller/Action.php
+++ b/app/code/core/Mage/Install/Controller/Action.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Install

--- a/app/code/core/Mage/Install/Controller/Action.php
+++ b/app/code/core/Mage/Install/Controller/Action.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Install

--- a/app/code/core/Mage/Install/Controller/Router/Install.php
+++ b/app/code/core/Mage/Install/Controller/Router/Install.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Install/Controller/Router/Install.php
+++ b/app/code/core/Mage/Install/Controller/Router/Install.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Install

--- a/app/code/core/Mage/Install/Controller/Router/Install.php
+++ b/app/code/core/Mage/Install/Controller/Router/Install.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Install

--- a/app/code/core/Mage/Install/Helper/Data.php
+++ b/app/code/core/Mage/Install/Helper/Data.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Install/Helper/Data.php
+++ b/app/code/core/Mage/Install/Helper/Data.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Install

--- a/app/code/core/Mage/Install/Helper/Data.php
+++ b/app/code/core/Mage/Install/Helper/Data.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Install

--- a/app/code/core/Mage/Install/Model/Config.php
+++ b/app/code/core/Mage/Install/Model/Config.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Install/Model/Config.php
+++ b/app/code/core/Mage/Install/Model/Config.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Install

--- a/app/code/core/Mage/Install/Model/Config.php
+++ b/app/code/core/Mage/Install/Model/Config.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Install

--- a/app/code/core/Mage/Install/Model/Installer.php
+++ b/app/code/core/Mage/Install/Model/Installer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Install/Model/Installer.php
+++ b/app/code/core/Mage/Install/Model/Installer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Install

--- a/app/code/core/Mage/Install/Model/Installer.php
+++ b/app/code/core/Mage/Install/Model/Installer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Install

--- a/app/code/core/Mage/Install/Model/Installer/Abstract.php
+++ b/app/code/core/Mage/Install/Model/Installer/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Install/Model/Installer/Abstract.php
+++ b/app/code/core/Mage/Install/Model/Installer/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Install

--- a/app/code/core/Mage/Install/Model/Installer/Abstract.php
+++ b/app/code/core/Mage/Install/Model/Installer/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Install

--- a/app/code/core/Mage/Install/Model/Installer/Config.php
+++ b/app/code/core/Mage/Install/Model/Installer/Config.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Install/Model/Installer/Config.php
+++ b/app/code/core/Mage/Install/Model/Installer/Config.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Install

--- a/app/code/core/Mage/Install/Model/Installer/Config.php
+++ b/app/code/core/Mage/Install/Model/Installer/Config.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Install

--- a/app/code/core/Mage/Install/Model/Installer/Console.php
+++ b/app/code/core/Mage/Install/Model/Installer/Console.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Install/Model/Installer/Console.php
+++ b/app/code/core/Mage/Install/Model/Installer/Console.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Install

--- a/app/code/core/Mage/Install/Model/Installer/Console.php
+++ b/app/code/core/Mage/Install/Model/Installer/Console.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Install

--- a/app/code/core/Mage/Install/Model/Installer/Data.php
+++ b/app/code/core/Mage/Install/Model/Installer/Data.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Install/Model/Installer/Data.php
+++ b/app/code/core/Mage/Install/Model/Installer/Data.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Install

--- a/app/code/core/Mage/Install/Model/Installer/Data.php
+++ b/app/code/core/Mage/Install/Model/Installer/Data.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Install

--- a/app/code/core/Mage/Install/Model/Installer/Db.php
+++ b/app/code/core/Mage/Install/Model/Installer/Db.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Install/Model/Installer/Db.php
+++ b/app/code/core/Mage/Install/Model/Installer/Db.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Install

--- a/app/code/core/Mage/Install/Model/Installer/Db.php
+++ b/app/code/core/Mage/Install/Model/Installer/Db.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Install

--- a/app/code/core/Mage/Install/Model/Installer/Db/Abstract.php
+++ b/app/code/core/Mage/Install/Model/Installer/Db/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Install/Model/Installer/Db/Abstract.php
+++ b/app/code/core/Mage/Install/Model/Installer/Db/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Install

--- a/app/code/core/Mage/Install/Model/Installer/Db/Abstract.php
+++ b/app/code/core/Mage/Install/Model/Installer/Db/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Install

--- a/app/code/core/Mage/Install/Model/Installer/Db/Mysql4.php
+++ b/app/code/core/Mage/Install/Model/Installer/Db/Mysql4.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Install/Model/Installer/Db/Mysql4.php
+++ b/app/code/core/Mage/Install/Model/Installer/Db/Mysql4.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Install

--- a/app/code/core/Mage/Install/Model/Installer/Db/Mysql4.php
+++ b/app/code/core/Mage/Install/Model/Installer/Db/Mysql4.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Install

--- a/app/code/core/Mage/Install/Model/Installer/Env.php
+++ b/app/code/core/Mage/Install/Model/Installer/Env.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Install/Model/Installer/Env.php
+++ b/app/code/core/Mage/Install/Model/Installer/Env.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Install

--- a/app/code/core/Mage/Install/Model/Installer/Env.php
+++ b/app/code/core/Mage/Install/Model/Installer/Env.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Install

--- a/app/code/core/Mage/Install/Model/Installer/Filesystem.php
+++ b/app/code/core/Mage/Install/Model/Installer/Filesystem.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Install/Model/Installer/Filesystem.php
+++ b/app/code/core/Mage/Install/Model/Installer/Filesystem.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Install

--- a/app/code/core/Mage/Install/Model/Installer/Filesystem.php
+++ b/app/code/core/Mage/Install/Model/Installer/Filesystem.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Install

--- a/app/code/core/Mage/Install/Model/Observer.php
+++ b/app/code/core/Mage/Install/Model/Observer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Install/Model/Observer.php
+++ b/app/code/core/Mage/Install/Model/Observer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Install

--- a/app/code/core/Mage/Install/Model/Observer.php
+++ b/app/code/core/Mage/Install/Model/Observer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Install

--- a/app/code/core/Mage/Install/Model/Session.php
+++ b/app/code/core/Mage/Install/Model/Session.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Install/Model/Session.php
+++ b/app/code/core/Mage/Install/Model/Session.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Install

--- a/app/code/core/Mage/Install/Model/Session.php
+++ b/app/code/core/Mage/Install/Model/Session.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Install

--- a/app/code/core/Mage/Install/Model/Wizard.php
+++ b/app/code/core/Mage/Install/Model/Wizard.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Install/Model/Wizard.php
+++ b/app/code/core/Mage/Install/Model/Wizard.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Install

--- a/app/code/core/Mage/Install/Model/Wizard.php
+++ b/app/code/core/Mage/Install/Model/Wizard.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Install

--- a/app/code/core/Mage/Install/controllers/IndexController.php
+++ b/app/code/core/Mage/Install/controllers/IndexController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Install/controllers/IndexController.php
+++ b/app/code/core/Mage/Install/controllers/IndexController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Install

--- a/app/code/core/Mage/Install/controllers/IndexController.php
+++ b/app/code/core/Mage/Install/controllers/IndexController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Install

--- a/app/code/core/Mage/Install/controllers/WizardController.php
+++ b/app/code/core/Mage/Install/controllers/WizardController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Install/controllers/WizardController.php
+++ b/app/code/core/Mage/Install/controllers/WizardController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Install

--- a/app/code/core/Mage/Install/controllers/WizardController.php
+++ b/app/code/core/Mage/Install/controllers/WizardController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Install

--- a/app/code/core/Mage/Install/etc/config.xml
+++ b/app/code/core/Mage/Install/etc/config.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Install

--- a/app/code/core/Mage/Install/etc/config.xml
+++ b/app/code/core/Mage/Install/etc/config.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Install/etc/config.xml
+++ b/app/code/core/Mage/Install/etc/config.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Install

--- a/app/code/core/Mage/Install/etc/install.xml
+++ b/app/code/core/Mage/Install/etc/install.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Install

--- a/app/code/core/Mage/Install/etc/install.xml
+++ b/app/code/core/Mage/Install/etc/install.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Install/etc/install.xml
+++ b/app/code/core/Mage/Install/etc/install.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Install

--- a/app/code/core/Mage/Log/Helper/Data.php
+++ b/app/code/core/Mage/Log/Helper/Data.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Log/Helper/Data.php
+++ b/app/code/core/Mage/Log/Helper/Data.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Log

--- a/app/code/core/Mage/Log/Helper/Data.php
+++ b/app/code/core/Mage/Log/Helper/Data.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Log

--- a/app/code/core/Mage/Log/Model/Adminhtml/System/Config/Source/Loglevel.php
+++ b/app/code/core/Mage/Log/Model/Adminhtml/System/Config/Source/Loglevel.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Log/Model/Adminhtml/System/Config/Source/Loglevel.php
+++ b/app/code/core/Mage/Log/Model/Adminhtml/System/Config/Source/Loglevel.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Log

--- a/app/code/core/Mage/Log/Model/Adminhtml/System/Config/Source/Loglevel.php
+++ b/app/code/core/Mage/Log/Model/Adminhtml/System/Config/Source/Loglevel.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Log

--- a/app/code/core/Mage/Log/Model/Aggregation.php
+++ b/app/code/core/Mage/Log/Model/Aggregation.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Log/Model/Aggregation.php
+++ b/app/code/core/Mage/Log/Model/Aggregation.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Log

--- a/app/code/core/Mage/Log/Model/Aggregation.php
+++ b/app/code/core/Mage/Log/Model/Aggregation.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Log

--- a/app/code/core/Mage/Log/Model/Cron.php
+++ b/app/code/core/Mage/Log/Model/Cron.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Log/Model/Cron.php
+++ b/app/code/core/Mage/Log/Model/Cron.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Log

--- a/app/code/core/Mage/Log/Model/Cron.php
+++ b/app/code/core/Mage/Log/Model/Cron.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Log

--- a/app/code/core/Mage/Log/Model/Customer.php
+++ b/app/code/core/Mage/Log/Model/Customer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Log/Model/Customer.php
+++ b/app/code/core/Mage/Log/Model/Customer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Log

--- a/app/code/core/Mage/Log/Model/Customer.php
+++ b/app/code/core/Mage/Log/Model/Customer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Log

--- a/app/code/core/Mage/Log/Model/Log.php
+++ b/app/code/core/Mage/Log/Model/Log.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Log/Model/Log.php
+++ b/app/code/core/Mage/Log/Model/Log.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Log

--- a/app/code/core/Mage/Log/Model/Log.php
+++ b/app/code/core/Mage/Log/Model/Log.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Log

--- a/app/code/core/Mage/Log/Model/Mysql4/Aggregation.php
+++ b/app/code/core/Mage/Log/Model/Mysql4/Aggregation.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Log/Model/Mysql4/Aggregation.php
+++ b/app/code/core/Mage/Log/Model/Mysql4/Aggregation.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Log

--- a/app/code/core/Mage/Log/Model/Mysql4/Aggregation.php
+++ b/app/code/core/Mage/Log/Model/Mysql4/Aggregation.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Log

--- a/app/code/core/Mage/Log/Model/Mysql4/Customer.php
+++ b/app/code/core/Mage/Log/Model/Mysql4/Customer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Log/Model/Mysql4/Customer.php
+++ b/app/code/core/Mage/Log/Model/Mysql4/Customer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Log

--- a/app/code/core/Mage/Log/Model/Mysql4/Customer.php
+++ b/app/code/core/Mage/Log/Model/Mysql4/Customer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Log

--- a/app/code/core/Mage/Log/Model/Mysql4/Log.php
+++ b/app/code/core/Mage/Log/Model/Mysql4/Log.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Log/Model/Mysql4/Log.php
+++ b/app/code/core/Mage/Log/Model/Mysql4/Log.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Log

--- a/app/code/core/Mage/Log/Model/Mysql4/Log.php
+++ b/app/code/core/Mage/Log/Model/Mysql4/Log.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Log

--- a/app/code/core/Mage/Log/Model/Mysql4/Visitor.php
+++ b/app/code/core/Mage/Log/Model/Mysql4/Visitor.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Log/Model/Mysql4/Visitor.php
+++ b/app/code/core/Mage/Log/Model/Mysql4/Visitor.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Log

--- a/app/code/core/Mage/Log/Model/Mysql4/Visitor.php
+++ b/app/code/core/Mage/Log/Model/Mysql4/Visitor.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Log

--- a/app/code/core/Mage/Log/Model/Mysql4/Visitor/Collection.php
+++ b/app/code/core/Mage/Log/Model/Mysql4/Visitor/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Log/Model/Mysql4/Visitor/Collection.php
+++ b/app/code/core/Mage/Log/Model/Mysql4/Visitor/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Log

--- a/app/code/core/Mage/Log/Model/Mysql4/Visitor/Collection.php
+++ b/app/code/core/Mage/Log/Model/Mysql4/Visitor/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Log

--- a/app/code/core/Mage/Log/Model/Mysql4/Visitor/Online.php
+++ b/app/code/core/Mage/Log/Model/Mysql4/Visitor/Online.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Log/Model/Mysql4/Visitor/Online.php
+++ b/app/code/core/Mage/Log/Model/Mysql4/Visitor/Online.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Log

--- a/app/code/core/Mage/Log/Model/Mysql4/Visitor/Online.php
+++ b/app/code/core/Mage/Log/Model/Mysql4/Visitor/Online.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Log

--- a/app/code/core/Mage/Log/Model/Mysql4/Visitor/Online/Collection.php
+++ b/app/code/core/Mage/Log/Model/Mysql4/Visitor/Online/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Log/Model/Mysql4/Visitor/Online/Collection.php
+++ b/app/code/core/Mage/Log/Model/Mysql4/Visitor/Online/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Log

--- a/app/code/core/Mage/Log/Model/Mysql4/Visitor/Online/Collection.php
+++ b/app/code/core/Mage/Log/Model/Mysql4/Visitor/Online/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Log

--- a/app/code/core/Mage/Log/Model/Resource/Aggregation.php
+++ b/app/code/core/Mage/Log/Model/Resource/Aggregation.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Log/Model/Resource/Aggregation.php
+++ b/app/code/core/Mage/Log/Model/Resource/Aggregation.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Log

--- a/app/code/core/Mage/Log/Model/Resource/Aggregation.php
+++ b/app/code/core/Mage/Log/Model/Resource/Aggregation.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Log

--- a/app/code/core/Mage/Log/Model/Resource/Customer.php
+++ b/app/code/core/Mage/Log/Model/Resource/Customer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Log/Model/Resource/Customer.php
+++ b/app/code/core/Mage/Log/Model/Resource/Customer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Log

--- a/app/code/core/Mage/Log/Model/Resource/Customer.php
+++ b/app/code/core/Mage/Log/Model/Resource/Customer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Log

--- a/app/code/core/Mage/Log/Model/Resource/Log.php
+++ b/app/code/core/Mage/Log/Model/Resource/Log.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Log/Model/Resource/Log.php
+++ b/app/code/core/Mage/Log/Model/Resource/Log.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Log

--- a/app/code/core/Mage/Log/Model/Resource/Log.php
+++ b/app/code/core/Mage/Log/Model/Resource/Log.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Log

--- a/app/code/core/Mage/Log/Model/Resource/Visitor.php
+++ b/app/code/core/Mage/Log/Model/Resource/Visitor.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Log/Model/Resource/Visitor.php
+++ b/app/code/core/Mage/Log/Model/Resource/Visitor.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Log

--- a/app/code/core/Mage/Log/Model/Resource/Visitor.php
+++ b/app/code/core/Mage/Log/Model/Resource/Visitor.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Log

--- a/app/code/core/Mage/Log/Model/Resource/Visitor/Collection.php
+++ b/app/code/core/Mage/Log/Model/Resource/Visitor/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Log/Model/Resource/Visitor/Collection.php
+++ b/app/code/core/Mage/Log/Model/Resource/Visitor/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Log

--- a/app/code/core/Mage/Log/Model/Resource/Visitor/Collection.php
+++ b/app/code/core/Mage/Log/Model/Resource/Visitor/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Log

--- a/app/code/core/Mage/Log/Model/Resource/Visitor/Online.php
+++ b/app/code/core/Mage/Log/Model/Resource/Visitor/Online.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Log/Model/Resource/Visitor/Online.php
+++ b/app/code/core/Mage/Log/Model/Resource/Visitor/Online.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Log

--- a/app/code/core/Mage/Log/Model/Resource/Visitor/Online.php
+++ b/app/code/core/Mage/Log/Model/Resource/Visitor/Online.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Log

--- a/app/code/core/Mage/Log/Model/Resource/Visitor/Online/Collection.php
+++ b/app/code/core/Mage/Log/Model/Resource/Visitor/Online/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Log/Model/Resource/Visitor/Online/Collection.php
+++ b/app/code/core/Mage/Log/Model/Resource/Visitor/Online/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Log

--- a/app/code/core/Mage/Log/Model/Resource/Visitor/Online/Collection.php
+++ b/app/code/core/Mage/Log/Model/Resource/Visitor/Online/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Log

--- a/app/code/core/Mage/Log/Model/Visitor.php
+++ b/app/code/core/Mage/Log/Model/Visitor.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Log/Model/Visitor.php
+++ b/app/code/core/Mage/Log/Model/Visitor.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Log

--- a/app/code/core/Mage/Log/Model/Visitor.php
+++ b/app/code/core/Mage/Log/Model/Visitor.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Log

--- a/app/code/core/Mage/Log/Model/Visitor/Online.php
+++ b/app/code/core/Mage/Log/Model/Visitor/Online.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Log/Model/Visitor/Online.php
+++ b/app/code/core/Mage/Log/Model/Visitor/Online.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Log

--- a/app/code/core/Mage/Log/Model/Visitor/Online.php
+++ b/app/code/core/Mage/Log/Model/Visitor/Online.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Log

--- a/app/code/core/Mage/Log/data/log_setup/data-install-1.6.0.0.php
+++ b/app/code/core/Mage/Log/data/log_setup/data-install-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Log/data/log_setup/data-install-1.6.0.0.php
+++ b/app/code/core/Mage/Log/data/log_setup/data-install-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Log

--- a/app/code/core/Mage/Log/data/log_setup/data-install-1.6.0.0.php
+++ b/app/code/core/Mage/Log/data/log_setup/data-install-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Log

--- a/app/code/core/Mage/Log/etc/config.xml
+++ b/app/code/core/Mage/Log/etc/config.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Log

--- a/app/code/core/Mage/Log/etc/config.xml
+++ b/app/code/core/Mage/Log/etc/config.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Log

--- a/app/code/core/Mage/Log/etc/config.xml
+++ b/app/code/core/Mage/Log/etc/config.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Log/etc/system.xml
+++ b/app/code/core/Mage/Log/etc/system.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Log

--- a/app/code/core/Mage/Log/etc/system.xml
+++ b/app/code/core/Mage/Log/etc/system.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Log

--- a/app/code/core/Mage/Log/etc/system.xml
+++ b/app/code/core/Mage/Log/etc/system.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Log/sql/log_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Log/sql/log_setup/install-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Log/sql/log_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Log/sql/log_setup/install-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Log

--- a/app/code/core/Mage/Log/sql/log_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Log/sql/log_setup/install-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Log

--- a/app/code/core/Mage/Log/sql/log_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/Log/sql/log_setup/mysql4-install-0.7.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Log/sql/log_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/Log/sql/log_setup/mysql4-install-0.7.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Log

--- a/app/code/core/Mage/Log/sql/log_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/Log/sql/log_setup/mysql4-install-0.7.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Log

--- a/app/code/core/Mage/Log/sql/log_setup/mysql4-upgrade-0.7.0-0.7.1.php
+++ b/app/code/core/Mage/Log/sql/log_setup/mysql4-upgrade-0.7.0-0.7.1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Log/sql/log_setup/mysql4-upgrade-0.7.0-0.7.1.php
+++ b/app/code/core/Mage/Log/sql/log_setup/mysql4-upgrade-0.7.0-0.7.1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Log

--- a/app/code/core/Mage/Log/sql/log_setup/mysql4-upgrade-0.7.0-0.7.1.php
+++ b/app/code/core/Mage/Log/sql/log_setup/mysql4-upgrade-0.7.0-0.7.1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Log

--- a/app/code/core/Mage/Log/sql/log_setup/mysql4-upgrade-0.7.1-0.7.2.php
+++ b/app/code/core/Mage/Log/sql/log_setup/mysql4-upgrade-0.7.1-0.7.2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Log/sql/log_setup/mysql4-upgrade-0.7.1-0.7.2.php
+++ b/app/code/core/Mage/Log/sql/log_setup/mysql4-upgrade-0.7.1-0.7.2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Log

--- a/app/code/core/Mage/Log/sql/log_setup/mysql4-upgrade-0.7.1-0.7.2.php
+++ b/app/code/core/Mage/Log/sql/log_setup/mysql4-upgrade-0.7.1-0.7.2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Log

--- a/app/code/core/Mage/Log/sql/log_setup/mysql4-upgrade-0.7.3-0.7.4.php
+++ b/app/code/core/Mage/Log/sql/log_setup/mysql4-upgrade-0.7.3-0.7.4.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Log/sql/log_setup/mysql4-upgrade-0.7.3-0.7.4.php
+++ b/app/code/core/Mage/Log/sql/log_setup/mysql4-upgrade-0.7.3-0.7.4.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Log

--- a/app/code/core/Mage/Log/sql/log_setup/mysql4-upgrade-0.7.3-0.7.4.php
+++ b/app/code/core/Mage/Log/sql/log_setup/mysql4-upgrade-0.7.3-0.7.4.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Log

--- a/app/code/core/Mage/Log/sql/log_setup/mysql4-upgrade-0.7.4-0.7.5.php
+++ b/app/code/core/Mage/Log/sql/log_setup/mysql4-upgrade-0.7.4-0.7.5.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Log/sql/log_setup/mysql4-upgrade-0.7.4-0.7.5.php
+++ b/app/code/core/Mage/Log/sql/log_setup/mysql4-upgrade-0.7.4-0.7.5.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Log

--- a/app/code/core/Mage/Log/sql/log_setup/mysql4-upgrade-0.7.4-0.7.5.php
+++ b/app/code/core/Mage/Log/sql/log_setup/mysql4-upgrade-0.7.4-0.7.5.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Log

--- a/app/code/core/Mage/Log/sql/log_setup/mysql4-upgrade-0.7.5-0.7.6.php
+++ b/app/code/core/Mage/Log/sql/log_setup/mysql4-upgrade-0.7.5-0.7.6.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Log/sql/log_setup/mysql4-upgrade-0.7.5-0.7.6.php
+++ b/app/code/core/Mage/Log/sql/log_setup/mysql4-upgrade-0.7.5-0.7.6.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Log

--- a/app/code/core/Mage/Log/sql/log_setup/mysql4-upgrade-0.7.5-0.7.6.php
+++ b/app/code/core/Mage/Log/sql/log_setup/mysql4-upgrade-0.7.5-0.7.6.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Log

--- a/app/code/core/Mage/Log/sql/log_setup/mysql4-upgrade-0.7.6-0.7.7.php
+++ b/app/code/core/Mage/Log/sql/log_setup/mysql4-upgrade-0.7.6-0.7.7.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Log/sql/log_setup/mysql4-upgrade-0.7.6-0.7.7.php
+++ b/app/code/core/Mage/Log/sql/log_setup/mysql4-upgrade-0.7.6-0.7.7.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Log

--- a/app/code/core/Mage/Log/sql/log_setup/mysql4-upgrade-0.7.6-0.7.7.php
+++ b/app/code/core/Mage/Log/sql/log_setup/mysql4-upgrade-0.7.6-0.7.7.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Log

--- a/app/code/core/Mage/Log/sql/log_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/Log/sql/log_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Log/sql/log_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/Log/sql/log_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Log

--- a/app/code/core/Mage/Log/sql/log_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/Log/sql/log_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Log

--- a/app/code/core/Mage/Log/sql/log_setup/mysql4-upgrade-1.6.0.0-1.6.1.0.php
+++ b/app/code/core/Mage/Log/sql/log_setup/mysql4-upgrade-1.6.0.0-1.6.1.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Log/sql/log_setup/mysql4-upgrade-1.6.0.0-1.6.1.0.php
+++ b/app/code/core/Mage/Log/sql/log_setup/mysql4-upgrade-1.6.0.0-1.6.1.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Log

--- a/app/code/core/Mage/Log/sql/log_setup/mysql4-upgrade-1.6.0.0-1.6.1.0.php
+++ b/app/code/core/Mage/Log/sql/log_setup/mysql4-upgrade-1.6.0.0-1.6.1.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Log

--- a/app/code/core/Mage/Log/sql/log_setup/mysql4-upgrade-1.6.1.0-1.6.1.1.php
+++ b/app/code/core/Mage/Log/sql/log_setup/mysql4-upgrade-1.6.1.0-1.6.1.1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Log/sql/log_setup/mysql4-upgrade-1.6.1.0-1.6.1.1.php
+++ b/app/code/core/Mage/Log/sql/log_setup/mysql4-upgrade-1.6.1.0-1.6.1.1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Log

--- a/app/code/core/Mage/Log/sql/log_setup/mysql4-upgrade-1.6.1.0-1.6.1.1.php
+++ b/app/code/core/Mage/Log/sql/log_setup/mysql4-upgrade-1.6.1.0-1.6.1.1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Log

--- a/app/code/core/Mage/Media/Helper/Data.php
+++ b/app/code/core/Mage/Media/Helper/Data.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Media/Helper/Data.php
+++ b/app/code/core/Mage/Media/Helper/Data.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Media

--- a/app/code/core/Mage/Media/Helper/Data.php
+++ b/app/code/core/Mage/Media/Helper/Data.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Media

--- a/app/code/core/Mage/Media/Model/File/Image.php
+++ b/app/code/core/Mage/Media/Model/File/Image.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Media/Model/File/Image.php
+++ b/app/code/core/Mage/Media/Model/File/Image.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Media

--- a/app/code/core/Mage/Media/Model/File/Image.php
+++ b/app/code/core/Mage/Media/Model/File/Image.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Media

--- a/app/code/core/Mage/Media/Model/Image.php
+++ b/app/code/core/Mage/Media/Model/Image.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Media/Model/Image.php
+++ b/app/code/core/Mage/Media/Model/Image.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Media

--- a/app/code/core/Mage/Media/Model/Image.php
+++ b/app/code/core/Mage/Media/Model/Image.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Media

--- a/app/code/core/Mage/Media/Model/Image/Config/Interface.php
+++ b/app/code/core/Mage/Media/Model/Image/Config/Interface.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Media/Model/Image/Config/Interface.php
+++ b/app/code/core/Mage/Media/Model/Image/Config/Interface.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Media

--- a/app/code/core/Mage/Media/Model/Image/Config/Interface.php
+++ b/app/code/core/Mage/Media/Model/Image/Config/Interface.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Media

--- a/app/code/core/Mage/Media/etc/config.xml
+++ b/app/code/core/Mage/Media/etc/config.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Media

--- a/app/code/core/Mage/Media/etc/config.xml
+++ b/app/code/core/Mage/Media/etc/config.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Media

--- a/app/code/core/Mage/Media/etc/config.xml
+++ b/app/code/core/Mage/Media/etc/config.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Newsletter/Block/Subscribe.php
+++ b/app/code/core/Mage/Newsletter/Block/Subscribe.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Newsletter/Block/Subscribe.php
+++ b/app/code/core/Mage/Newsletter/Block/Subscribe.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Newsletter

--- a/app/code/core/Mage/Newsletter/Block/Subscribe.php
+++ b/app/code/core/Mage/Newsletter/Block/Subscribe.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Newsletter

--- a/app/code/core/Mage/Newsletter/Helper/Data.php
+++ b/app/code/core/Mage/Newsletter/Helper/Data.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Newsletter/Helper/Data.php
+++ b/app/code/core/Mage/Newsletter/Helper/Data.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Newsletter

--- a/app/code/core/Mage/Newsletter/Helper/Data.php
+++ b/app/code/core/Mage/Newsletter/Helper/Data.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Newsletter

--- a/app/code/core/Mage/Newsletter/Model/Message.php
+++ b/app/code/core/Mage/Newsletter/Model/Message.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Newsletter/Model/Message.php
+++ b/app/code/core/Mage/Newsletter/Model/Message.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Newsletter

--- a/app/code/core/Mage/Newsletter/Model/Message.php
+++ b/app/code/core/Mage/Newsletter/Model/Message.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Newsletter

--- a/app/code/core/Mage/Newsletter/Model/Mysql4/Problem.php
+++ b/app/code/core/Mage/Newsletter/Model/Mysql4/Problem.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Newsletter/Model/Mysql4/Problem.php
+++ b/app/code/core/Mage/Newsletter/Model/Mysql4/Problem.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Newsletter

--- a/app/code/core/Mage/Newsletter/Model/Mysql4/Problem.php
+++ b/app/code/core/Mage/Newsletter/Model/Mysql4/Problem.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Newsletter

--- a/app/code/core/Mage/Newsletter/Model/Mysql4/Problem/Collection.php
+++ b/app/code/core/Mage/Newsletter/Model/Mysql4/Problem/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Newsletter/Model/Mysql4/Problem/Collection.php
+++ b/app/code/core/Mage/Newsletter/Model/Mysql4/Problem/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Newsletter

--- a/app/code/core/Mage/Newsletter/Model/Mysql4/Problem/Collection.php
+++ b/app/code/core/Mage/Newsletter/Model/Mysql4/Problem/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Newsletter

--- a/app/code/core/Mage/Newsletter/Model/Mysql4/Queue.php
+++ b/app/code/core/Mage/Newsletter/Model/Mysql4/Queue.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Newsletter/Model/Mysql4/Queue.php
+++ b/app/code/core/Mage/Newsletter/Model/Mysql4/Queue.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Newsletter

--- a/app/code/core/Mage/Newsletter/Model/Mysql4/Queue.php
+++ b/app/code/core/Mage/Newsletter/Model/Mysql4/Queue.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Newsletter

--- a/app/code/core/Mage/Newsletter/Model/Mysql4/Queue/Collection.php
+++ b/app/code/core/Mage/Newsletter/Model/Mysql4/Queue/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Newsletter/Model/Mysql4/Queue/Collection.php
+++ b/app/code/core/Mage/Newsletter/Model/Mysql4/Queue/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Newsletter

--- a/app/code/core/Mage/Newsletter/Model/Mysql4/Queue/Collection.php
+++ b/app/code/core/Mage/Newsletter/Model/Mysql4/Queue/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Newsletter

--- a/app/code/core/Mage/Newsletter/Model/Mysql4/Subscriber.php
+++ b/app/code/core/Mage/Newsletter/Model/Mysql4/Subscriber.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Newsletter/Model/Mysql4/Subscriber.php
+++ b/app/code/core/Mage/Newsletter/Model/Mysql4/Subscriber.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Newsletter

--- a/app/code/core/Mage/Newsletter/Model/Mysql4/Subscriber.php
+++ b/app/code/core/Mage/Newsletter/Model/Mysql4/Subscriber.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Newsletter

--- a/app/code/core/Mage/Newsletter/Model/Mysql4/Subscriber/Collection.php
+++ b/app/code/core/Mage/Newsletter/Model/Mysql4/Subscriber/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Newsletter/Model/Mysql4/Subscriber/Collection.php
+++ b/app/code/core/Mage/Newsletter/Model/Mysql4/Subscriber/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Newsletter

--- a/app/code/core/Mage/Newsletter/Model/Mysql4/Subscriber/Collection.php
+++ b/app/code/core/Mage/Newsletter/Model/Mysql4/Subscriber/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Newsletter

--- a/app/code/core/Mage/Newsletter/Model/Mysql4/Template.php
+++ b/app/code/core/Mage/Newsletter/Model/Mysql4/Template.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Newsletter/Model/Mysql4/Template.php
+++ b/app/code/core/Mage/Newsletter/Model/Mysql4/Template.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Newsletter

--- a/app/code/core/Mage/Newsletter/Model/Mysql4/Template.php
+++ b/app/code/core/Mage/Newsletter/Model/Mysql4/Template.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Newsletter

--- a/app/code/core/Mage/Newsletter/Model/Mysql4/Template/Collection.php
+++ b/app/code/core/Mage/Newsletter/Model/Mysql4/Template/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Newsletter/Model/Mysql4/Template/Collection.php
+++ b/app/code/core/Mage/Newsletter/Model/Mysql4/Template/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Newsletter

--- a/app/code/core/Mage/Newsletter/Model/Mysql4/Template/Collection.php
+++ b/app/code/core/Mage/Newsletter/Model/Mysql4/Template/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Newsletter

--- a/app/code/core/Mage/Newsletter/Model/Observer.php
+++ b/app/code/core/Mage/Newsletter/Model/Observer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Newsletter/Model/Observer.php
+++ b/app/code/core/Mage/Newsletter/Model/Observer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Newsletter

--- a/app/code/core/Mage/Newsletter/Model/Observer.php
+++ b/app/code/core/Mage/Newsletter/Model/Observer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Newsletter

--- a/app/code/core/Mage/Newsletter/Model/Problem.php
+++ b/app/code/core/Mage/Newsletter/Model/Problem.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Newsletter/Model/Problem.php
+++ b/app/code/core/Mage/Newsletter/Model/Problem.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Newsletter

--- a/app/code/core/Mage/Newsletter/Model/Problem.php
+++ b/app/code/core/Mage/Newsletter/Model/Problem.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Newsletter

--- a/app/code/core/Mage/Newsletter/Model/Queue.php
+++ b/app/code/core/Mage/Newsletter/Model/Queue.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Newsletter/Model/Queue.php
+++ b/app/code/core/Mage/Newsletter/Model/Queue.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Newsletter

--- a/app/code/core/Mage/Newsletter/Model/Queue.php
+++ b/app/code/core/Mage/Newsletter/Model/Queue.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Newsletter

--- a/app/code/core/Mage/Newsletter/Model/Resource/Problem.php
+++ b/app/code/core/Mage/Newsletter/Model/Resource/Problem.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Newsletter/Model/Resource/Problem.php
+++ b/app/code/core/Mage/Newsletter/Model/Resource/Problem.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Newsletter

--- a/app/code/core/Mage/Newsletter/Model/Resource/Problem.php
+++ b/app/code/core/Mage/Newsletter/Model/Resource/Problem.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Newsletter

--- a/app/code/core/Mage/Newsletter/Model/Resource/Problem/Collection.php
+++ b/app/code/core/Mage/Newsletter/Model/Resource/Problem/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Newsletter/Model/Resource/Problem/Collection.php
+++ b/app/code/core/Mage/Newsletter/Model/Resource/Problem/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Newsletter

--- a/app/code/core/Mage/Newsletter/Model/Resource/Problem/Collection.php
+++ b/app/code/core/Mage/Newsletter/Model/Resource/Problem/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Newsletter

--- a/app/code/core/Mage/Newsletter/Model/Resource/Queue.php
+++ b/app/code/core/Mage/Newsletter/Model/Resource/Queue.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Newsletter/Model/Resource/Queue.php
+++ b/app/code/core/Mage/Newsletter/Model/Resource/Queue.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Newsletter

--- a/app/code/core/Mage/Newsletter/Model/Resource/Queue.php
+++ b/app/code/core/Mage/Newsletter/Model/Resource/Queue.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Newsletter

--- a/app/code/core/Mage/Newsletter/Model/Resource/Queue/Collection.php
+++ b/app/code/core/Mage/Newsletter/Model/Resource/Queue/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Newsletter/Model/Resource/Queue/Collection.php
+++ b/app/code/core/Mage/Newsletter/Model/Resource/Queue/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Newsletter

--- a/app/code/core/Mage/Newsletter/Model/Resource/Queue/Collection.php
+++ b/app/code/core/Mage/Newsletter/Model/Resource/Queue/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Newsletter

--- a/app/code/core/Mage/Newsletter/Model/Resource/Subscriber.php
+++ b/app/code/core/Mage/Newsletter/Model/Resource/Subscriber.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Newsletter/Model/Resource/Subscriber.php
+++ b/app/code/core/Mage/Newsletter/Model/Resource/Subscriber.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Newsletter

--- a/app/code/core/Mage/Newsletter/Model/Resource/Subscriber.php
+++ b/app/code/core/Mage/Newsletter/Model/Resource/Subscriber.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Newsletter

--- a/app/code/core/Mage/Newsletter/Model/Resource/Subscriber/Collection.php
+++ b/app/code/core/Mage/Newsletter/Model/Resource/Subscriber/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Newsletter/Model/Resource/Subscriber/Collection.php
+++ b/app/code/core/Mage/Newsletter/Model/Resource/Subscriber/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Newsletter

--- a/app/code/core/Mage/Newsletter/Model/Resource/Subscriber/Collection.php
+++ b/app/code/core/Mage/Newsletter/Model/Resource/Subscriber/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Newsletter

--- a/app/code/core/Mage/Newsletter/Model/Resource/Template.php
+++ b/app/code/core/Mage/Newsletter/Model/Resource/Template.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Newsletter/Model/Resource/Template.php
+++ b/app/code/core/Mage/Newsletter/Model/Resource/Template.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Newsletter

--- a/app/code/core/Mage/Newsletter/Model/Resource/Template.php
+++ b/app/code/core/Mage/Newsletter/Model/Resource/Template.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Newsletter

--- a/app/code/core/Mage/Newsletter/Model/Resource/Template/Collection.php
+++ b/app/code/core/Mage/Newsletter/Model/Resource/Template/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Newsletter/Model/Resource/Template/Collection.php
+++ b/app/code/core/Mage/Newsletter/Model/Resource/Template/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Newsletter

--- a/app/code/core/Mage/Newsletter/Model/Resource/Template/Collection.php
+++ b/app/code/core/Mage/Newsletter/Model/Resource/Template/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Newsletter

--- a/app/code/core/Mage/Newsletter/Model/Session.php
+++ b/app/code/core/Mage/Newsletter/Model/Session.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Newsletter/Model/Session.php
+++ b/app/code/core/Mage/Newsletter/Model/Session.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Newsletter

--- a/app/code/core/Mage/Newsletter/Model/Session.php
+++ b/app/code/core/Mage/Newsletter/Model/Session.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Newsletter

--- a/app/code/core/Mage/Newsletter/Model/Subscriber.php
+++ b/app/code/core/Mage/Newsletter/Model/Subscriber.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Newsletter/Model/Subscriber.php
+++ b/app/code/core/Mage/Newsletter/Model/Subscriber.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Newsletter

--- a/app/code/core/Mage/Newsletter/Model/Subscriber.php
+++ b/app/code/core/Mage/Newsletter/Model/Subscriber.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Newsletter

--- a/app/code/core/Mage/Newsletter/Model/Template.php
+++ b/app/code/core/Mage/Newsletter/Model/Template.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Newsletter/Model/Template.php
+++ b/app/code/core/Mage/Newsletter/Model/Template.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Newsletter

--- a/app/code/core/Mage/Newsletter/Model/Template.php
+++ b/app/code/core/Mage/Newsletter/Model/Template.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Newsletter

--- a/app/code/core/Mage/Newsletter/Model/Template/Filter.php
+++ b/app/code/core/Mage/Newsletter/Model/Template/Filter.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Newsletter/Model/Template/Filter.php
+++ b/app/code/core/Mage/Newsletter/Model/Template/Filter.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Newsletter

--- a/app/code/core/Mage/Newsletter/Model/Template/Filter.php
+++ b/app/code/core/Mage/Newsletter/Model/Template/Filter.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Newsletter

--- a/app/code/core/Mage/Newsletter/controllers/ManageController.php
+++ b/app/code/core/Mage/Newsletter/controllers/ManageController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Newsletter/controllers/ManageController.php
+++ b/app/code/core/Mage/Newsletter/controllers/ManageController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Newsletter

--- a/app/code/core/Mage/Newsletter/controllers/ManageController.php
+++ b/app/code/core/Mage/Newsletter/controllers/ManageController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Newsletter

--- a/app/code/core/Mage/Newsletter/controllers/SubscriberController.php
+++ b/app/code/core/Mage/Newsletter/controllers/SubscriberController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Newsletter/controllers/SubscriberController.php
+++ b/app/code/core/Mage/Newsletter/controllers/SubscriberController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Newsletter

--- a/app/code/core/Mage/Newsletter/controllers/SubscriberController.php
+++ b/app/code/core/Mage/Newsletter/controllers/SubscriberController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Newsletter

--- a/app/code/core/Mage/Newsletter/data/newsletter_setup/data-upgrade-1.6.0.0-1.6.0.1.php
+++ b/app/code/core/Mage/Newsletter/data/newsletter_setup/data-upgrade-1.6.0.0-1.6.0.1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Newsletter/data/newsletter_setup/data-upgrade-1.6.0.0-1.6.0.1.php
+++ b/app/code/core/Mage/Newsletter/data/newsletter_setup/data-upgrade-1.6.0.0-1.6.0.1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Newsletter

--- a/app/code/core/Mage/Newsletter/data/newsletter_setup/data-upgrade-1.6.0.0-1.6.0.1.php
+++ b/app/code/core/Mage/Newsletter/data/newsletter_setup/data-upgrade-1.6.0.0-1.6.0.1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Newsletter

--- a/app/code/core/Mage/Newsletter/data/newsletter_setup/data-upgrade-1.6.0.1-1.6.0.2.php
+++ b/app/code/core/Mage/Newsletter/data/newsletter_setup/data-upgrade-1.6.0.1-1.6.0.2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Newsletter/data/newsletter_setup/data-upgrade-1.6.0.1-1.6.0.2.php
+++ b/app/code/core/Mage/Newsletter/data/newsletter_setup/data-upgrade-1.6.0.1-1.6.0.2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Newsletter

--- a/app/code/core/Mage/Newsletter/data/newsletter_setup/data-upgrade-1.6.0.1-1.6.0.2.php
+++ b/app/code/core/Mage/Newsletter/data/newsletter_setup/data-upgrade-1.6.0.1-1.6.0.2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Newsletter

--- a/app/code/core/Mage/Newsletter/etc/adminhtml.xml
+++ b/app/code/core/Mage/Newsletter/etc/adminhtml.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Newsletter

--- a/app/code/core/Mage/Newsletter/etc/adminhtml.xml
+++ b/app/code/core/Mage/Newsletter/etc/adminhtml.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Newsletter

--- a/app/code/core/Mage/Newsletter/etc/adminhtml.xml
+++ b/app/code/core/Mage/Newsletter/etc/adminhtml.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Newsletter/etc/config.xml
+++ b/app/code/core/Mage/Newsletter/etc/config.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Newsletter

--- a/app/code/core/Mage/Newsletter/etc/config.xml
+++ b/app/code/core/Mage/Newsletter/etc/config.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Newsletter

--- a/app/code/core/Mage/Newsletter/etc/config.xml
+++ b/app/code/core/Mage/Newsletter/etc/config.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Newsletter/etc/system.xml
+++ b/app/code/core/Mage/Newsletter/etc/system.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Newsletter

--- a/app/code/core/Mage/Newsletter/etc/system.xml
+++ b/app/code/core/Mage/Newsletter/etc/system.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Newsletter

--- a/app/code/core/Mage/Newsletter/etc/system.xml
+++ b/app/code/core/Mage/Newsletter/etc/system.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Newsletter/sql/newsletter_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Newsletter/sql/newsletter_setup/install-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Newsletter/sql/newsletter_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Newsletter/sql/newsletter_setup/install-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Newsletter

--- a/app/code/core/Mage/Newsletter/sql/newsletter_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Newsletter/sql/newsletter_setup/install-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Newsletter

--- a/app/code/core/Mage/Newsletter/sql/newsletter_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/Newsletter/sql/newsletter_setup/mysql4-install-0.7.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Newsletter/sql/newsletter_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/Newsletter/sql/newsletter_setup/mysql4-install-0.7.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Newsletter

--- a/app/code/core/Mage/Newsletter/sql/newsletter_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/Newsletter/sql/newsletter_setup/mysql4-install-0.7.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Newsletter

--- a/app/code/core/Mage/Newsletter/sql/newsletter_setup/mysql4-install-0.8.0.php
+++ b/app/code/core/Mage/Newsletter/sql/newsletter_setup/mysql4-install-0.8.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Newsletter/sql/newsletter_setup/mysql4-install-0.8.0.php
+++ b/app/code/core/Mage/Newsletter/sql/newsletter_setup/mysql4-install-0.8.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Newsletter

--- a/app/code/core/Mage/Newsletter/sql/newsletter_setup/mysql4-install-0.8.0.php
+++ b/app/code/core/Mage/Newsletter/sql/newsletter_setup/mysql4-install-0.8.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Newsletter

--- a/app/code/core/Mage/Newsletter/sql/newsletter_setup/mysql4-upgrade-0.7.0-0.7.1.php
+++ b/app/code/core/Mage/Newsletter/sql/newsletter_setup/mysql4-upgrade-0.7.0-0.7.1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Newsletter/sql/newsletter_setup/mysql4-upgrade-0.7.0-0.7.1.php
+++ b/app/code/core/Mage/Newsletter/sql/newsletter_setup/mysql4-upgrade-0.7.0-0.7.1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Newsletter

--- a/app/code/core/Mage/Newsletter/sql/newsletter_setup/mysql4-upgrade-0.7.0-0.7.1.php
+++ b/app/code/core/Mage/Newsletter/sql/newsletter_setup/mysql4-upgrade-0.7.0-0.7.1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Newsletter

--- a/app/code/core/Mage/Newsletter/sql/newsletter_setup/mysql4-upgrade-0.8.0-0.8.1.php
+++ b/app/code/core/Mage/Newsletter/sql/newsletter_setup/mysql4-upgrade-0.8.0-0.8.1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Newsletter/sql/newsletter_setup/mysql4-upgrade-0.8.0-0.8.1.php
+++ b/app/code/core/Mage/Newsletter/sql/newsletter_setup/mysql4-upgrade-0.8.0-0.8.1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Newsletter

--- a/app/code/core/Mage/Newsletter/sql/newsletter_setup/mysql4-upgrade-0.8.0-0.8.1.php
+++ b/app/code/core/Mage/Newsletter/sql/newsletter_setup/mysql4-upgrade-0.8.0-0.8.1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Newsletter

--- a/app/code/core/Mage/Newsletter/sql/newsletter_setup/mysql4-upgrade-0.8.1-0.8.2.php
+++ b/app/code/core/Mage/Newsletter/sql/newsletter_setup/mysql4-upgrade-0.8.1-0.8.2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Newsletter/sql/newsletter_setup/mysql4-upgrade-0.8.1-0.8.2.php
+++ b/app/code/core/Mage/Newsletter/sql/newsletter_setup/mysql4-upgrade-0.8.1-0.8.2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Newsletter

--- a/app/code/core/Mage/Newsletter/sql/newsletter_setup/mysql4-upgrade-0.8.1-0.8.2.php
+++ b/app/code/core/Mage/Newsletter/sql/newsletter_setup/mysql4-upgrade-0.8.1-0.8.2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Newsletter

--- a/app/code/core/Mage/Newsletter/sql/newsletter_setup/mysql4-upgrade-0.8.2-0.8.3.php
+++ b/app/code/core/Mage/Newsletter/sql/newsletter_setup/mysql4-upgrade-0.8.2-0.8.3.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Newsletter/sql/newsletter_setup/mysql4-upgrade-0.8.2-0.8.3.php
+++ b/app/code/core/Mage/Newsletter/sql/newsletter_setup/mysql4-upgrade-0.8.2-0.8.3.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Newsletter

--- a/app/code/core/Mage/Newsletter/sql/newsletter_setup/mysql4-upgrade-0.8.2-0.8.3.php
+++ b/app/code/core/Mage/Newsletter/sql/newsletter_setup/mysql4-upgrade-0.8.2-0.8.3.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Newsletter

--- a/app/code/core/Mage/Newsletter/sql/newsletter_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/Newsletter/sql/newsletter_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Newsletter/sql/newsletter_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/Newsletter/sql/newsletter_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Newsletter

--- a/app/code/core/Mage/Newsletter/sql/newsletter_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/Newsletter/sql/newsletter_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Newsletter

--- a/app/code/core/Mage/Oauth/Block/Adminhtml/Oauth/Admin/Token.php
+++ b/app/code/core/Mage/Oauth/Block/Adminhtml/Oauth/Admin/Token.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Oauth

--- a/app/code/core/Mage/Oauth/Block/Adminhtml/Oauth/Admin/Token.php
+++ b/app/code/core/Mage/Oauth/Block/Adminhtml/Oauth/Admin/Token.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Oauth/Block/Adminhtml/Oauth/Admin/Token.php
+++ b/app/code/core/Mage/Oauth/Block/Adminhtml/Oauth/Admin/Token.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Oauth

--- a/app/code/core/Mage/Oauth/Block/Adminhtml/Oauth/Admin/Token/Grid.php
+++ b/app/code/core/Mage/Oauth/Block/Adminhtml/Oauth/Admin/Token/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Oauth

--- a/app/code/core/Mage/Oauth/Block/Adminhtml/Oauth/Admin/Token/Grid.php
+++ b/app/code/core/Mage/Oauth/Block/Adminhtml/Oauth/Admin/Token/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Oauth/Block/Adminhtml/Oauth/Admin/Token/Grid.php
+++ b/app/code/core/Mage/Oauth/Block/Adminhtml/Oauth/Admin/Token/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Oauth

--- a/app/code/core/Mage/Oauth/Block/Adminhtml/Oauth/Authorize.php
+++ b/app/code/core/Mage/Oauth/Block/Adminhtml/Oauth/Authorize.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Oauth

--- a/app/code/core/Mage/Oauth/Block/Adminhtml/Oauth/Authorize.php
+++ b/app/code/core/Mage/Oauth/Block/Adminhtml/Oauth/Authorize.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Oauth/Block/Adminhtml/Oauth/Authorize.php
+++ b/app/code/core/Mage/Oauth/Block/Adminhtml/Oauth/Authorize.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Oauth

--- a/app/code/core/Mage/Oauth/Block/Adminhtml/Oauth/Authorize/Button.php
+++ b/app/code/core/Mage/Oauth/Block/Adminhtml/Oauth/Authorize/Button.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Oauth

--- a/app/code/core/Mage/Oauth/Block/Adminhtml/Oauth/Authorize/Button.php
+++ b/app/code/core/Mage/Oauth/Block/Adminhtml/Oauth/Authorize/Button.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Oauth/Block/Adminhtml/Oauth/Authorize/Button.php
+++ b/app/code/core/Mage/Oauth/Block/Adminhtml/Oauth/Authorize/Button.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Oauth

--- a/app/code/core/Mage/Oauth/Block/Adminhtml/Oauth/AuthorizedTokens.php
+++ b/app/code/core/Mage/Oauth/Block/Adminhtml/Oauth/AuthorizedTokens.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Oauth

--- a/app/code/core/Mage/Oauth/Block/Adminhtml/Oauth/AuthorizedTokens.php
+++ b/app/code/core/Mage/Oauth/Block/Adminhtml/Oauth/AuthorizedTokens.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Oauth/Block/Adminhtml/Oauth/AuthorizedTokens.php
+++ b/app/code/core/Mage/Oauth/Block/Adminhtml/Oauth/AuthorizedTokens.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Oauth

--- a/app/code/core/Mage/Oauth/Block/Adminhtml/Oauth/AuthorizedTokens/Grid.php
+++ b/app/code/core/Mage/Oauth/Block/Adminhtml/Oauth/AuthorizedTokens/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Oauth

--- a/app/code/core/Mage/Oauth/Block/Adminhtml/Oauth/AuthorizedTokens/Grid.php
+++ b/app/code/core/Mage/Oauth/Block/Adminhtml/Oauth/AuthorizedTokens/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Oauth/Block/Adminhtml/Oauth/AuthorizedTokens/Grid.php
+++ b/app/code/core/Mage/Oauth/Block/Adminhtml/Oauth/AuthorizedTokens/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Oauth

--- a/app/code/core/Mage/Oauth/Block/Adminhtml/Oauth/Consumer.php
+++ b/app/code/core/Mage/Oauth/Block/Adminhtml/Oauth/Consumer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Oauth

--- a/app/code/core/Mage/Oauth/Block/Adminhtml/Oauth/Consumer.php
+++ b/app/code/core/Mage/Oauth/Block/Adminhtml/Oauth/Consumer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Oauth/Block/Adminhtml/Oauth/Consumer.php
+++ b/app/code/core/Mage/Oauth/Block/Adminhtml/Oauth/Consumer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Oauth

--- a/app/code/core/Mage/Oauth/Block/Adminhtml/Oauth/Consumer/Edit.php
+++ b/app/code/core/Mage/Oauth/Block/Adminhtml/Oauth/Consumer/Edit.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Oauth

--- a/app/code/core/Mage/Oauth/Block/Adminhtml/Oauth/Consumer/Edit.php
+++ b/app/code/core/Mage/Oauth/Block/Adminhtml/Oauth/Consumer/Edit.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Oauth/Block/Adminhtml/Oauth/Consumer/Edit.php
+++ b/app/code/core/Mage/Oauth/Block/Adminhtml/Oauth/Consumer/Edit.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Oauth

--- a/app/code/core/Mage/Oauth/Block/Adminhtml/Oauth/Consumer/Edit/Form.php
+++ b/app/code/core/Mage/Oauth/Block/Adminhtml/Oauth/Consumer/Edit/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Oauth

--- a/app/code/core/Mage/Oauth/Block/Adminhtml/Oauth/Consumer/Edit/Form.php
+++ b/app/code/core/Mage/Oauth/Block/Adminhtml/Oauth/Consumer/Edit/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Oauth/Block/Adminhtml/Oauth/Consumer/Edit/Form.php
+++ b/app/code/core/Mage/Oauth/Block/Adminhtml/Oauth/Consumer/Edit/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Oauth

--- a/app/code/core/Mage/Oauth/Block/Adminhtml/Oauth/Consumer/Grid.php
+++ b/app/code/core/Mage/Oauth/Block/Adminhtml/Oauth/Consumer/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Oauth

--- a/app/code/core/Mage/Oauth/Block/Adminhtml/Oauth/Consumer/Grid.php
+++ b/app/code/core/Mage/Oauth/Block/Adminhtml/Oauth/Consumer/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Oauth/Block/Adminhtml/Oauth/Consumer/Grid.php
+++ b/app/code/core/Mage/Oauth/Block/Adminhtml/Oauth/Consumer/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Oauth

--- a/app/code/core/Mage/Oauth/Block/Authorize.php
+++ b/app/code/core/Mage/Oauth/Block/Authorize.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Oauth

--- a/app/code/core/Mage/Oauth/Block/Authorize.php
+++ b/app/code/core/Mage/Oauth/Block/Authorize.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Oauth/Block/Authorize.php
+++ b/app/code/core/Mage/Oauth/Block/Authorize.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Oauth

--- a/app/code/core/Mage/Oauth/Block/Authorize/Abstract.php
+++ b/app/code/core/Mage/Oauth/Block/Authorize/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Oauth

--- a/app/code/core/Mage/Oauth/Block/Authorize/Abstract.php
+++ b/app/code/core/Mage/Oauth/Block/Authorize/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Oauth/Block/Authorize/Abstract.php
+++ b/app/code/core/Mage/Oauth/Block/Authorize/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Oauth

--- a/app/code/core/Mage/Oauth/Block/Authorize/Button.php
+++ b/app/code/core/Mage/Oauth/Block/Authorize/Button.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Oauth

--- a/app/code/core/Mage/Oauth/Block/Authorize/Button.php
+++ b/app/code/core/Mage/Oauth/Block/Authorize/Button.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Oauth/Block/Authorize/Button.php
+++ b/app/code/core/Mage/Oauth/Block/Authorize/Button.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Oauth

--- a/app/code/core/Mage/Oauth/Block/Authorize/ButtonBaseAbstract.php
+++ b/app/code/core/Mage/Oauth/Block/Authorize/ButtonBaseAbstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Oauth

--- a/app/code/core/Mage/Oauth/Block/Authorize/ButtonBaseAbstract.php
+++ b/app/code/core/Mage/Oauth/Block/Authorize/ButtonBaseAbstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Oauth/Block/Authorize/ButtonBaseAbstract.php
+++ b/app/code/core/Mage/Oauth/Block/Authorize/ButtonBaseAbstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Oauth

--- a/app/code/core/Mage/Oauth/Block/AuthorizeBaseAbstract.php
+++ b/app/code/core/Mage/Oauth/Block/AuthorizeBaseAbstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Oauth

--- a/app/code/core/Mage/Oauth/Block/AuthorizeBaseAbstract.php
+++ b/app/code/core/Mage/Oauth/Block/AuthorizeBaseAbstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Oauth/Block/AuthorizeBaseAbstract.php
+++ b/app/code/core/Mage/Oauth/Block/AuthorizeBaseAbstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Oauth

--- a/app/code/core/Mage/Oauth/Block/Customer/Token/List.php
+++ b/app/code/core/Mage/Oauth/Block/Customer/Token/List.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Oauth

--- a/app/code/core/Mage/Oauth/Block/Customer/Token/List.php
+++ b/app/code/core/Mage/Oauth/Block/Customer/Token/List.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Oauth/Block/Customer/Token/List.php
+++ b/app/code/core/Mage/Oauth/Block/Customer/Token/List.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Oauth

--- a/app/code/core/Mage/Oauth/Exception.php
+++ b/app/code/core/Mage/Oauth/Exception.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Oauth

--- a/app/code/core/Mage/Oauth/Exception.php
+++ b/app/code/core/Mage/Oauth/Exception.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Oauth/Exception.php
+++ b/app/code/core/Mage/Oauth/Exception.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Oauth

--- a/app/code/core/Mage/Oauth/Helper/Data.php
+++ b/app/code/core/Mage/Oauth/Helper/Data.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Oauth

--- a/app/code/core/Mage/Oauth/Helper/Data.php
+++ b/app/code/core/Mage/Oauth/Helper/Data.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Oauth/Helper/Data.php
+++ b/app/code/core/Mage/Oauth/Helper/Data.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Oauth

--- a/app/code/core/Mage/Oauth/Model/Consumer.php
+++ b/app/code/core/Mage/Oauth/Model/Consumer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Oauth

--- a/app/code/core/Mage/Oauth/Model/Consumer.php
+++ b/app/code/core/Mage/Oauth/Model/Consumer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Oauth/Model/Consumer.php
+++ b/app/code/core/Mage/Oauth/Model/Consumer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Oauth

--- a/app/code/core/Mage/Oauth/Model/Consumer/Validator/KeyLength.php
+++ b/app/code/core/Mage/Oauth/Model/Consumer/Validator/KeyLength.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Oauth

--- a/app/code/core/Mage/Oauth/Model/Consumer/Validator/KeyLength.php
+++ b/app/code/core/Mage/Oauth/Model/Consumer/Validator/KeyLength.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Oauth/Model/Consumer/Validator/KeyLength.php
+++ b/app/code/core/Mage/Oauth/Model/Consumer/Validator/KeyLength.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Oauth

--- a/app/code/core/Mage/Oauth/Model/Nonce.php
+++ b/app/code/core/Mage/Oauth/Model/Nonce.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Oauth

--- a/app/code/core/Mage/Oauth/Model/Nonce.php
+++ b/app/code/core/Mage/Oauth/Model/Nonce.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Oauth/Model/Nonce.php
+++ b/app/code/core/Mage/Oauth/Model/Nonce.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Oauth

--- a/app/code/core/Mage/Oauth/Model/Observer.php
+++ b/app/code/core/Mage/Oauth/Model/Observer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Oauth

--- a/app/code/core/Mage/Oauth/Model/Observer.php
+++ b/app/code/core/Mage/Oauth/Model/Observer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Oauth/Model/Observer.php
+++ b/app/code/core/Mage/Oauth/Model/Observer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Oauth

--- a/app/code/core/Mage/Oauth/Model/Resource/Consumer.php
+++ b/app/code/core/Mage/Oauth/Model/Resource/Consumer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Oauth

--- a/app/code/core/Mage/Oauth/Model/Resource/Consumer.php
+++ b/app/code/core/Mage/Oauth/Model/Resource/Consumer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Oauth/Model/Resource/Consumer.php
+++ b/app/code/core/Mage/Oauth/Model/Resource/Consumer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Oauth

--- a/app/code/core/Mage/Oauth/Model/Resource/Consumer/Collection.php
+++ b/app/code/core/Mage/Oauth/Model/Resource/Consumer/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Oauth

--- a/app/code/core/Mage/Oauth/Model/Resource/Consumer/Collection.php
+++ b/app/code/core/Mage/Oauth/Model/Resource/Consumer/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Oauth/Model/Resource/Consumer/Collection.php
+++ b/app/code/core/Mage/Oauth/Model/Resource/Consumer/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Oauth

--- a/app/code/core/Mage/Oauth/Model/Resource/Nonce.php
+++ b/app/code/core/Mage/Oauth/Model/Resource/Nonce.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Oauth

--- a/app/code/core/Mage/Oauth/Model/Resource/Nonce.php
+++ b/app/code/core/Mage/Oauth/Model/Resource/Nonce.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Oauth/Model/Resource/Nonce.php
+++ b/app/code/core/Mage/Oauth/Model/Resource/Nonce.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Oauth

--- a/app/code/core/Mage/Oauth/Model/Resource/Nonce/Collection.php
+++ b/app/code/core/Mage/Oauth/Model/Resource/Nonce/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Oauth

--- a/app/code/core/Mage/Oauth/Model/Resource/Nonce/Collection.php
+++ b/app/code/core/Mage/Oauth/Model/Resource/Nonce/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Oauth/Model/Resource/Nonce/Collection.php
+++ b/app/code/core/Mage/Oauth/Model/Resource/Nonce/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Oauth

--- a/app/code/core/Mage/Oauth/Model/Resource/Setup.php
+++ b/app/code/core/Mage/Oauth/Model/Resource/Setup.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Oauth

--- a/app/code/core/Mage/Oauth/Model/Resource/Setup.php
+++ b/app/code/core/Mage/Oauth/Model/Resource/Setup.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Oauth/Model/Resource/Setup.php
+++ b/app/code/core/Mage/Oauth/Model/Resource/Setup.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Oauth

--- a/app/code/core/Mage/Oauth/Model/Resource/Token.php
+++ b/app/code/core/Mage/Oauth/Model/Resource/Token.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Oauth

--- a/app/code/core/Mage/Oauth/Model/Resource/Token.php
+++ b/app/code/core/Mage/Oauth/Model/Resource/Token.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Oauth/Model/Resource/Token.php
+++ b/app/code/core/Mage/Oauth/Model/Resource/Token.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Oauth

--- a/app/code/core/Mage/Oauth/Model/Resource/Token/Collection.php
+++ b/app/code/core/Mage/Oauth/Model/Resource/Token/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Oauth

--- a/app/code/core/Mage/Oauth/Model/Resource/Token/Collection.php
+++ b/app/code/core/Mage/Oauth/Model/Resource/Token/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Oauth/Model/Resource/Token/Collection.php
+++ b/app/code/core/Mage/Oauth/Model/Resource/Token/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Oauth

--- a/app/code/core/Mage/Oauth/Model/Server.php
+++ b/app/code/core/Mage/Oauth/Model/Server.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Oauth

--- a/app/code/core/Mage/Oauth/Model/Server.php
+++ b/app/code/core/Mage/Oauth/Model/Server.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Oauth/Model/Server.php
+++ b/app/code/core/Mage/Oauth/Model/Server.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Oauth

--- a/app/code/core/Mage/Oauth/Model/Token.php
+++ b/app/code/core/Mage/Oauth/Model/Token.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Oauth

--- a/app/code/core/Mage/Oauth/Model/Token.php
+++ b/app/code/core/Mage/Oauth/Model/Token.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Oauth/Model/Token.php
+++ b/app/code/core/Mage/Oauth/Model/Token.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Oauth

--- a/app/code/core/Mage/Oauth/controllers/Adminhtml/Oauth/Admin/TokenController.php
+++ b/app/code/core/Mage/Oauth/controllers/Adminhtml/Oauth/Admin/TokenController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Oauth

--- a/app/code/core/Mage/Oauth/controllers/Adminhtml/Oauth/Admin/TokenController.php
+++ b/app/code/core/Mage/Oauth/controllers/Adminhtml/Oauth/Admin/TokenController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Oauth/controllers/Adminhtml/Oauth/Admin/TokenController.php
+++ b/app/code/core/Mage/Oauth/controllers/Adminhtml/Oauth/Admin/TokenController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Oauth

--- a/app/code/core/Mage/Oauth/controllers/Adminhtml/Oauth/AuthorizeController.php
+++ b/app/code/core/Mage/Oauth/controllers/Adminhtml/Oauth/AuthorizeController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Oauth

--- a/app/code/core/Mage/Oauth/controllers/Adminhtml/Oauth/AuthorizeController.php
+++ b/app/code/core/Mage/Oauth/controllers/Adminhtml/Oauth/AuthorizeController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Oauth/controllers/Adminhtml/Oauth/AuthorizeController.php
+++ b/app/code/core/Mage/Oauth/controllers/Adminhtml/Oauth/AuthorizeController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Oauth

--- a/app/code/core/Mage/Oauth/controllers/Adminhtml/Oauth/AuthorizedTokensController.php
+++ b/app/code/core/Mage/Oauth/controllers/Adminhtml/Oauth/AuthorizedTokensController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Oauth

--- a/app/code/core/Mage/Oauth/controllers/Adminhtml/Oauth/AuthorizedTokensController.php
+++ b/app/code/core/Mage/Oauth/controllers/Adminhtml/Oauth/AuthorizedTokensController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Oauth/controllers/Adminhtml/Oauth/AuthorizedTokensController.php
+++ b/app/code/core/Mage/Oauth/controllers/Adminhtml/Oauth/AuthorizedTokensController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Oauth

--- a/app/code/core/Mage/Oauth/controllers/Adminhtml/Oauth/ConsumerController.php
+++ b/app/code/core/Mage/Oauth/controllers/Adminhtml/Oauth/ConsumerController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Oauth

--- a/app/code/core/Mage/Oauth/controllers/Adminhtml/Oauth/ConsumerController.php
+++ b/app/code/core/Mage/Oauth/controllers/Adminhtml/Oauth/ConsumerController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Oauth/controllers/Adminhtml/Oauth/ConsumerController.php
+++ b/app/code/core/Mage/Oauth/controllers/Adminhtml/Oauth/ConsumerController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Oauth

--- a/app/code/core/Mage/Oauth/controllers/AuthorizeController.php
+++ b/app/code/core/Mage/Oauth/controllers/AuthorizeController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Oauth

--- a/app/code/core/Mage/Oauth/controllers/AuthorizeController.php
+++ b/app/code/core/Mage/Oauth/controllers/AuthorizeController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Oauth/controllers/AuthorizeController.php
+++ b/app/code/core/Mage/Oauth/controllers/AuthorizeController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Oauth

--- a/app/code/core/Mage/Oauth/controllers/Customer/TokenController.php
+++ b/app/code/core/Mage/Oauth/controllers/Customer/TokenController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Oauth

--- a/app/code/core/Mage/Oauth/controllers/Customer/TokenController.php
+++ b/app/code/core/Mage/Oauth/controllers/Customer/TokenController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Oauth/controllers/Customer/TokenController.php
+++ b/app/code/core/Mage/Oauth/controllers/Customer/TokenController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Oauth

--- a/app/code/core/Mage/Oauth/controllers/InitiateController.php
+++ b/app/code/core/Mage/Oauth/controllers/InitiateController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Oauth

--- a/app/code/core/Mage/Oauth/controllers/InitiateController.php
+++ b/app/code/core/Mage/Oauth/controllers/InitiateController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Oauth/controllers/InitiateController.php
+++ b/app/code/core/Mage/Oauth/controllers/InitiateController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Oauth

--- a/app/code/core/Mage/Oauth/controllers/TokenController.php
+++ b/app/code/core/Mage/Oauth/controllers/TokenController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Oauth

--- a/app/code/core/Mage/Oauth/controllers/TokenController.php
+++ b/app/code/core/Mage/Oauth/controllers/TokenController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Oauth/controllers/TokenController.php
+++ b/app/code/core/Mage/Oauth/controllers/TokenController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Oauth

--- a/app/code/core/Mage/Oauth/etc/adminhtml.xml
+++ b/app/code/core/Mage/Oauth/etc/adminhtml.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Oauth

--- a/app/code/core/Mage/Oauth/etc/adminhtml.xml
+++ b/app/code/core/Mage/Oauth/etc/adminhtml.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Oauth/etc/adminhtml.xml
+++ b/app/code/core/Mage/Oauth/etc/adminhtml.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Oauth

--- a/app/code/core/Mage/Oauth/etc/config.xml
+++ b/app/code/core/Mage/Oauth/etc/config.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Oauth

--- a/app/code/core/Mage/Oauth/etc/config.xml
+++ b/app/code/core/Mage/Oauth/etc/config.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Oauth/etc/config.xml
+++ b/app/code/core/Mage/Oauth/etc/config.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Oauth

--- a/app/code/core/Mage/Oauth/etc/system.xml
+++ b/app/code/core/Mage/Oauth/etc/system.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Oauth

--- a/app/code/core/Mage/Oauth/etc/system.xml
+++ b/app/code/core/Mage/Oauth/etc/system.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Oauth/etc/system.xml
+++ b/app/code/core/Mage/Oauth/etc/system.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Oauth

--- a/app/code/core/Mage/Oauth/sql/oauth_setup/install-1.0.0.0.php
+++ b/app/code/core/Mage/Oauth/sql/oauth_setup/install-1.0.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Oauth

--- a/app/code/core/Mage/Oauth/sql/oauth_setup/install-1.0.0.0.php
+++ b/app/code/core/Mage/Oauth/sql/oauth_setup/install-1.0.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Oauth/sql/oauth_setup/install-1.0.0.0.php
+++ b/app/code/core/Mage/Oauth/sql/oauth_setup/install-1.0.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Oauth

--- a/app/code/core/Mage/Page/Block/Html.php
+++ b/app/code/core/Mage/Page/Block/Html.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Page

--- a/app/code/core/Mage/Page/Block/Html.php
+++ b/app/code/core/Mage/Page/Block/Html.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Page/Block/Html.php
+++ b/app/code/core/Mage/Page/Block/Html.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Page

--- a/app/code/core/Mage/Page/Block/Html/Breadcrumbs.php
+++ b/app/code/core/Mage/Page/Block/Html/Breadcrumbs.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Page

--- a/app/code/core/Mage/Page/Block/Html/Breadcrumbs.php
+++ b/app/code/core/Mage/Page/Block/Html/Breadcrumbs.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Page/Block/Html/Breadcrumbs.php
+++ b/app/code/core/Mage/Page/Block/Html/Breadcrumbs.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Page

--- a/app/code/core/Mage/Page/Block/Html/CookieNotice.php
+++ b/app/code/core/Mage/Page/Block/Html/CookieNotice.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Page

--- a/app/code/core/Mage/Page/Block/Html/CookieNotice.php
+++ b/app/code/core/Mage/Page/Block/Html/CookieNotice.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Page/Block/Html/CookieNotice.php
+++ b/app/code/core/Mage/Page/Block/Html/CookieNotice.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Page

--- a/app/code/core/Mage/Page/Block/Html/Footer.php
+++ b/app/code/core/Mage/Page/Block/Html/Footer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Page

--- a/app/code/core/Mage/Page/Block/Html/Footer.php
+++ b/app/code/core/Mage/Page/Block/Html/Footer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Page/Block/Html/Footer.php
+++ b/app/code/core/Mage/Page/Block/Html/Footer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Page

--- a/app/code/core/Mage/Page/Block/Html/Head.php
+++ b/app/code/core/Mage/Page/Block/Html/Head.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Page

--- a/app/code/core/Mage/Page/Block/Html/Head.php
+++ b/app/code/core/Mage/Page/Block/Html/Head.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Page/Block/Html/Head.php
+++ b/app/code/core/Mage/Page/Block/Html/Head.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Page

--- a/app/code/core/Mage/Page/Block/Html/Header.php
+++ b/app/code/core/Mage/Page/Block/Html/Header.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Page

--- a/app/code/core/Mage/Page/Block/Html/Header.php
+++ b/app/code/core/Mage/Page/Block/Html/Header.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Page/Block/Html/Header.php
+++ b/app/code/core/Mage/Page/Block/Html/Header.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Page

--- a/app/code/core/Mage/Page/Block/Html/Notices.php
+++ b/app/code/core/Mage/Page/Block/Html/Notices.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Page

--- a/app/code/core/Mage/Page/Block/Html/Notices.php
+++ b/app/code/core/Mage/Page/Block/Html/Notices.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Page/Block/Html/Notices.php
+++ b/app/code/core/Mage/Page/Block/Html/Notices.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Page

--- a/app/code/core/Mage/Page/Block/Html/Pager.php
+++ b/app/code/core/Mage/Page/Block/Html/Pager.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Page

--- a/app/code/core/Mage/Page/Block/Html/Pager.php
+++ b/app/code/core/Mage/Page/Block/Html/Pager.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Page/Block/Html/Pager.php
+++ b/app/code/core/Mage/Page/Block/Html/Pager.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Page

--- a/app/code/core/Mage/Page/Block/Html/Toplinks.php
+++ b/app/code/core/Mage/Page/Block/Html/Toplinks.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Page

--- a/app/code/core/Mage/Page/Block/Html/Toplinks.php
+++ b/app/code/core/Mage/Page/Block/Html/Toplinks.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Page/Block/Html/Toplinks.php
+++ b/app/code/core/Mage/Page/Block/Html/Toplinks.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Page

--- a/app/code/core/Mage/Page/Block/Html/Topmenu.php
+++ b/app/code/core/Mage/Page/Block/Html/Topmenu.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Page

--- a/app/code/core/Mage/Page/Block/Html/Topmenu.php
+++ b/app/code/core/Mage/Page/Block/Html/Topmenu.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Page/Block/Html/Topmenu.php
+++ b/app/code/core/Mage/Page/Block/Html/Topmenu.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Page

--- a/app/code/core/Mage/Page/Block/Html/Topmenu/Renderer.php
+++ b/app/code/core/Mage/Page/Block/Html/Topmenu/Renderer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Page

--- a/app/code/core/Mage/Page/Block/Html/Topmenu/Renderer.php
+++ b/app/code/core/Mage/Page/Block/Html/Topmenu/Renderer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Page/Block/Html/Topmenu/Renderer.php
+++ b/app/code/core/Mage/Page/Block/Html/Topmenu/Renderer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Page

--- a/app/code/core/Mage/Page/Block/Html/Welcome.php
+++ b/app/code/core/Mage/Page/Block/Html/Welcome.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Page

--- a/app/code/core/Mage/Page/Block/Html/Welcome.php
+++ b/app/code/core/Mage/Page/Block/Html/Welcome.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Page/Block/Html/Welcome.php
+++ b/app/code/core/Mage/Page/Block/Html/Welcome.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Page

--- a/app/code/core/Mage/Page/Block/Html/Wrapper.php
+++ b/app/code/core/Mage/Page/Block/Html/Wrapper.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Page

--- a/app/code/core/Mage/Page/Block/Html/Wrapper.php
+++ b/app/code/core/Mage/Page/Block/Html/Wrapper.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Page/Block/Html/Wrapper.php
+++ b/app/code/core/Mage/Page/Block/Html/Wrapper.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Page

--- a/app/code/core/Mage/Page/Block/Js/Cookie.php
+++ b/app/code/core/Mage/Page/Block/Js/Cookie.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Page

--- a/app/code/core/Mage/Page/Block/Js/Cookie.php
+++ b/app/code/core/Mage/Page/Block/Js/Cookie.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Page/Block/Js/Cookie.php
+++ b/app/code/core/Mage/Page/Block/Js/Cookie.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Page

--- a/app/code/core/Mage/Page/Block/Js/Translate.php
+++ b/app/code/core/Mage/Page/Block/Js/Translate.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Page

--- a/app/code/core/Mage/Page/Block/Js/Translate.php
+++ b/app/code/core/Mage/Page/Block/Js/Translate.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Page/Block/Js/Translate.php
+++ b/app/code/core/Mage/Page/Block/Js/Translate.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Page

--- a/app/code/core/Mage/Page/Block/Redirect.php
+++ b/app/code/core/Mage/Page/Block/Redirect.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Page

--- a/app/code/core/Mage/Page/Block/Redirect.php
+++ b/app/code/core/Mage/Page/Block/Redirect.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Page/Block/Redirect.php
+++ b/app/code/core/Mage/Page/Block/Redirect.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Page

--- a/app/code/core/Mage/Page/Block/Switch.php
+++ b/app/code/core/Mage/Page/Block/Switch.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Page

--- a/app/code/core/Mage/Page/Block/Switch.php
+++ b/app/code/core/Mage/Page/Block/Switch.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Page/Block/Switch.php
+++ b/app/code/core/Mage/Page/Block/Switch.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Page

--- a/app/code/core/Mage/Page/Block/Template/Container.php
+++ b/app/code/core/Mage/Page/Block/Template/Container.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Page

--- a/app/code/core/Mage/Page/Block/Template/Container.php
+++ b/app/code/core/Mage/Page/Block/Template/Container.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Page/Block/Template/Container.php
+++ b/app/code/core/Mage/Page/Block/Template/Container.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Page

--- a/app/code/core/Mage/Page/Block/Template/Links.php
+++ b/app/code/core/Mage/Page/Block/Template/Links.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Page

--- a/app/code/core/Mage/Page/Block/Template/Links.php
+++ b/app/code/core/Mage/Page/Block/Template/Links.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Page/Block/Template/Links.php
+++ b/app/code/core/Mage/Page/Block/Template/Links.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Page

--- a/app/code/core/Mage/Page/Block/Template/Links/Block.php
+++ b/app/code/core/Mage/Page/Block/Template/Links/Block.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Page

--- a/app/code/core/Mage/Page/Block/Template/Links/Block.php
+++ b/app/code/core/Mage/Page/Block/Template/Links/Block.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Page/Block/Template/Links/Block.php
+++ b/app/code/core/Mage/Page/Block/Template/Links/Block.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Page

--- a/app/code/core/Mage/Page/Helper/Data.php
+++ b/app/code/core/Mage/Page/Helper/Data.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Page

--- a/app/code/core/Mage/Page/Helper/Data.php
+++ b/app/code/core/Mage/Page/Helper/Data.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Page/Helper/Data.php
+++ b/app/code/core/Mage/Page/Helper/Data.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Page

--- a/app/code/core/Mage/Page/Helper/Html.php
+++ b/app/code/core/Mage/Page/Helper/Html.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Page

--- a/app/code/core/Mage/Page/Helper/Html.php
+++ b/app/code/core/Mage/Page/Helper/Html.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Page/Helper/Html.php
+++ b/app/code/core/Mage/Page/Helper/Html.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Page

--- a/app/code/core/Mage/Page/Helper/Layout.php
+++ b/app/code/core/Mage/Page/Helper/Layout.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Page

--- a/app/code/core/Mage/Page/Helper/Layout.php
+++ b/app/code/core/Mage/Page/Helper/Layout.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Page/Helper/Layout.php
+++ b/app/code/core/Mage/Page/Helper/Layout.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Page

--- a/app/code/core/Mage/Page/Model/Config.php
+++ b/app/code/core/Mage/Page/Model/Config.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Page

--- a/app/code/core/Mage/Page/Model/Config.php
+++ b/app/code/core/Mage/Page/Model/Config.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Page/Model/Config.php
+++ b/app/code/core/Mage/Page/Model/Config.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Page

--- a/app/code/core/Mage/Page/Model/Source/Layout.php
+++ b/app/code/core/Mage/Page/Model/Source/Layout.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Page

--- a/app/code/core/Mage/Page/Model/Source/Layout.php
+++ b/app/code/core/Mage/Page/Model/Source/Layout.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Page/Model/Source/Layout.php
+++ b/app/code/core/Mage/Page/Model/Source/Layout.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Page

--- a/app/code/core/Mage/Page/etc/config.xml
+++ b/app/code/core/Mage/Page/etc/config.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Page

--- a/app/code/core/Mage/Page/etc/config.xml
+++ b/app/code/core/Mage/Page/etc/config.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Page

--- a/app/code/core/Mage/Page/etc/config.xml
+++ b/app/code/core/Mage/Page/etc/config.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Page/etc/system.xml
+++ b/app/code/core/Mage/Page/etc/system.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Page

--- a/app/code/core/Mage/Page/etc/system.xml
+++ b/app/code/core/Mage/Page/etc/system.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Page

--- a/app/code/core/Mage/Page/etc/system.xml
+++ b/app/code/core/Mage/Page/etc/system.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paygate/Block/Authorizenet/Form/Cc.php
+++ b/app/code/core/Mage/Paygate/Block/Authorizenet/Form/Cc.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paygate/Block/Authorizenet/Form/Cc.php
+++ b/app/code/core/Mage/Paygate/Block/Authorizenet/Form/Cc.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paygate

--- a/app/code/core/Mage/Paygate/Block/Authorizenet/Form/Cc.php
+++ b/app/code/core/Mage/Paygate/Block/Authorizenet/Form/Cc.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paygate

--- a/app/code/core/Mage/Paygate/Block/Authorizenet/Info/Cc.php
+++ b/app/code/core/Mage/Paygate/Block/Authorizenet/Info/Cc.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paygate/Block/Authorizenet/Info/Cc.php
+++ b/app/code/core/Mage/Paygate/Block/Authorizenet/Info/Cc.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paygate

--- a/app/code/core/Mage/Paygate/Block/Authorizenet/Info/Cc.php
+++ b/app/code/core/Mage/Paygate/Block/Authorizenet/Info/Cc.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paygate

--- a/app/code/core/Mage/Paygate/Helper/Data.php
+++ b/app/code/core/Mage/Paygate/Helper/Data.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paygate/Helper/Data.php
+++ b/app/code/core/Mage/Paygate/Helper/Data.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paygate

--- a/app/code/core/Mage/Paygate/Helper/Data.php
+++ b/app/code/core/Mage/Paygate/Helper/Data.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paygate

--- a/app/code/core/Mage/Paygate/Model/Authorizenet.php
+++ b/app/code/core/Mage/Paygate/Model/Authorizenet.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paygate/Model/Authorizenet.php
+++ b/app/code/core/Mage/Paygate/Model/Authorizenet.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paygate

--- a/app/code/core/Mage/Paygate/Model/Authorizenet.php
+++ b/app/code/core/Mage/Paygate/Model/Authorizenet.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paygate

--- a/app/code/core/Mage/Paygate/Model/Authorizenet/Cards.php
+++ b/app/code/core/Mage/Paygate/Model/Authorizenet/Cards.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paygate/Model/Authorizenet/Cards.php
+++ b/app/code/core/Mage/Paygate/Model/Authorizenet/Cards.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paygate

--- a/app/code/core/Mage/Paygate/Model/Authorizenet/Cards.php
+++ b/app/code/core/Mage/Paygate/Model/Authorizenet/Cards.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paygate

--- a/app/code/core/Mage/Paygate/Model/Authorizenet/Debug.php
+++ b/app/code/core/Mage/Paygate/Model/Authorizenet/Debug.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paygate/Model/Authorizenet/Debug.php
+++ b/app/code/core/Mage/Paygate/Model/Authorizenet/Debug.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paygate

--- a/app/code/core/Mage/Paygate/Model/Authorizenet/Debug.php
+++ b/app/code/core/Mage/Paygate/Model/Authorizenet/Debug.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paygate

--- a/app/code/core/Mage/Paygate/Model/Authorizenet/Request.php
+++ b/app/code/core/Mage/Paygate/Model/Authorizenet/Request.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paygate/Model/Authorizenet/Request.php
+++ b/app/code/core/Mage/Paygate/Model/Authorizenet/Request.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paygate

--- a/app/code/core/Mage/Paygate/Model/Authorizenet/Request.php
+++ b/app/code/core/Mage/Paygate/Model/Authorizenet/Request.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paygate

--- a/app/code/core/Mage/Paygate/Model/Authorizenet/Result.php
+++ b/app/code/core/Mage/Paygate/Model/Authorizenet/Result.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paygate/Model/Authorizenet/Result.php
+++ b/app/code/core/Mage/Paygate/Model/Authorizenet/Result.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paygate

--- a/app/code/core/Mage/Paygate/Model/Authorizenet/Result.php
+++ b/app/code/core/Mage/Paygate/Model/Authorizenet/Result.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paygate

--- a/app/code/core/Mage/Paygate/Model/Authorizenet/Source/Cctype.php
+++ b/app/code/core/Mage/Paygate/Model/Authorizenet/Source/Cctype.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paygate/Model/Authorizenet/Source/Cctype.php
+++ b/app/code/core/Mage/Paygate/Model/Authorizenet/Source/Cctype.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paygate

--- a/app/code/core/Mage/Paygate/Model/Authorizenet/Source/Cctype.php
+++ b/app/code/core/Mage/Paygate/Model/Authorizenet/Source/Cctype.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paygate

--- a/app/code/core/Mage/Paygate/Model/Authorizenet/Source/PaymentAction.php
+++ b/app/code/core/Mage/Paygate/Model/Authorizenet/Source/PaymentAction.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paygate/Model/Authorizenet/Source/PaymentAction.php
+++ b/app/code/core/Mage/Paygate/Model/Authorizenet/Source/PaymentAction.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paygate

--- a/app/code/core/Mage/Paygate/Model/Authorizenet/Source/PaymentAction.php
+++ b/app/code/core/Mage/Paygate/Model/Authorizenet/Source/PaymentAction.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paygate

--- a/app/code/core/Mage/Paygate/Model/Mysql4/Authorizenet/Debug.php
+++ b/app/code/core/Mage/Paygate/Model/Mysql4/Authorizenet/Debug.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paygate/Model/Mysql4/Authorizenet/Debug.php
+++ b/app/code/core/Mage/Paygate/Model/Mysql4/Authorizenet/Debug.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paygate

--- a/app/code/core/Mage/Paygate/Model/Mysql4/Authorizenet/Debug.php
+++ b/app/code/core/Mage/Paygate/Model/Mysql4/Authorizenet/Debug.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paygate

--- a/app/code/core/Mage/Paygate/Model/Mysql4/Authorizenet/Debug/Collection.php
+++ b/app/code/core/Mage/Paygate/Model/Mysql4/Authorizenet/Debug/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paygate/Model/Mysql4/Authorizenet/Debug/Collection.php
+++ b/app/code/core/Mage/Paygate/Model/Mysql4/Authorizenet/Debug/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paygate

--- a/app/code/core/Mage/Paygate/Model/Mysql4/Authorizenet/Debug/Collection.php
+++ b/app/code/core/Mage/Paygate/Model/Mysql4/Authorizenet/Debug/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paygate

--- a/app/code/core/Mage/Paygate/Model/Resource/Authorizenet/Debug.php
+++ b/app/code/core/Mage/Paygate/Model/Resource/Authorizenet/Debug.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paygate/Model/Resource/Authorizenet/Debug.php
+++ b/app/code/core/Mage/Paygate/Model/Resource/Authorizenet/Debug.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paygate

--- a/app/code/core/Mage/Paygate/Model/Resource/Authorizenet/Debug.php
+++ b/app/code/core/Mage/Paygate/Model/Resource/Authorizenet/Debug.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paygate

--- a/app/code/core/Mage/Paygate/Model/Resource/Authorizenet/Debug/Collection.php
+++ b/app/code/core/Mage/Paygate/Model/Resource/Authorizenet/Debug/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paygate/Model/Resource/Authorizenet/Debug/Collection.php
+++ b/app/code/core/Mage/Paygate/Model/Resource/Authorizenet/Debug/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paygate

--- a/app/code/core/Mage/Paygate/Model/Resource/Authorizenet/Debug/Collection.php
+++ b/app/code/core/Mage/Paygate/Model/Resource/Authorizenet/Debug/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paygate

--- a/app/code/core/Mage/Paygate/controllers/Adminhtml/Paygate/Authorizenet/PaymentController.php
+++ b/app/code/core/Mage/Paygate/controllers/Adminhtml/Paygate/Authorizenet/PaymentController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paygate/controllers/Adminhtml/Paygate/Authorizenet/PaymentController.php
+++ b/app/code/core/Mage/Paygate/controllers/Adminhtml/Paygate/Authorizenet/PaymentController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paygate

--- a/app/code/core/Mage/Paygate/controllers/Adminhtml/Paygate/Authorizenet/PaymentController.php
+++ b/app/code/core/Mage/Paygate/controllers/Adminhtml/Paygate/Authorizenet/PaymentController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paygate

--- a/app/code/core/Mage/Paygate/controllers/Authorizenet/PaymentController.php
+++ b/app/code/core/Mage/Paygate/controllers/Authorizenet/PaymentController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paygate/controllers/Authorizenet/PaymentController.php
+++ b/app/code/core/Mage/Paygate/controllers/Authorizenet/PaymentController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paygate

--- a/app/code/core/Mage/Paygate/controllers/Authorizenet/PaymentController.php
+++ b/app/code/core/Mage/Paygate/controllers/Authorizenet/PaymentController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paygate

--- a/app/code/core/Mage/Paygate/etc/config.xml
+++ b/app/code/core/Mage/Paygate/etc/config.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paygate

--- a/app/code/core/Mage/Paygate/etc/config.xml
+++ b/app/code/core/Mage/Paygate/etc/config.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paygate

--- a/app/code/core/Mage/Paygate/etc/config.xml
+++ b/app/code/core/Mage/Paygate/etc/config.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paygate/etc/system.xml
+++ b/app/code/core/Mage/Paygate/etc/system.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paygate

--- a/app/code/core/Mage/Paygate/etc/system.xml
+++ b/app/code/core/Mage/Paygate/etc/system.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paygate

--- a/app/code/core/Mage/Paygate/etc/system.xml
+++ b/app/code/core/Mage/Paygate/etc/system.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paygate/sql/paygate_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Paygate/sql/paygate_setup/install-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paygate/sql/paygate_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Paygate/sql/paygate_setup/install-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paygate

--- a/app/code/core/Mage/Paygate/sql/paygate_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Paygate/sql/paygate_setup/install-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paygate

--- a/app/code/core/Mage/Paygate/sql/paygate_setup/mysql4-data-upgrade-0.7.0-0.7.1.php
+++ b/app/code/core/Mage/Paygate/sql/paygate_setup/mysql4-data-upgrade-0.7.0-0.7.1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paygate/sql/paygate_setup/mysql4-data-upgrade-0.7.0-0.7.1.php
+++ b/app/code/core/Mage/Paygate/sql/paygate_setup/mysql4-data-upgrade-0.7.0-0.7.1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paygate

--- a/app/code/core/Mage/Paygate/sql/paygate_setup/mysql4-data-upgrade-0.7.0-0.7.1.php
+++ b/app/code/core/Mage/Paygate/sql/paygate_setup/mysql4-data-upgrade-0.7.0-0.7.1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paygate

--- a/app/code/core/Mage/Paygate/sql/paygate_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/Paygate/sql/paygate_setup/mysql4-install-0.7.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paygate/sql/paygate_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/Paygate/sql/paygate_setup/mysql4-install-0.7.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paygate

--- a/app/code/core/Mage/Paygate/sql/paygate_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/Paygate/sql/paygate_setup/mysql4-install-0.7.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paygate

--- a/app/code/core/Mage/Paygate/sql/paygate_setup/mysql4-upgrade-0.7.0-0.7.1.php
+++ b/app/code/core/Mage/Paygate/sql/paygate_setup/mysql4-upgrade-0.7.0-0.7.1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paygate/sql/paygate_setup/mysql4-upgrade-0.7.0-0.7.1.php
+++ b/app/code/core/Mage/Paygate/sql/paygate_setup/mysql4-upgrade-0.7.0-0.7.1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paygate

--- a/app/code/core/Mage/Paygate/sql/paygate_setup/mysql4-upgrade-0.7.0-0.7.1.php
+++ b/app/code/core/Mage/Paygate/sql/paygate_setup/mysql4-upgrade-0.7.0-0.7.1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paygate

--- a/app/code/core/Mage/Payment/Block/Catalog/Product/View/Profile.php
+++ b/app/code/core/Mage/Payment/Block/Catalog/Product/View/Profile.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Payment/Block/Catalog/Product/View/Profile.php
+++ b/app/code/core/Mage/Payment/Block/Catalog/Product/View/Profile.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Payment

--- a/app/code/core/Mage/Payment/Block/Catalog/Product/View/Profile.php
+++ b/app/code/core/Mage/Payment/Block/Catalog/Product/View/Profile.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Payment

--- a/app/code/core/Mage/Payment/Block/Form.php
+++ b/app/code/core/Mage/Payment/Block/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Payment/Block/Form.php
+++ b/app/code/core/Mage/Payment/Block/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Payment

--- a/app/code/core/Mage/Payment/Block/Form.php
+++ b/app/code/core/Mage/Payment/Block/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Payment

--- a/app/code/core/Mage/Payment/Block/Form/Banktransfer.php
+++ b/app/code/core/Mage/Payment/Block/Form/Banktransfer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Payment/Block/Form/Banktransfer.php
+++ b/app/code/core/Mage/Payment/Block/Form/Banktransfer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Payment

--- a/app/code/core/Mage/Payment/Block/Form/Banktransfer.php
+++ b/app/code/core/Mage/Payment/Block/Form/Banktransfer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Payment

--- a/app/code/core/Mage/Payment/Block/Form/Cashondelivery.php
+++ b/app/code/core/Mage/Payment/Block/Form/Cashondelivery.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Payment/Block/Form/Cashondelivery.php
+++ b/app/code/core/Mage/Payment/Block/Form/Cashondelivery.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Payment

--- a/app/code/core/Mage/Payment/Block/Form/Cashondelivery.php
+++ b/app/code/core/Mage/Payment/Block/Form/Cashondelivery.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Payment

--- a/app/code/core/Mage/Payment/Block/Form/Cc.php
+++ b/app/code/core/Mage/Payment/Block/Form/Cc.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Payment/Block/Form/Cc.php
+++ b/app/code/core/Mage/Payment/Block/Form/Cc.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Payment

--- a/app/code/core/Mage/Payment/Block/Form/Cc.php
+++ b/app/code/core/Mage/Payment/Block/Form/Cc.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Payment

--- a/app/code/core/Mage/Payment/Block/Form/Ccsave.php
+++ b/app/code/core/Mage/Payment/Block/Form/Ccsave.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Payment/Block/Form/Ccsave.php
+++ b/app/code/core/Mage/Payment/Block/Form/Ccsave.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Payment

--- a/app/code/core/Mage/Payment/Block/Form/Ccsave.php
+++ b/app/code/core/Mage/Payment/Block/Form/Ccsave.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Payment

--- a/app/code/core/Mage/Payment/Block/Form/Checkmo.php
+++ b/app/code/core/Mage/Payment/Block/Form/Checkmo.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Payment/Block/Form/Checkmo.php
+++ b/app/code/core/Mage/Payment/Block/Form/Checkmo.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Payment

--- a/app/code/core/Mage/Payment/Block/Form/Checkmo.php
+++ b/app/code/core/Mage/Payment/Block/Form/Checkmo.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Payment

--- a/app/code/core/Mage/Payment/Block/Form/Container.php
+++ b/app/code/core/Mage/Payment/Block/Form/Container.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Payment/Block/Form/Container.php
+++ b/app/code/core/Mage/Payment/Block/Form/Container.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Payment

--- a/app/code/core/Mage/Payment/Block/Form/Container.php
+++ b/app/code/core/Mage/Payment/Block/Form/Container.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Payment

--- a/app/code/core/Mage/Payment/Block/Form/Purchaseorder.php
+++ b/app/code/core/Mage/Payment/Block/Form/Purchaseorder.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Payment/Block/Form/Purchaseorder.php
+++ b/app/code/core/Mage/Payment/Block/Form/Purchaseorder.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Payment

--- a/app/code/core/Mage/Payment/Block/Form/Purchaseorder.php
+++ b/app/code/core/Mage/Payment/Block/Form/Purchaseorder.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Payment

--- a/app/code/core/Mage/Payment/Block/Info.php
+++ b/app/code/core/Mage/Payment/Block/Info.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Payment/Block/Info.php
+++ b/app/code/core/Mage/Payment/Block/Info.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Payment

--- a/app/code/core/Mage/Payment/Block/Info.php
+++ b/app/code/core/Mage/Payment/Block/Info.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Payment

--- a/app/code/core/Mage/Payment/Block/Info/Banktransfer.php
+++ b/app/code/core/Mage/Payment/Block/Info/Banktransfer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Payment/Block/Info/Banktransfer.php
+++ b/app/code/core/Mage/Payment/Block/Info/Banktransfer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Payment

--- a/app/code/core/Mage/Payment/Block/Info/Banktransfer.php
+++ b/app/code/core/Mage/Payment/Block/Info/Banktransfer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Payment

--- a/app/code/core/Mage/Payment/Block/Info/Cc.php
+++ b/app/code/core/Mage/Payment/Block/Info/Cc.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Payment/Block/Info/Cc.php
+++ b/app/code/core/Mage/Payment/Block/Info/Cc.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Payment

--- a/app/code/core/Mage/Payment/Block/Info/Cc.php
+++ b/app/code/core/Mage/Payment/Block/Info/Cc.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Payment

--- a/app/code/core/Mage/Payment/Block/Info/Ccsave.php
+++ b/app/code/core/Mage/Payment/Block/Info/Ccsave.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Payment/Block/Info/Ccsave.php
+++ b/app/code/core/Mage/Payment/Block/Info/Ccsave.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Payment

--- a/app/code/core/Mage/Payment/Block/Info/Ccsave.php
+++ b/app/code/core/Mage/Payment/Block/Info/Ccsave.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Payment

--- a/app/code/core/Mage/Payment/Block/Info/Checkmo.php
+++ b/app/code/core/Mage/Payment/Block/Info/Checkmo.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Payment/Block/Info/Checkmo.php
+++ b/app/code/core/Mage/Payment/Block/Info/Checkmo.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Payment

--- a/app/code/core/Mage/Payment/Block/Info/Checkmo.php
+++ b/app/code/core/Mage/Payment/Block/Info/Checkmo.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Payment

--- a/app/code/core/Mage/Payment/Block/Info/Container.php
+++ b/app/code/core/Mage/Payment/Block/Info/Container.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Payment/Block/Info/Container.php
+++ b/app/code/core/Mage/Payment/Block/Info/Container.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Payment

--- a/app/code/core/Mage/Payment/Block/Info/Container.php
+++ b/app/code/core/Mage/Payment/Block/Info/Container.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Payment

--- a/app/code/core/Mage/Payment/Block/Info/Purchaseorder.php
+++ b/app/code/core/Mage/Payment/Block/Info/Purchaseorder.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Payment/Block/Info/Purchaseorder.php
+++ b/app/code/core/Mage/Payment/Block/Info/Purchaseorder.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Payment

--- a/app/code/core/Mage/Payment/Block/Info/Purchaseorder.php
+++ b/app/code/core/Mage/Payment/Block/Info/Purchaseorder.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Payment

--- a/app/code/core/Mage/Payment/Exception.php
+++ b/app/code/core/Mage/Payment/Exception.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Payment/Exception.php
+++ b/app/code/core/Mage/Payment/Exception.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Payment

--- a/app/code/core/Mage/Payment/Exception.php
+++ b/app/code/core/Mage/Payment/Exception.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Payment

--- a/app/code/core/Mage/Payment/Helper/Data.php
+++ b/app/code/core/Mage/Payment/Helper/Data.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Payment/Helper/Data.php
+++ b/app/code/core/Mage/Payment/Helper/Data.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Payment

--- a/app/code/core/Mage/Payment/Helper/Data.php
+++ b/app/code/core/Mage/Payment/Helper/Data.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Payment

--- a/app/code/core/Mage/Payment/Model/Billing/Agreement/MethodInterface.php
+++ b/app/code/core/Mage/Payment/Model/Billing/Agreement/MethodInterface.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Payment/Model/Billing/Agreement/MethodInterface.php
+++ b/app/code/core/Mage/Payment/Model/Billing/Agreement/MethodInterface.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Payment

--- a/app/code/core/Mage/Payment/Model/Billing/Agreement/MethodInterface.php
+++ b/app/code/core/Mage/Payment/Model/Billing/Agreement/MethodInterface.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Payment

--- a/app/code/core/Mage/Payment/Model/Billing/AgreementAbstract.php
+++ b/app/code/core/Mage/Payment/Model/Billing/AgreementAbstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Payment/Model/Billing/AgreementAbstract.php
+++ b/app/code/core/Mage/Payment/Model/Billing/AgreementAbstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Payment

--- a/app/code/core/Mage/Payment/Model/Billing/AgreementAbstract.php
+++ b/app/code/core/Mage/Payment/Model/Billing/AgreementAbstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Payment

--- a/app/code/core/Mage/Payment/Model/Config.php
+++ b/app/code/core/Mage/Payment/Model/Config.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Payment/Model/Config.php
+++ b/app/code/core/Mage/Payment/Model/Config.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Payment

--- a/app/code/core/Mage/Payment/Model/Config.php
+++ b/app/code/core/Mage/Payment/Model/Config.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Payment

--- a/app/code/core/Mage/Payment/Model/Info.php
+++ b/app/code/core/Mage/Payment/Model/Info.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Payment/Model/Info.php
+++ b/app/code/core/Mage/Payment/Model/Info.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Payment

--- a/app/code/core/Mage/Payment/Model/Info.php
+++ b/app/code/core/Mage/Payment/Model/Info.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Payment

--- a/app/code/core/Mage/Payment/Model/Info/Exception.php
+++ b/app/code/core/Mage/Payment/Model/Info/Exception.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Payment/Model/Info/Exception.php
+++ b/app/code/core/Mage/Payment/Model/Info/Exception.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Payment

--- a/app/code/core/Mage/Payment/Model/Info/Exception.php
+++ b/app/code/core/Mage/Payment/Model/Info/Exception.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Payment

--- a/app/code/core/Mage/Payment/Model/Method/Abstract.php
+++ b/app/code/core/Mage/Payment/Model/Method/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Payment/Model/Method/Abstract.php
+++ b/app/code/core/Mage/Payment/Model/Method/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Payment

--- a/app/code/core/Mage/Payment/Model/Method/Abstract.php
+++ b/app/code/core/Mage/Payment/Model/Method/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Payment

--- a/app/code/core/Mage/Payment/Model/Method/Banktransfer.php
+++ b/app/code/core/Mage/Payment/Model/Method/Banktransfer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Payment/Model/Method/Banktransfer.php
+++ b/app/code/core/Mage/Payment/Model/Method/Banktransfer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Payment

--- a/app/code/core/Mage/Payment/Model/Method/Banktransfer.php
+++ b/app/code/core/Mage/Payment/Model/Method/Banktransfer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Payment

--- a/app/code/core/Mage/Payment/Model/Method/Cashondelivery.php
+++ b/app/code/core/Mage/Payment/Model/Method/Cashondelivery.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Payment/Model/Method/Cashondelivery.php
+++ b/app/code/core/Mage/Payment/Model/Method/Cashondelivery.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Payment

--- a/app/code/core/Mage/Payment/Model/Method/Cashondelivery.php
+++ b/app/code/core/Mage/Payment/Model/Method/Cashondelivery.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Payment

--- a/app/code/core/Mage/Payment/Model/Method/Cc.php
+++ b/app/code/core/Mage/Payment/Model/Method/Cc.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Payment/Model/Method/Cc.php
+++ b/app/code/core/Mage/Payment/Model/Method/Cc.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Payment

--- a/app/code/core/Mage/Payment/Model/Method/Cc.php
+++ b/app/code/core/Mage/Payment/Model/Method/Cc.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Payment

--- a/app/code/core/Mage/Payment/Model/Method/Ccsave.php
+++ b/app/code/core/Mage/Payment/Model/Method/Ccsave.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Payment/Model/Method/Ccsave.php
+++ b/app/code/core/Mage/Payment/Model/Method/Ccsave.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Payment

--- a/app/code/core/Mage/Payment/Model/Method/Ccsave.php
+++ b/app/code/core/Mage/Payment/Model/Method/Ccsave.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Payment

--- a/app/code/core/Mage/Payment/Model/Method/Checkmo.php
+++ b/app/code/core/Mage/Payment/Model/Method/Checkmo.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Payment/Model/Method/Checkmo.php
+++ b/app/code/core/Mage/Payment/Model/Method/Checkmo.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Payment

--- a/app/code/core/Mage/Payment/Model/Method/Checkmo.php
+++ b/app/code/core/Mage/Payment/Model/Method/Checkmo.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Payment

--- a/app/code/core/Mage/Payment/Model/Method/Free.php
+++ b/app/code/core/Mage/Payment/Model/Method/Free.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Payment/Model/Method/Free.php
+++ b/app/code/core/Mage/Payment/Model/Method/Free.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Payment

--- a/app/code/core/Mage/Payment/Model/Method/Free.php
+++ b/app/code/core/Mage/Payment/Model/Method/Free.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Payment

--- a/app/code/core/Mage/Payment/Model/Method/Purchaseorder.php
+++ b/app/code/core/Mage/Payment/Model/Method/Purchaseorder.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Payment/Model/Method/Purchaseorder.php
+++ b/app/code/core/Mage/Payment/Model/Method/Purchaseorder.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Payment

--- a/app/code/core/Mage/Payment/Model/Method/Purchaseorder.php
+++ b/app/code/core/Mage/Payment/Model/Method/Purchaseorder.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Payment

--- a/app/code/core/Mage/Payment/Model/Observer.php
+++ b/app/code/core/Mage/Payment/Model/Observer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Payment/Model/Observer.php
+++ b/app/code/core/Mage/Payment/Model/Observer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Payment

--- a/app/code/core/Mage/Payment/Model/Observer.php
+++ b/app/code/core/Mage/Payment/Model/Observer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Payment

--- a/app/code/core/Mage/Payment/Model/Paygate/Result.php
+++ b/app/code/core/Mage/Payment/Model/Paygate/Result.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Payment/Model/Paygate/Result.php
+++ b/app/code/core/Mage/Payment/Model/Paygate/Result.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Payment

--- a/app/code/core/Mage/Payment/Model/Paygate/Result.php
+++ b/app/code/core/Mage/Payment/Model/Paygate/Result.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Payment

--- a/app/code/core/Mage/Payment/Model/Recurring/Profile.php
+++ b/app/code/core/Mage/Payment/Model/Recurring/Profile.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Payment/Model/Recurring/Profile.php
+++ b/app/code/core/Mage/Payment/Model/Recurring/Profile.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Payment

--- a/app/code/core/Mage/Payment/Model/Recurring/Profile.php
+++ b/app/code/core/Mage/Payment/Model/Recurring/Profile.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Payment

--- a/app/code/core/Mage/Payment/Model/Recurring/Profile/MethodInterface.php
+++ b/app/code/core/Mage/Payment/Model/Recurring/Profile/MethodInterface.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Payment/Model/Recurring/Profile/MethodInterface.php
+++ b/app/code/core/Mage/Payment/Model/Recurring/Profile/MethodInterface.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Payment

--- a/app/code/core/Mage/Payment/Model/Recurring/Profile/MethodInterface.php
+++ b/app/code/core/Mage/Payment/Model/Recurring/Profile/MethodInterface.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Payment

--- a/app/code/core/Mage/Payment/Model/Source/Cctype.php
+++ b/app/code/core/Mage/Payment/Model/Source/Cctype.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Payment/Model/Source/Cctype.php
+++ b/app/code/core/Mage/Payment/Model/Source/Cctype.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Payment

--- a/app/code/core/Mage/Payment/Model/Source/Cctype.php
+++ b/app/code/core/Mage/Payment/Model/Source/Cctype.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Payment

--- a/app/code/core/Mage/Payment/Model/Source/Invoice.php
+++ b/app/code/core/Mage/Payment/Model/Source/Invoice.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Payment/Model/Source/Invoice.php
+++ b/app/code/core/Mage/Payment/Model/Source/Invoice.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Payment

--- a/app/code/core/Mage/Payment/Model/Source/Invoice.php
+++ b/app/code/core/Mage/Payment/Model/Source/Invoice.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Payment

--- a/app/code/core/Mage/Payment/etc/adminhtml.xml
+++ b/app/code/core/Mage/Payment/etc/adminhtml.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Payment

--- a/app/code/core/Mage/Payment/etc/adminhtml.xml
+++ b/app/code/core/Mage/Payment/etc/adminhtml.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Payment

--- a/app/code/core/Mage/Payment/etc/adminhtml.xml
+++ b/app/code/core/Mage/Payment/etc/adminhtml.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Payment/etc/config.xml
+++ b/app/code/core/Mage/Payment/etc/config.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Payment

--- a/app/code/core/Mage/Payment/etc/config.xml
+++ b/app/code/core/Mage/Payment/etc/config.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Payment

--- a/app/code/core/Mage/Payment/etc/config.xml
+++ b/app/code/core/Mage/Payment/etc/config.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Payment/etc/system.xml
+++ b/app/code/core/Mage/Payment/etc/system.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Payment

--- a/app/code/core/Mage/Payment/etc/system.xml
+++ b/app/code/core/Mage/Payment/etc/system.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Payment

--- a/app/code/core/Mage/Payment/etc/system.xml
+++ b/app/code/core/Mage/Payment/etc/system.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Payment/sql/payment_setup/upgrade-1.6.0.0-1.6.0.1.php
+++ b/app/code/core/Mage/Payment/sql/payment_setup/upgrade-1.6.0.0-1.6.0.1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Payment/sql/payment_setup/upgrade-1.6.0.0-1.6.0.1.php
+++ b/app/code/core/Mage/Payment/sql/payment_setup/upgrade-1.6.0.0-1.6.0.1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Payment

--- a/app/code/core/Mage/Payment/sql/payment_setup/upgrade-1.6.0.0-1.6.0.1.php
+++ b/app/code/core/Mage/Payment/sql/payment_setup/upgrade-1.6.0.0-1.6.0.1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Payment

--- a/app/code/core/Mage/Paypal/Block/Adminhtml/Settlement/Details.php
+++ b/app/code/core/Mage/Paypal/Block/Adminhtml/Settlement/Details.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Block/Adminhtml/Settlement/Details.php
+++ b/app/code/core/Mage/Paypal/Block/Adminhtml/Settlement/Details.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Block/Adminhtml/Settlement/Details.php
+++ b/app/code/core/Mage/Paypal/Block/Adminhtml/Settlement/Details.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Block/Adminhtml/Settlement/Details/Form.php
+++ b/app/code/core/Mage/Paypal/Block/Adminhtml/Settlement/Details/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Block/Adminhtml/Settlement/Details/Form.php
+++ b/app/code/core/Mage/Paypal/Block/Adminhtml/Settlement/Details/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Block/Adminhtml/Settlement/Details/Form.php
+++ b/app/code/core/Mage/Paypal/Block/Adminhtml/Settlement/Details/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Block/Adminhtml/Settlement/Report.php
+++ b/app/code/core/Mage/Paypal/Block/Adminhtml/Settlement/Report.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Block/Adminhtml/Settlement/Report.php
+++ b/app/code/core/Mage/Paypal/Block/Adminhtml/Settlement/Report.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Block/Adminhtml/Settlement/Report.php
+++ b/app/code/core/Mage/Paypal/Block/Adminhtml/Settlement/Report.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Block/Adminhtml/Settlement/Report/Grid.php
+++ b/app/code/core/Mage/Paypal/Block/Adminhtml/Settlement/Report/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Block/Adminhtml/Settlement/Report/Grid.php
+++ b/app/code/core/Mage/Paypal/Block/Adminhtml/Settlement/Report/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Block/Adminhtml/Settlement/Report/Grid.php
+++ b/app/code/core/Mage/Paypal/Block/Adminhtml/Settlement/Report/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/ApiWizard.php
+++ b/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/ApiWizard.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/ApiWizard.php
+++ b/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/ApiWizard.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/ApiWizard.php
+++ b/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/ApiWizard.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/BmlApiWizard.php
+++ b/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/BmlApiWizard.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/BmlApiWizard.php
+++ b/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/BmlApiWizard.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/BmlApiWizard.php
+++ b/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/BmlApiWizard.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/Field/Country.php
+++ b/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/Field/Country.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/Field/Country.php
+++ b/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/Field/Country.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/Field/Country.php
+++ b/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/Field/Country.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/Field/Hidden.php
+++ b/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/Field/Hidden.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/Field/Hidden.php
+++ b/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/Field/Hidden.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/Field/Hidden.php
+++ b/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/Field/Hidden.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/Field/SolutionType.php
+++ b/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/Field/SolutionType.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/Field/SolutionType.php
+++ b/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/Field/SolutionType.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/Field/SolutionType.php
+++ b/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/Field/SolutionType.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/Fieldset/Deprecated.php
+++ b/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/Fieldset/Deprecated.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/Fieldset/Deprecated.php
+++ b/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/Fieldset/Deprecated.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/Fieldset/Deprecated.php
+++ b/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/Fieldset/Deprecated.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/Fieldset/Expanded.php
+++ b/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/Fieldset/Expanded.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/Fieldset/Expanded.php
+++ b/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/Fieldset/Expanded.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/Fieldset/Expanded.php
+++ b/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/Fieldset/Expanded.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/Fieldset/Global.php
+++ b/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/Fieldset/Global.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/Fieldset/Global.php
+++ b/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/Fieldset/Global.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/Fieldset/Global.php
+++ b/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/Fieldset/Global.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/Fieldset/Group.php
+++ b/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/Fieldset/Group.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/Fieldset/Group.php
+++ b/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/Fieldset/Group.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/Fieldset/Group.php
+++ b/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/Fieldset/Group.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/Fieldset/Hint.php
+++ b/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/Fieldset/Hint.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/Fieldset/Hint.php
+++ b/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/Fieldset/Hint.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/Fieldset/Hint.php
+++ b/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/Fieldset/Hint.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/Fieldset/Location.php
+++ b/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/Fieldset/Location.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/Fieldset/Location.php
+++ b/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/Fieldset/Location.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/Fieldset/Location.php
+++ b/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/Fieldset/Location.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/Fieldset/PathDependent.php
+++ b/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/Fieldset/PathDependent.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/Fieldset/PathDependent.php
+++ b/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/Fieldset/PathDependent.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/Fieldset/PathDependent.php
+++ b/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/Fieldset/PathDependent.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/Fieldset/Payment.php
+++ b/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/Fieldset/Payment.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/Fieldset/Payment.php
+++ b/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/Fieldset/Payment.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/Fieldset/Payment.php
+++ b/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/Fieldset/Payment.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/Fieldset/Store.php
+++ b/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/Fieldset/Store.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/Fieldset/Store.php
+++ b/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/Fieldset/Store.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/Fieldset/Store.php
+++ b/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/Fieldset/Store.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/Payflowlink/Advanced.php
+++ b/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/Payflowlink/Advanced.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/Payflowlink/Advanced.php
+++ b/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/Payflowlink/Advanced.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/Payflowlink/Advanced.php
+++ b/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/Payflowlink/Advanced.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/Payflowlink/Info.php
+++ b/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/Payflowlink/Info.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/Payflowlink/Info.php
+++ b/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/Payflowlink/Info.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/Payflowlink/Info.php
+++ b/app/code/core/Mage/Paypal/Block/Adminhtml/System/Config/Payflowlink/Info.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Block/Bml/Banners.php
+++ b/app/code/core/Mage/Paypal/Block/Bml/Banners.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Block/Bml/Banners.php
+++ b/app/code/core/Mage/Paypal/Block/Bml/Banners.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Block/Bml/Banners.php
+++ b/app/code/core/Mage/Paypal/Block/Bml/Banners.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Block/Bml/Form.php
+++ b/app/code/core/Mage/Paypal/Block/Bml/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Block/Bml/Form.php
+++ b/app/code/core/Mage/Paypal/Block/Bml/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Block/Bml/Form.php
+++ b/app/code/core/Mage/Paypal/Block/Bml/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Block/Express/Form.php
+++ b/app/code/core/Mage/Paypal/Block/Express/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Block/Express/Form.php
+++ b/app/code/core/Mage/Paypal/Block/Express/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Block/Express/Form.php
+++ b/app/code/core/Mage/Paypal/Block/Express/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Block/Express/Review.php
+++ b/app/code/core/Mage/Paypal/Block/Express/Review.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Block/Express/Review.php
+++ b/app/code/core/Mage/Paypal/Block/Express/Review.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Block/Express/Review.php
+++ b/app/code/core/Mage/Paypal/Block/Express/Review.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Block/Express/Review/Billing.php
+++ b/app/code/core/Mage/Paypal/Block/Express/Review/Billing.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Block/Express/Review/Billing.php
+++ b/app/code/core/Mage/Paypal/Block/Express/Review/Billing.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Block/Express/Review/Billing.php
+++ b/app/code/core/Mage/Paypal/Block/Express/Review/Billing.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Block/Express/Review/Details.php
+++ b/app/code/core/Mage/Paypal/Block/Express/Review/Details.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Block/Express/Review/Details.php
+++ b/app/code/core/Mage/Paypal/Block/Express/Review/Details.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Block/Express/Review/Details.php
+++ b/app/code/core/Mage/Paypal/Block/Express/Review/Details.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Block/Express/Review/Shipping.php
+++ b/app/code/core/Mage/Paypal/Block/Express/Review/Shipping.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Block/Express/Review/Shipping.php
+++ b/app/code/core/Mage/Paypal/Block/Express/Review/Shipping.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Block/Express/Review/Shipping.php
+++ b/app/code/core/Mage/Paypal/Block/Express/Review/Shipping.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Block/Express/Shortcut.php
+++ b/app/code/core/Mage/Paypal/Block/Express/Shortcut.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Block/Express/Shortcut.php
+++ b/app/code/core/Mage/Paypal/Block/Express/Shortcut.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Block/Express/Shortcut.php
+++ b/app/code/core/Mage/Paypal/Block/Express/Shortcut.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Block/Hosted/Pro/Form.php
+++ b/app/code/core/Mage/Paypal/Block/Hosted/Pro/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Block/Hosted/Pro/Form.php
+++ b/app/code/core/Mage/Paypal/Block/Hosted/Pro/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Block/Hosted/Pro/Form.php
+++ b/app/code/core/Mage/Paypal/Block/Hosted/Pro/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Block/Hosted/Pro/Iframe.php
+++ b/app/code/core/Mage/Paypal/Block/Hosted/Pro/Iframe.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Block/Hosted/Pro/Iframe.php
+++ b/app/code/core/Mage/Paypal/Block/Hosted/Pro/Iframe.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Block/Hosted/Pro/Iframe.php
+++ b/app/code/core/Mage/Paypal/Block/Hosted/Pro/Iframe.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Block/Hosted/Pro/Info.php
+++ b/app/code/core/Mage/Paypal/Block/Hosted/Pro/Info.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Block/Hosted/Pro/Info.php
+++ b/app/code/core/Mage/Paypal/Block/Hosted/Pro/Info.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Block/Hosted/Pro/Info.php
+++ b/app/code/core/Mage/Paypal/Block/Hosted/Pro/Info.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Block/Iframe.php
+++ b/app/code/core/Mage/Paypal/Block/Iframe.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Block/Iframe.php
+++ b/app/code/core/Mage/Paypal/Block/Iframe.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Block/Iframe.php
+++ b/app/code/core/Mage/Paypal/Block/Iframe.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Block/Logo.php
+++ b/app/code/core/Mage/Paypal/Block/Logo.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Block/Logo.php
+++ b/app/code/core/Mage/Paypal/Block/Logo.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Block/Logo.php
+++ b/app/code/core/Mage/Paypal/Block/Logo.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Block/Payflow/Advanced/Form.php
+++ b/app/code/core/Mage/Paypal/Block/Payflow/Advanced/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Block/Payflow/Advanced/Form.php
+++ b/app/code/core/Mage/Paypal/Block/Payflow/Advanced/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Block/Payflow/Advanced/Form.php
+++ b/app/code/core/Mage/Paypal/Block/Payflow/Advanced/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Block/Payflow/Advanced/Iframe.php
+++ b/app/code/core/Mage/Paypal/Block/Payflow/Advanced/Iframe.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Block/Payflow/Advanced/Iframe.php
+++ b/app/code/core/Mage/Paypal/Block/Payflow/Advanced/Iframe.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Block/Payflow/Advanced/Iframe.php
+++ b/app/code/core/Mage/Paypal/Block/Payflow/Advanced/Iframe.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Block/Payflow/Advanced/Info.php
+++ b/app/code/core/Mage/Paypal/Block/Payflow/Advanced/Info.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Block/Payflow/Advanced/Info.php
+++ b/app/code/core/Mage/Paypal/Block/Payflow/Advanced/Info.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Block/Payflow/Advanced/Info.php
+++ b/app/code/core/Mage/Paypal/Block/Payflow/Advanced/Info.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Block/Payflow/Advanced/Review.php
+++ b/app/code/core/Mage/Paypal/Block/Payflow/Advanced/Review.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Block/Payflow/Advanced/Review.php
+++ b/app/code/core/Mage/Paypal/Block/Payflow/Advanced/Review.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Block/Payflow/Advanced/Review.php
+++ b/app/code/core/Mage/Paypal/Block/Payflow/Advanced/Review.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Block/Payflow/Link/Form.php
+++ b/app/code/core/Mage/Paypal/Block/Payflow/Link/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Block/Payflow/Link/Form.php
+++ b/app/code/core/Mage/Paypal/Block/Payflow/Link/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Block/Payflow/Link/Form.php
+++ b/app/code/core/Mage/Paypal/Block/Payflow/Link/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Block/Payflow/Link/Iframe.php
+++ b/app/code/core/Mage/Paypal/Block/Payflow/Link/Iframe.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Block/Payflow/Link/Iframe.php
+++ b/app/code/core/Mage/Paypal/Block/Payflow/Link/Iframe.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Block/Payflow/Link/Iframe.php
+++ b/app/code/core/Mage/Paypal/Block/Payflow/Link/Iframe.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Block/Payflow/Link/Info.php
+++ b/app/code/core/Mage/Paypal/Block/Payflow/Link/Info.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Block/Payflow/Link/Info.php
+++ b/app/code/core/Mage/Paypal/Block/Payflow/Link/Info.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Block/Payflow/Link/Info.php
+++ b/app/code/core/Mage/Paypal/Block/Payflow/Link/Info.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Block/Payflow/Link/Review.php
+++ b/app/code/core/Mage/Paypal/Block/Payflow/Link/Review.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Block/Payflow/Link/Review.php
+++ b/app/code/core/Mage/Paypal/Block/Payflow/Link/Review.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Block/Payflow/Link/Review.php
+++ b/app/code/core/Mage/Paypal/Block/Payflow/Link/Review.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Block/Payment/Info.php
+++ b/app/code/core/Mage/Paypal/Block/Payment/Info.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Block/Payment/Info.php
+++ b/app/code/core/Mage/Paypal/Block/Payment/Info.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Block/Payment/Info.php
+++ b/app/code/core/Mage/Paypal/Block/Payment/Info.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Block/Standard/Form.php
+++ b/app/code/core/Mage/Paypal/Block/Standard/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Block/Standard/Form.php
+++ b/app/code/core/Mage/Paypal/Block/Standard/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Block/Standard/Form.php
+++ b/app/code/core/Mage/Paypal/Block/Standard/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Block/Standard/Redirect.php
+++ b/app/code/core/Mage/Paypal/Block/Standard/Redirect.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Block/Standard/Redirect.php
+++ b/app/code/core/Mage/Paypal/Block/Standard/Redirect.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Block/Standard/Redirect.php
+++ b/app/code/core/Mage/Paypal/Block/Standard/Redirect.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Controller/Express/Abstract.php
+++ b/app/code/core/Mage/Paypal/Controller/Express/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Controller/Express/Abstract.php
+++ b/app/code/core/Mage/Paypal/Controller/Express/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Controller/Express/Abstract.php
+++ b/app/code/core/Mage/Paypal/Controller/Express/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Exception.php
+++ b/app/code/core/Mage/Paypal/Exception.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Exception.php
+++ b/app/code/core/Mage/Paypal/Exception.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Exception.php
+++ b/app/code/core/Mage/Paypal/Exception.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Helper/Checkout.php
+++ b/app/code/core/Mage/Paypal/Helper/Checkout.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Helper/Checkout.php
+++ b/app/code/core/Mage/Paypal/Helper/Checkout.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Helper/Checkout.php
+++ b/app/code/core/Mage/Paypal/Helper/Checkout.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Helper/Data.php
+++ b/app/code/core/Mage/Paypal/Helper/Data.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Helper/Data.php
+++ b/app/code/core/Mage/Paypal/Helper/Data.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Helper/Data.php
+++ b/app/code/core/Mage/Paypal/Helper/Data.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Helper/Hss.php
+++ b/app/code/core/Mage/Paypal/Helper/Hss.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Helper/Hss.php
+++ b/app/code/core/Mage/Paypal/Helper/Hss.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Helper/Hss.php
+++ b/app/code/core/Mage/Paypal/Helper/Hss.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/Api/Abstract.php
+++ b/app/code/core/Mage/Paypal/Model/Api/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/Api/Abstract.php
+++ b/app/code/core/Mage/Paypal/Model/Api/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Model/Api/Abstract.php
+++ b/app/code/core/Mage/Paypal/Model/Api/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/Api/Nvp.php
+++ b/app/code/core/Mage/Paypal/Model/Api/Nvp.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/Api/Nvp.php
+++ b/app/code/core/Mage/Paypal/Model/Api/Nvp.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Model/Api/Nvp.php
+++ b/app/code/core/Mage/Paypal/Model/Api/Nvp.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/Api/ProcessableException.php
+++ b/app/code/core/Mage/Paypal/Model/Api/ProcessableException.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/Api/ProcessableException.php
+++ b/app/code/core/Mage/Paypal/Model/Api/ProcessableException.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Model/Api/ProcessableException.php
+++ b/app/code/core/Mage/Paypal/Model/Api/ProcessableException.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/Api/Standard.php
+++ b/app/code/core/Mage/Paypal/Model/Api/Standard.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/Api/Standard.php
+++ b/app/code/core/Mage/Paypal/Model/Api/Standard.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Model/Api/Standard.php
+++ b/app/code/core/Mage/Paypal/Model/Api/Standard.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/Bml.php
+++ b/app/code/core/Mage/Paypal/Model/Bml.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/Bml.php
+++ b/app/code/core/Mage/Paypal/Model/Bml.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Model/Bml.php
+++ b/app/code/core/Mage/Paypal/Model/Bml.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/Cart.php
+++ b/app/code/core/Mage/Paypal/Model/Cart.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/Cart.php
+++ b/app/code/core/Mage/Paypal/Model/Cart.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Model/Cart.php
+++ b/app/code/core/Mage/Paypal/Model/Cart.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/Cert.php
+++ b/app/code/core/Mage/Paypal/Model/Cert.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/Cert.php
+++ b/app/code/core/Mage/Paypal/Model/Cert.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Model/Cert.php
+++ b/app/code/core/Mage/Paypal/Model/Cert.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/Config.php
+++ b/app/code/core/Mage/Paypal/Model/Config.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/Config.php
+++ b/app/code/core/Mage/Paypal/Model/Config.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Model/Config.php
+++ b/app/code/core/Mage/Paypal/Model/Config.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/Direct.php
+++ b/app/code/core/Mage/Paypal/Model/Direct.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/Direct.php
+++ b/app/code/core/Mage/Paypal/Model/Direct.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Model/Direct.php
+++ b/app/code/core/Mage/Paypal/Model/Direct.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/Express.php
+++ b/app/code/core/Mage/Paypal/Model/Express.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/Express.php
+++ b/app/code/core/Mage/Paypal/Model/Express.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Model/Express.php
+++ b/app/code/core/Mage/Paypal/Model/Express.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/Express/Checkout.php
+++ b/app/code/core/Mage/Paypal/Model/Express/Checkout.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/Express/Checkout.php
+++ b/app/code/core/Mage/Paypal/Model/Express/Checkout.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Model/Express/Checkout.php
+++ b/app/code/core/Mage/Paypal/Model/Express/Checkout.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/Hostedpro.php
+++ b/app/code/core/Mage/Paypal/Model/Hostedpro.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/Hostedpro.php
+++ b/app/code/core/Mage/Paypal/Model/Hostedpro.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Model/Hostedpro.php
+++ b/app/code/core/Mage/Paypal/Model/Hostedpro.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/Hostedpro/Request.php
+++ b/app/code/core/Mage/Paypal/Model/Hostedpro/Request.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/Hostedpro/Request.php
+++ b/app/code/core/Mage/Paypal/Model/Hostedpro/Request.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Model/Hostedpro/Request.php
+++ b/app/code/core/Mage/Paypal/Model/Hostedpro/Request.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/Info.php
+++ b/app/code/core/Mage/Paypal/Model/Info.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/Info.php
+++ b/app/code/core/Mage/Paypal/Model/Info.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Model/Info.php
+++ b/app/code/core/Mage/Paypal/Model/Info.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/Ipn.php
+++ b/app/code/core/Mage/Paypal/Model/Ipn.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/Ipn.php
+++ b/app/code/core/Mage/Paypal/Model/Ipn.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Model/Ipn.php
+++ b/app/code/core/Mage/Paypal/Model/Ipn.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/Method/Agreement.php
+++ b/app/code/core/Mage/Paypal/Model/Method/Agreement.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/Method/Agreement.php
+++ b/app/code/core/Mage/Paypal/Model/Method/Agreement.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Model/Method/Agreement.php
+++ b/app/code/core/Mage/Paypal/Model/Method/Agreement.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/Mysql4/Cert.php
+++ b/app/code/core/Mage/Paypal/Model/Mysql4/Cert.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/Mysql4/Cert.php
+++ b/app/code/core/Mage/Paypal/Model/Mysql4/Cert.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Model/Mysql4/Cert.php
+++ b/app/code/core/Mage/Paypal/Model/Mysql4/Cert.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/Mysql4/Report/Settlement.php
+++ b/app/code/core/Mage/Paypal/Model/Mysql4/Report/Settlement.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/Mysql4/Report/Settlement.php
+++ b/app/code/core/Mage/Paypal/Model/Mysql4/Report/Settlement.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Model/Mysql4/Report/Settlement.php
+++ b/app/code/core/Mage/Paypal/Model/Mysql4/Report/Settlement.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/Mysql4/Report/Settlement/Row.php
+++ b/app/code/core/Mage/Paypal/Model/Mysql4/Report/Settlement/Row.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/Mysql4/Report/Settlement/Row.php
+++ b/app/code/core/Mage/Paypal/Model/Mysql4/Report/Settlement/Row.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Model/Mysql4/Report/Settlement/Row.php
+++ b/app/code/core/Mage/Paypal/Model/Mysql4/Report/Settlement/Row.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/Mysql4/Report/Settlement/Row/Collection.php
+++ b/app/code/core/Mage/Paypal/Model/Mysql4/Report/Settlement/Row/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/Mysql4/Report/Settlement/Row/Collection.php
+++ b/app/code/core/Mage/Paypal/Model/Mysql4/Report/Settlement/Row/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Model/Mysql4/Report/Settlement/Row/Collection.php
+++ b/app/code/core/Mage/Paypal/Model/Mysql4/Report/Settlement/Row/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/Mysql4/Setup.php
+++ b/app/code/core/Mage/Paypal/Model/Mysql4/Setup.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/Mysql4/Setup.php
+++ b/app/code/core/Mage/Paypal/Model/Mysql4/Setup.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Model/Mysql4/Setup.php
+++ b/app/code/core/Mage/Paypal/Model/Mysql4/Setup.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/Observer.php
+++ b/app/code/core/Mage/Paypal/Model/Observer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/Observer.php
+++ b/app/code/core/Mage/Paypal/Model/Observer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Model/Observer.php
+++ b/app/code/core/Mage/Paypal/Model/Observer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/Payflow/Request.php
+++ b/app/code/core/Mage/Paypal/Model/Payflow/Request.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/Payflow/Request.php
+++ b/app/code/core/Mage/Paypal/Model/Payflow/Request.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Model/Payflow/Request.php
+++ b/app/code/core/Mage/Paypal/Model/Payflow/Request.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/Payflowadvanced.php
+++ b/app/code/core/Mage/Paypal/Model/Payflowadvanced.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/Payflowadvanced.php
+++ b/app/code/core/Mage/Paypal/Model/Payflowadvanced.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Model/Payflowadvanced.php
+++ b/app/code/core/Mage/Paypal/Model/Payflowadvanced.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/Payflowlink.php
+++ b/app/code/core/Mage/Paypal/Model/Payflowlink.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/Payflowlink.php
+++ b/app/code/core/Mage/Paypal/Model/Payflowlink.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Model/Payflowlink.php
+++ b/app/code/core/Mage/Paypal/Model/Payflowlink.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/Payflowpro.php
+++ b/app/code/core/Mage/Paypal/Model/Payflowpro.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/Payflowpro.php
+++ b/app/code/core/Mage/Paypal/Model/Payflowpro.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Model/Payflowpro.php
+++ b/app/code/core/Mage/Paypal/Model/Payflowpro.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/Payment/Transaction.php
+++ b/app/code/core/Mage/Paypal/Model/Payment/Transaction.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/Payment/Transaction.php
+++ b/app/code/core/Mage/Paypal/Model/Payment/Transaction.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Model/Payment/Transaction.php
+++ b/app/code/core/Mage/Paypal/Model/Payment/Transaction.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/Pro.php
+++ b/app/code/core/Mage/Paypal/Model/Pro.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/Pro.php
+++ b/app/code/core/Mage/Paypal/Model/Pro.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Model/Pro.php
+++ b/app/code/core/Mage/Paypal/Model/Pro.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/Report/Settlement.php
+++ b/app/code/core/Mage/Paypal/Model/Report/Settlement.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/Report/Settlement.php
+++ b/app/code/core/Mage/Paypal/Model/Report/Settlement.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Model/Report/Settlement.php
+++ b/app/code/core/Mage/Paypal/Model/Report/Settlement.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/Report/Settlement/Row.php
+++ b/app/code/core/Mage/Paypal/Model/Report/Settlement/Row.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/Report/Settlement/Row.php
+++ b/app/code/core/Mage/Paypal/Model/Report/Settlement/Row.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Model/Report/Settlement/Row.php
+++ b/app/code/core/Mage/Paypal/Model/Report/Settlement/Row.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/Resource/Cert.php
+++ b/app/code/core/Mage/Paypal/Model/Resource/Cert.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/Resource/Cert.php
+++ b/app/code/core/Mage/Paypal/Model/Resource/Cert.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Model/Resource/Cert.php
+++ b/app/code/core/Mage/Paypal/Model/Resource/Cert.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/Resource/Payment/Transaction.php
+++ b/app/code/core/Mage/Paypal/Model/Resource/Payment/Transaction.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/Resource/Payment/Transaction.php
+++ b/app/code/core/Mage/Paypal/Model/Resource/Payment/Transaction.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Model/Resource/Payment/Transaction.php
+++ b/app/code/core/Mage/Paypal/Model/Resource/Payment/Transaction.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/Resource/Payment/Transaction/Collection.php
+++ b/app/code/core/Mage/Paypal/Model/Resource/Payment/Transaction/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/Resource/Payment/Transaction/Collection.php
+++ b/app/code/core/Mage/Paypal/Model/Resource/Payment/Transaction/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Model/Resource/Payment/Transaction/Collection.php
+++ b/app/code/core/Mage/Paypal/Model/Resource/Payment/Transaction/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/Resource/Report/Settlement.php
+++ b/app/code/core/Mage/Paypal/Model/Resource/Report/Settlement.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/Resource/Report/Settlement.php
+++ b/app/code/core/Mage/Paypal/Model/Resource/Report/Settlement.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Model/Resource/Report/Settlement.php
+++ b/app/code/core/Mage/Paypal/Model/Resource/Report/Settlement.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/Resource/Report/Settlement/Row.php
+++ b/app/code/core/Mage/Paypal/Model/Resource/Report/Settlement/Row.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/Resource/Report/Settlement/Row.php
+++ b/app/code/core/Mage/Paypal/Model/Resource/Report/Settlement/Row.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Model/Resource/Report/Settlement/Row.php
+++ b/app/code/core/Mage/Paypal/Model/Resource/Report/Settlement/Row.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/Resource/Report/Settlement/Row/Collection.php
+++ b/app/code/core/Mage/Paypal/Model/Resource/Report/Settlement/Row/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/Resource/Report/Settlement/Row/Collection.php
+++ b/app/code/core/Mage/Paypal/Model/Resource/Report/Settlement/Row/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Model/Resource/Report/Settlement/Row/Collection.php
+++ b/app/code/core/Mage/Paypal/Model/Resource/Report/Settlement/Row/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/Resource/Setup.php
+++ b/app/code/core/Mage/Paypal/Model/Resource/Setup.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/Resource/Setup.php
+++ b/app/code/core/Mage/Paypal/Model/Resource/Setup.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Model/Resource/Setup.php
+++ b/app/code/core/Mage/Paypal/Model/Resource/Setup.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/Session.php
+++ b/app/code/core/Mage/Paypal/Model/Session.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/Session.php
+++ b/app/code/core/Mage/Paypal/Model/Session.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Model/Session.php
+++ b/app/code/core/Mage/Paypal/Model/Session.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/Standard.php
+++ b/app/code/core/Mage/Paypal/Model/Standard.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/Standard.php
+++ b/app/code/core/Mage/Paypal/Model/Standard.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Model/Standard.php
+++ b/app/code/core/Mage/Paypal/Model/Standard.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/System/Config/Backend/Cert.php
+++ b/app/code/core/Mage/Paypal/Model/System/Config/Backend/Cert.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/System/Config/Backend/Cert.php
+++ b/app/code/core/Mage/Paypal/Model/System/Config/Backend/Cert.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Model/System/Config/Backend/Cert.php
+++ b/app/code/core/Mage/Paypal/Model/System/Config/Backend/Cert.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/System/Config/Backend/Cron.php
+++ b/app/code/core/Mage/Paypal/Model/System/Config/Backend/Cron.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/System/Config/Backend/Cron.php
+++ b/app/code/core/Mage/Paypal/Model/System/Config/Backend/Cron.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Model/System/Config/Backend/Cron.php
+++ b/app/code/core/Mage/Paypal/Model/System/Config/Backend/Cron.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/System/Config/Backend/MerchantCountry.php
+++ b/app/code/core/Mage/Paypal/Model/System/Config/Backend/MerchantCountry.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/System/Config/Backend/MerchantCountry.php
+++ b/app/code/core/Mage/Paypal/Model/System/Config/Backend/MerchantCountry.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Model/System/Config/Backend/MerchantCountry.php
+++ b/app/code/core/Mage/Paypal/Model/System/Config/Backend/MerchantCountry.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/System/Config/Source/AuthorizationAmounts.php
+++ b/app/code/core/Mage/Paypal/Model/System/Config/Source/AuthorizationAmounts.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/System/Config/Source/AuthorizationAmounts.php
+++ b/app/code/core/Mage/Paypal/Model/System/Config/Source/AuthorizationAmounts.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Model/System/Config/Source/AuthorizationAmounts.php
+++ b/app/code/core/Mage/Paypal/Model/System/Config/Source/AuthorizationAmounts.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/System/Config/Source/BmlPosition.php
+++ b/app/code/core/Mage/Paypal/Model/System/Config/Source/BmlPosition.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/System/Config/Source/BmlPosition.php
+++ b/app/code/core/Mage/Paypal/Model/System/Config/Source/BmlPosition.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Model/System/Config/Source/BmlPosition.php
+++ b/app/code/core/Mage/Paypal/Model/System/Config/Source/BmlPosition.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/System/Config/Source/BmlSize.php
+++ b/app/code/core/Mage/Paypal/Model/System/Config/Source/BmlSize.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/System/Config/Source/BmlSize.php
+++ b/app/code/core/Mage/Paypal/Model/System/Config/Source/BmlSize.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Model/System/Config/Source/BmlSize.php
+++ b/app/code/core/Mage/Paypal/Model/System/Config/Source/BmlSize.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/System/Config/Source/BuyerCountry.php
+++ b/app/code/core/Mage/Paypal/Model/System/Config/Source/BuyerCountry.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/System/Config/Source/BuyerCountry.php
+++ b/app/code/core/Mage/Paypal/Model/System/Config/Source/BuyerCountry.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Model/System/Config/Source/BuyerCountry.php
+++ b/app/code/core/Mage/Paypal/Model/System/Config/Source/BuyerCountry.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/System/Config/Source/FetchingSchedule.php
+++ b/app/code/core/Mage/Paypal/Model/System/Config/Source/FetchingSchedule.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/System/Config/Source/FetchingSchedule.php
+++ b/app/code/core/Mage/Paypal/Model/System/Config/Source/FetchingSchedule.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Model/System/Config/Source/FetchingSchedule.php
+++ b/app/code/core/Mage/Paypal/Model/System/Config/Source/FetchingSchedule.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/System/Config/Source/Logo.php
+++ b/app/code/core/Mage/Paypal/Model/System/Config/Source/Logo.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/System/Config/Source/Logo.php
+++ b/app/code/core/Mage/Paypal/Model/System/Config/Source/Logo.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Model/System/Config/Source/Logo.php
+++ b/app/code/core/Mage/Paypal/Model/System/Config/Source/Logo.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/System/Config/Source/MerchantCountry.php
+++ b/app/code/core/Mage/Paypal/Model/System/Config/Source/MerchantCountry.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/System/Config/Source/MerchantCountry.php
+++ b/app/code/core/Mage/Paypal/Model/System/Config/Source/MerchantCountry.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Model/System/Config/Source/MerchantCountry.php
+++ b/app/code/core/Mage/Paypal/Model/System/Config/Source/MerchantCountry.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/System/Config/Source/PaymentActions.php
+++ b/app/code/core/Mage/Paypal/Model/System/Config/Source/PaymentActions.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/System/Config/Source/PaymentActions.php
+++ b/app/code/core/Mage/Paypal/Model/System/Config/Source/PaymentActions.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Model/System/Config/Source/PaymentActions.php
+++ b/app/code/core/Mage/Paypal/Model/System/Config/Source/PaymentActions.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/System/Config/Source/PaymentActions/Express.php
+++ b/app/code/core/Mage/Paypal/Model/System/Config/Source/PaymentActions/Express.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/System/Config/Source/PaymentActions/Express.php
+++ b/app/code/core/Mage/Paypal/Model/System/Config/Source/PaymentActions/Express.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Model/System/Config/Source/PaymentActions/Express.php
+++ b/app/code/core/Mage/Paypal/Model/System/Config/Source/PaymentActions/Express.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/System/Config/Source/RequireBillingAddress.php
+++ b/app/code/core/Mage/Paypal/Model/System/Config/Source/RequireBillingAddress.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/System/Config/Source/RequireBillingAddress.php
+++ b/app/code/core/Mage/Paypal/Model/System/Config/Source/RequireBillingAddress.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Model/System/Config/Source/RequireBillingAddress.php
+++ b/app/code/core/Mage/Paypal/Model/System/Config/Source/RequireBillingAddress.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/System/Config/Source/UrlMethod.php
+++ b/app/code/core/Mage/Paypal/Model/System/Config/Source/UrlMethod.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/System/Config/Source/UrlMethod.php
+++ b/app/code/core/Mage/Paypal/Model/System/Config/Source/UrlMethod.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Model/System/Config/Source/UrlMethod.php
+++ b/app/code/core/Mage/Paypal/Model/System/Config/Source/UrlMethod.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/System/Config/Source/YesnoShortcut.php
+++ b/app/code/core/Mage/Paypal/Model/System/Config/Source/YesnoShortcut.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/Model/System/Config/Source/YesnoShortcut.php
+++ b/app/code/core/Mage/Paypal/Model/System/Config/Source/YesnoShortcut.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/Model/System/Config/Source/YesnoShortcut.php
+++ b/app/code/core/Mage/Paypal/Model/System/Config/Source/YesnoShortcut.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/UnavailableException.php
+++ b/app/code/core/Mage/Paypal/UnavailableException.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/UnavailableException.php
+++ b/app/code/core/Mage/Paypal/UnavailableException.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/UnavailableException.php
+++ b/app/code/core/Mage/Paypal/UnavailableException.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/controllers/Adminhtml/Paypal/ReportsController.php
+++ b/app/code/core/Mage/Paypal/controllers/Adminhtml/Paypal/ReportsController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/controllers/Adminhtml/Paypal/ReportsController.php
+++ b/app/code/core/Mage/Paypal/controllers/Adminhtml/Paypal/ReportsController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/controllers/Adminhtml/Paypal/ReportsController.php
+++ b/app/code/core/Mage/Paypal/controllers/Adminhtml/Paypal/ReportsController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/controllers/BmlController.php
+++ b/app/code/core/Mage/Paypal/controllers/BmlController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/controllers/BmlController.php
+++ b/app/code/core/Mage/Paypal/controllers/BmlController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/controllers/BmlController.php
+++ b/app/code/core/Mage/Paypal/controllers/BmlController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/controllers/ExpressController.php
+++ b/app/code/core/Mage/Paypal/controllers/ExpressController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/controllers/ExpressController.php
+++ b/app/code/core/Mage/Paypal/controllers/ExpressController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/controllers/ExpressController.php
+++ b/app/code/core/Mage/Paypal/controllers/ExpressController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/controllers/HostedproController.php
+++ b/app/code/core/Mage/Paypal/controllers/HostedproController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/controllers/HostedproController.php
+++ b/app/code/core/Mage/Paypal/controllers/HostedproController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/controllers/HostedproController.php
+++ b/app/code/core/Mage/Paypal/controllers/HostedproController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/controllers/IpnController.php
+++ b/app/code/core/Mage/Paypal/controllers/IpnController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/controllers/IpnController.php
+++ b/app/code/core/Mage/Paypal/controllers/IpnController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/controllers/IpnController.php
+++ b/app/code/core/Mage/Paypal/controllers/IpnController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/controllers/PayflowController.php
+++ b/app/code/core/Mage/Paypal/controllers/PayflowController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/controllers/PayflowController.php
+++ b/app/code/core/Mage/Paypal/controllers/PayflowController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/controllers/PayflowController.php
+++ b/app/code/core/Mage/Paypal/controllers/PayflowController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/controllers/PayflowadvancedController.php
+++ b/app/code/core/Mage/Paypal/controllers/PayflowadvancedController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/controllers/PayflowadvancedController.php
+++ b/app/code/core/Mage/Paypal/controllers/PayflowadvancedController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/controllers/PayflowadvancedController.php
+++ b/app/code/core/Mage/Paypal/controllers/PayflowadvancedController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/controllers/StandardController.php
+++ b/app/code/core/Mage/Paypal/controllers/StandardController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/controllers/StandardController.php
+++ b/app/code/core/Mage/Paypal/controllers/StandardController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/controllers/StandardController.php
+++ b/app/code/core/Mage/Paypal/controllers/StandardController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/data/paypal_setup/data-install-1.6.0.5.php
+++ b/app/code/core/Mage/Paypal/data/paypal_setup/data-install-1.6.0.5.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/data/paypal_setup/data-install-1.6.0.5.php
+++ b/app/code/core/Mage/Paypal/data/paypal_setup/data-install-1.6.0.5.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/data/paypal_setup/data-install-1.6.0.5.php
+++ b/app/code/core/Mage/Paypal/data/paypal_setup/data-install-1.6.0.5.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/data/paypal_setup/data-upgrade-1.6.0.2-1.6.0.3.php
+++ b/app/code/core/Mage/Paypal/data/paypal_setup/data-upgrade-1.6.0.2-1.6.0.3.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/data/paypal_setup/data-upgrade-1.6.0.2-1.6.0.3.php
+++ b/app/code/core/Mage/Paypal/data/paypal_setup/data-upgrade-1.6.0.2-1.6.0.3.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/data/paypal_setup/data-upgrade-1.6.0.2-1.6.0.3.php
+++ b/app/code/core/Mage/Paypal/data/paypal_setup/data-upgrade-1.6.0.2-1.6.0.3.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/data/paypal_setup/data-upgrade-1.6.0.4-1.6.0.5.php
+++ b/app/code/core/Mage/Paypal/data/paypal_setup/data-upgrade-1.6.0.4-1.6.0.5.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/data/paypal_setup/data-upgrade-1.6.0.4-1.6.0.5.php
+++ b/app/code/core/Mage/Paypal/data/paypal_setup/data-upgrade-1.6.0.4-1.6.0.5.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/data/paypal_setup/data-upgrade-1.6.0.4-1.6.0.5.php
+++ b/app/code/core/Mage/Paypal/data/paypal_setup/data-upgrade-1.6.0.4-1.6.0.5.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/data/paypal_setup/data-upgrade-1.6.0.5-1.6.0.6.php
+++ b/app/code/core/Mage/Paypal/data/paypal_setup/data-upgrade-1.6.0.5-1.6.0.6.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/data/paypal_setup/data-upgrade-1.6.0.5-1.6.0.6.php
+++ b/app/code/core/Mage/Paypal/data/paypal_setup/data-upgrade-1.6.0.5-1.6.0.6.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/data/paypal_setup/data-upgrade-1.6.0.5-1.6.0.6.php
+++ b/app/code/core/Mage/Paypal/data/paypal_setup/data-upgrade-1.6.0.5-1.6.0.6.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/etc/adminhtml.xml
+++ b/app/code/core/Mage/Paypal/etc/adminhtml.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/etc/adminhtml.xml
+++ b/app/code/core/Mage/Paypal/etc/adminhtml.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/etc/adminhtml.xml
+++ b/app/code/core/Mage/Paypal/etc/adminhtml.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/etc/config.xml
+++ b/app/code/core/Mage/Paypal/etc/config.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/etc/config.xml
+++ b/app/code/core/Mage/Paypal/etc/config.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/etc/config.xml
+++ b/app/code/core/Mage/Paypal/etc/config.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/etc/system.xml
+++ b/app/code/core/Mage/Paypal/etc/system.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/etc/system.xml
+++ b/app/code/core/Mage/Paypal/etc/system.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/etc/system.xml
+++ b/app/code/core/Mage/Paypal/etc/system.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/sql/paypal_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Paypal/sql/paypal_setup/install-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/sql/paypal_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Paypal/sql/paypal_setup/install-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/sql/paypal_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Paypal/sql/paypal_setup/install-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/sql/paypal_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/Paypal/sql/paypal_setup/mysql4-install-0.7.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/sql/paypal_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/Paypal/sql/paypal_setup/mysql4-install-0.7.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/sql/paypal_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/Paypal/sql/paypal_setup/mysql4-install-0.7.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/sql/paypal_setup/mysql4-install-1.4.0.0.php
+++ b/app/code/core/Mage/Paypal/sql/paypal_setup/mysql4-install-1.4.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/sql/paypal_setup/mysql4-install-1.4.0.0.php
+++ b/app/code/core/Mage/Paypal/sql/paypal_setup/mysql4-install-1.4.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/sql/paypal_setup/mysql4-install-1.4.0.0.php
+++ b/app/code/core/Mage/Paypal/sql/paypal_setup/mysql4-install-1.4.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/sql/paypal_setup/mysql4-upgrade-0.7.1-0.7.2.php
+++ b/app/code/core/Mage/Paypal/sql/paypal_setup/mysql4-upgrade-0.7.1-0.7.2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/sql/paypal_setup/mysql4-upgrade-0.7.1-0.7.2.php
+++ b/app/code/core/Mage/Paypal/sql/paypal_setup/mysql4-upgrade-0.7.1-0.7.2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/sql/paypal_setup/mysql4-upgrade-0.7.1-0.7.2.php
+++ b/app/code/core/Mage/Paypal/sql/paypal_setup/mysql4-upgrade-0.7.1-0.7.2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/sql/paypal_setup/mysql4-upgrade-0.7.2-0.7.3.php
+++ b/app/code/core/Mage/Paypal/sql/paypal_setup/mysql4-upgrade-0.7.2-0.7.3.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/sql/paypal_setup/mysql4-upgrade-0.7.2-0.7.3.php
+++ b/app/code/core/Mage/Paypal/sql/paypal_setup/mysql4-upgrade-0.7.2-0.7.3.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/sql/paypal_setup/mysql4-upgrade-0.7.2-0.7.3.php
+++ b/app/code/core/Mage/Paypal/sql/paypal_setup/mysql4-upgrade-0.7.2-0.7.3.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/sql/paypal_setup/mysql4-upgrade-1.4.0.0-1.4.0.1.php
+++ b/app/code/core/Mage/Paypal/sql/paypal_setup/mysql4-upgrade-1.4.0.0-1.4.0.1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/sql/paypal_setup/mysql4-upgrade-1.4.0.0-1.4.0.1.php
+++ b/app/code/core/Mage/Paypal/sql/paypal_setup/mysql4-upgrade-1.4.0.0-1.4.0.1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/sql/paypal_setup/mysql4-upgrade-1.4.0.0-1.4.0.1.php
+++ b/app/code/core/Mage/Paypal/sql/paypal_setup/mysql4-upgrade-1.4.0.0-1.4.0.1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/sql/paypal_setup/mysql4-upgrade-1.4.0.1-1.4.0.2.php
+++ b/app/code/core/Mage/Paypal/sql/paypal_setup/mysql4-upgrade-1.4.0.1-1.4.0.2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/sql/paypal_setup/mysql4-upgrade-1.4.0.1-1.4.0.2.php
+++ b/app/code/core/Mage/Paypal/sql/paypal_setup/mysql4-upgrade-1.4.0.1-1.4.0.2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/sql/paypal_setup/mysql4-upgrade-1.4.0.1-1.4.0.2.php
+++ b/app/code/core/Mage/Paypal/sql/paypal_setup/mysql4-upgrade-1.4.0.1-1.4.0.2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/sql/paypal_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/Paypal/sql/paypal_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/sql/paypal_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/Paypal/sql/paypal_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/sql/paypal_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/Paypal/sql/paypal_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/sql/paypal_setup/upgrade-1.6.0.0-1.6.0.1.php
+++ b/app/code/core/Mage/Paypal/sql/paypal_setup/upgrade-1.6.0.0-1.6.0.1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/sql/paypal_setup/upgrade-1.6.0.0-1.6.0.1.php
+++ b/app/code/core/Mage/Paypal/sql/paypal_setup/upgrade-1.6.0.0-1.6.0.1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/sql/paypal_setup/upgrade-1.6.0.0-1.6.0.1.php
+++ b/app/code/core/Mage/Paypal/sql/paypal_setup/upgrade-1.6.0.0-1.6.0.1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/sql/paypal_setup/upgrade-1.6.0.1-1.6.0.2.php
+++ b/app/code/core/Mage/Paypal/sql/paypal_setup/upgrade-1.6.0.1-1.6.0.2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/sql/paypal_setup/upgrade-1.6.0.1-1.6.0.2.php
+++ b/app/code/core/Mage/Paypal/sql/paypal_setup/upgrade-1.6.0.1-1.6.0.2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/sql/paypal_setup/upgrade-1.6.0.1-1.6.0.2.php
+++ b/app/code/core/Mage/Paypal/sql/paypal_setup/upgrade-1.6.0.1-1.6.0.2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/sql/paypal_setup/upgrade-1.6.0.3-1.6.0.4.php
+++ b/app/code/core/Mage/Paypal/sql/paypal_setup/upgrade-1.6.0.3-1.6.0.4.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/Paypal/sql/paypal_setup/upgrade-1.6.0.3-1.6.0.4.php
+++ b/app/code/core/Mage/Paypal/sql/paypal_setup/upgrade-1.6.0.3-1.6.0.4.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Paypal/sql/paypal_setup/upgrade-1.6.0.3-1.6.0.4.php
+++ b/app/code/core/Mage/Paypal/sql/paypal_setup/upgrade-1.6.0.3-1.6.0.4.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/code/core/Mage/PaypalUk/Block/Bml/Form.php
+++ b/app/code/core/Mage/PaypalUk/Block/Bml/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/PaypalUk/Block/Bml/Form.php
+++ b/app/code/core/Mage/PaypalUk/Block/Bml/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_PaypalUk

--- a/app/code/core/Mage/PaypalUk/Block/Bml/Form.php
+++ b/app/code/core/Mage/PaypalUk/Block/Bml/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_PaypalUk

--- a/app/code/core/Mage/PaypalUk/Block/Express/Form.php
+++ b/app/code/core/Mage/PaypalUk/Block/Express/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/PaypalUk/Block/Express/Form.php
+++ b/app/code/core/Mage/PaypalUk/Block/Express/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_PaypalUk

--- a/app/code/core/Mage/PaypalUk/Block/Express/Form.php
+++ b/app/code/core/Mage/PaypalUk/Block/Express/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_PaypalUk

--- a/app/code/core/Mage/PaypalUk/Block/Express/Shortcut.php
+++ b/app/code/core/Mage/PaypalUk/Block/Express/Shortcut.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/PaypalUk/Block/Express/Shortcut.php
+++ b/app/code/core/Mage/PaypalUk/Block/Express/Shortcut.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_PaypalUk

--- a/app/code/core/Mage/PaypalUk/Block/Express/Shortcut.php
+++ b/app/code/core/Mage/PaypalUk/Block/Express/Shortcut.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_PaypalUk

--- a/app/code/core/Mage/PaypalUk/Helper/Data.php
+++ b/app/code/core/Mage/PaypalUk/Helper/Data.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/PaypalUk/Helper/Data.php
+++ b/app/code/core/Mage/PaypalUk/Helper/Data.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_PaypalUk

--- a/app/code/core/Mage/PaypalUk/Helper/Data.php
+++ b/app/code/core/Mage/PaypalUk/Helper/Data.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_PaypalUk

--- a/app/code/core/Mage/PaypalUk/Model/Api/Express/Nvp.php
+++ b/app/code/core/Mage/PaypalUk/Model/Api/Express/Nvp.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/PaypalUk/Model/Api/Express/Nvp.php
+++ b/app/code/core/Mage/PaypalUk/Model/Api/Express/Nvp.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_PaypalUk

--- a/app/code/core/Mage/PaypalUk/Model/Api/Express/Nvp.php
+++ b/app/code/core/Mage/PaypalUk/Model/Api/Express/Nvp.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_PaypalUk

--- a/app/code/core/Mage/PaypalUk/Model/Api/Nvp.php
+++ b/app/code/core/Mage/PaypalUk/Model/Api/Nvp.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/PaypalUk/Model/Api/Nvp.php
+++ b/app/code/core/Mage/PaypalUk/Model/Api/Nvp.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_PaypalUk

--- a/app/code/core/Mage/PaypalUk/Model/Api/Nvp.php
+++ b/app/code/core/Mage/PaypalUk/Model/Api/Nvp.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_PaypalUk

--- a/app/code/core/Mage/PaypalUk/Model/Bml.php
+++ b/app/code/core/Mage/PaypalUk/Model/Bml.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/PaypalUk/Model/Bml.php
+++ b/app/code/core/Mage/PaypalUk/Model/Bml.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_PaypalUk

--- a/app/code/core/Mage/PaypalUk/Model/Bml.php
+++ b/app/code/core/Mage/PaypalUk/Model/Bml.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_PaypalUk

--- a/app/code/core/Mage/PaypalUk/Model/Direct.php
+++ b/app/code/core/Mage/PaypalUk/Model/Direct.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/PaypalUk/Model/Direct.php
+++ b/app/code/core/Mage/PaypalUk/Model/Direct.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_PaypalUk

--- a/app/code/core/Mage/PaypalUk/Model/Direct.php
+++ b/app/code/core/Mage/PaypalUk/Model/Direct.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_PaypalUk

--- a/app/code/core/Mage/PaypalUk/Model/Express.php
+++ b/app/code/core/Mage/PaypalUk/Model/Express.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/PaypalUk/Model/Express.php
+++ b/app/code/core/Mage/PaypalUk/Model/Express.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_PaypalUk

--- a/app/code/core/Mage/PaypalUk/Model/Express.php
+++ b/app/code/core/Mage/PaypalUk/Model/Express.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_PaypalUk

--- a/app/code/core/Mage/PaypalUk/Model/Express/Checkout.php
+++ b/app/code/core/Mage/PaypalUk/Model/Express/Checkout.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/PaypalUk/Model/Express/Checkout.php
+++ b/app/code/core/Mage/PaypalUk/Model/Express/Checkout.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_PaypalUk

--- a/app/code/core/Mage/PaypalUk/Model/Express/Checkout.php
+++ b/app/code/core/Mage/PaypalUk/Model/Express/Checkout.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_PaypalUk

--- a/app/code/core/Mage/PaypalUk/Model/Express/Pro.php
+++ b/app/code/core/Mage/PaypalUk/Model/Express/Pro.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/PaypalUk/Model/Express/Pro.php
+++ b/app/code/core/Mage/PaypalUk/Model/Express/Pro.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_PaypalUk

--- a/app/code/core/Mage/PaypalUk/Model/Express/Pro.php
+++ b/app/code/core/Mage/PaypalUk/Model/Express/Pro.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_PaypalUk

--- a/app/code/core/Mage/PaypalUk/Model/Pro.php
+++ b/app/code/core/Mage/PaypalUk/Model/Pro.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/PaypalUk/Model/Pro.php
+++ b/app/code/core/Mage/PaypalUk/Model/Pro.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_PaypalUk

--- a/app/code/core/Mage/PaypalUk/Model/Pro.php
+++ b/app/code/core/Mage/PaypalUk/Model/Pro.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_PaypalUk

--- a/app/code/core/Mage/PaypalUk/Model/Session.php
+++ b/app/code/core/Mage/PaypalUk/Model/Session.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/PaypalUk/Model/Session.php
+++ b/app/code/core/Mage/PaypalUk/Model/Session.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_PaypalUk

--- a/app/code/core/Mage/PaypalUk/Model/Session.php
+++ b/app/code/core/Mage/PaypalUk/Model/Session.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_PaypalUk

--- a/app/code/core/Mage/PaypalUk/controllers/BmlController.php
+++ b/app/code/core/Mage/PaypalUk/controllers/BmlController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/PaypalUk/controllers/BmlController.php
+++ b/app/code/core/Mage/PaypalUk/controllers/BmlController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_PaypalUk

--- a/app/code/core/Mage/PaypalUk/controllers/BmlController.php
+++ b/app/code/core/Mage/PaypalUk/controllers/BmlController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_PaypalUk

--- a/app/code/core/Mage/PaypalUk/controllers/ExpressController.php
+++ b/app/code/core/Mage/PaypalUk/controllers/ExpressController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/PaypalUk/controllers/ExpressController.php
+++ b/app/code/core/Mage/PaypalUk/controllers/ExpressController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_PaypalUk

--- a/app/code/core/Mage/PaypalUk/controllers/ExpressController.php
+++ b/app/code/core/Mage/PaypalUk/controllers/ExpressController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_PaypalUk

--- a/app/code/core/Mage/PaypalUk/etc/config.xml
+++ b/app/code/core/Mage/PaypalUk/etc/config.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_PaypalUk

--- a/app/code/core/Mage/PaypalUk/etc/config.xml
+++ b/app/code/core/Mage/PaypalUk/etc/config.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_PaypalUk

--- a/app/code/core/Mage/PaypalUk/etc/config.xml
+++ b/app/code/core/Mage/PaypalUk/etc/config.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/PaypalUk/sql/paypaluk_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/PaypalUk/sql/paypaluk_setup/install-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/PaypalUk/sql/paypaluk_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/PaypalUk/sql/paypaluk_setup/install-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_PaypalUk

--- a/app/code/core/Mage/PaypalUk/sql/paypaluk_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/PaypalUk/sql/paypaluk_setup/install-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_PaypalUk

--- a/app/code/core/Mage/PaypalUk/sql/paypaluk_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/PaypalUk/sql/paypaluk_setup/mysql4-install-0.7.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/PaypalUk/sql/paypaluk_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/PaypalUk/sql/paypaluk_setup/mysql4-install-0.7.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_PaypalUk

--- a/app/code/core/Mage/PaypalUk/sql/paypaluk_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/PaypalUk/sql/paypaluk_setup/mysql4-install-0.7.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_PaypalUk

--- a/app/code/core/Mage/Persistent/Block/Form/Remember.php
+++ b/app/code/core/Mage/Persistent/Block/Form/Remember.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Persistent/Block/Form/Remember.php
+++ b/app/code/core/Mage/Persistent/Block/Form/Remember.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Persistent

--- a/app/code/core/Mage/Persistent/Block/Form/Remember.php
+++ b/app/code/core/Mage/Persistent/Block/Form/Remember.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Persistent

--- a/app/code/core/Mage/Persistent/Block/Header/Additional.php
+++ b/app/code/core/Mage/Persistent/Block/Header/Additional.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Persistent/Block/Header/Additional.php
+++ b/app/code/core/Mage/Persistent/Block/Header/Additional.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Persistent

--- a/app/code/core/Mage/Persistent/Block/Header/Additional.php
+++ b/app/code/core/Mage/Persistent/Block/Header/Additional.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Persistent

--- a/app/code/core/Mage/Persistent/Helper/Data.php
+++ b/app/code/core/Mage/Persistent/Helper/Data.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Persistent/Helper/Data.php
+++ b/app/code/core/Mage/Persistent/Helper/Data.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Persistent

--- a/app/code/core/Mage/Persistent/Helper/Data.php
+++ b/app/code/core/Mage/Persistent/Helper/Data.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Persistent

--- a/app/code/core/Mage/Persistent/Helper/Session.php
+++ b/app/code/core/Mage/Persistent/Helper/Session.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Persistent/Helper/Session.php
+++ b/app/code/core/Mage/Persistent/Helper/Session.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Persistent

--- a/app/code/core/Mage/Persistent/Helper/Session.php
+++ b/app/code/core/Mage/Persistent/Helper/Session.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Persistent

--- a/app/code/core/Mage/Persistent/Model/Observer.php
+++ b/app/code/core/Mage/Persistent/Model/Observer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Persistent/Model/Observer.php
+++ b/app/code/core/Mage/Persistent/Model/Observer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Persistent

--- a/app/code/core/Mage/Persistent/Model/Observer.php
+++ b/app/code/core/Mage/Persistent/Model/Observer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Persistent

--- a/app/code/core/Mage/Persistent/Model/Observer/Session.php
+++ b/app/code/core/Mage/Persistent/Model/Observer/Session.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Persistent/Model/Observer/Session.php
+++ b/app/code/core/Mage/Persistent/Model/Observer/Session.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Persistent

--- a/app/code/core/Mage/Persistent/Model/Observer/Session.php
+++ b/app/code/core/Mage/Persistent/Model/Observer/Session.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Persistent

--- a/app/code/core/Mage/Persistent/Model/Persistent/Config.php
+++ b/app/code/core/Mage/Persistent/Model/Persistent/Config.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Persistent/Model/Persistent/Config.php
+++ b/app/code/core/Mage/Persistent/Model/Persistent/Config.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Persistent

--- a/app/code/core/Mage/Persistent/Model/Persistent/Config.php
+++ b/app/code/core/Mage/Persistent/Model/Persistent/Config.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Persistent

--- a/app/code/core/Mage/Persistent/Model/Resource/Session.php
+++ b/app/code/core/Mage/Persistent/Model/Resource/Session.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Persistent/Model/Resource/Session.php
+++ b/app/code/core/Mage/Persistent/Model/Resource/Session.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Persistent

--- a/app/code/core/Mage/Persistent/Model/Resource/Session.php
+++ b/app/code/core/Mage/Persistent/Model/Resource/Session.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Persistent

--- a/app/code/core/Mage/Persistent/Model/Session.php
+++ b/app/code/core/Mage/Persistent/Model/Session.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Persistent/Model/Session.php
+++ b/app/code/core/Mage/Persistent/Model/Session.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Persistent

--- a/app/code/core/Mage/Persistent/Model/Session.php
+++ b/app/code/core/Mage/Persistent/Model/Session.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Persistent

--- a/app/code/core/Mage/Persistent/controllers/IndexController.php
+++ b/app/code/core/Mage/Persistent/controllers/IndexController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Persistent/controllers/IndexController.php
+++ b/app/code/core/Mage/Persistent/controllers/IndexController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Persistent

--- a/app/code/core/Mage/Persistent/controllers/IndexController.php
+++ b/app/code/core/Mage/Persistent/controllers/IndexController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Persistent

--- a/app/code/core/Mage/Persistent/etc/adminhtml.xml
+++ b/app/code/core/Mage/Persistent/etc/adminhtml.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Persistent

--- a/app/code/core/Mage/Persistent/etc/adminhtml.xml
+++ b/app/code/core/Mage/Persistent/etc/adminhtml.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Persistent/etc/adminhtml.xml
+++ b/app/code/core/Mage/Persistent/etc/adminhtml.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Persistent

--- a/app/code/core/Mage/Persistent/etc/config.xml
+++ b/app/code/core/Mage/Persistent/etc/config.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Persistent

--- a/app/code/core/Mage/Persistent/etc/config.xml
+++ b/app/code/core/Mage/Persistent/etc/config.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Persistent/etc/config.xml
+++ b/app/code/core/Mage/Persistent/etc/config.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Persistent

--- a/app/code/core/Mage/Persistent/etc/persistent.xml
+++ b/app/code/core/Mage/Persistent/etc/persistent.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Persistent

--- a/app/code/core/Mage/Persistent/etc/persistent.xml
+++ b/app/code/core/Mage/Persistent/etc/persistent.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Persistent/etc/persistent.xml
+++ b/app/code/core/Mage/Persistent/etc/persistent.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Persistent

--- a/app/code/core/Mage/Persistent/etc/system.xml
+++ b/app/code/core/Mage/Persistent/etc/system.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Persistent

--- a/app/code/core/Mage/Persistent/etc/system.xml
+++ b/app/code/core/Mage/Persistent/etc/system.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Persistent/etc/system.xml
+++ b/app/code/core/Mage/Persistent/etc/system.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Persistent

--- a/app/code/core/Mage/Persistent/sql/persistent_setup/install-1.0.0.0.php
+++ b/app/code/core/Mage/Persistent/sql/persistent_setup/install-1.0.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Persistent/sql/persistent_setup/install-1.0.0.0.php
+++ b/app/code/core/Mage/Persistent/sql/persistent_setup/install-1.0.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Persistent

--- a/app/code/core/Mage/Persistent/sql/persistent_setup/install-1.0.0.0.php
+++ b/app/code/core/Mage/Persistent/sql/persistent_setup/install-1.0.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Persistent

--- a/app/code/core/Mage/Poll/Block/ActivePoll.php
+++ b/app/code/core/Mage/Poll/Block/ActivePoll.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Poll

--- a/app/code/core/Mage/Poll/Block/ActivePoll.php
+++ b/app/code/core/Mage/Poll/Block/ActivePoll.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Poll

--- a/app/code/core/Mage/Poll/Block/ActivePoll.php
+++ b/app/code/core/Mage/Poll/Block/ActivePoll.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Poll/Block/Poll.php
+++ b/app/code/core/Mage/Poll/Block/Poll.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Poll

--- a/app/code/core/Mage/Poll/Block/Poll.php
+++ b/app/code/core/Mage/Poll/Block/Poll.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Poll

--- a/app/code/core/Mage/Poll/Block/Poll.php
+++ b/app/code/core/Mage/Poll/Block/Poll.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Poll/Helper/Data.php
+++ b/app/code/core/Mage/Poll/Helper/Data.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Poll

--- a/app/code/core/Mage/Poll/Helper/Data.php
+++ b/app/code/core/Mage/Poll/Helper/Data.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Poll

--- a/app/code/core/Mage/Poll/Helper/Data.php
+++ b/app/code/core/Mage/Poll/Helper/Data.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Poll/Model/Mysql4/Poll.php
+++ b/app/code/core/Mage/Poll/Model/Mysql4/Poll.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Poll

--- a/app/code/core/Mage/Poll/Model/Mysql4/Poll.php
+++ b/app/code/core/Mage/Poll/Model/Mysql4/Poll.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Poll

--- a/app/code/core/Mage/Poll/Model/Mysql4/Poll.php
+++ b/app/code/core/Mage/Poll/Model/Mysql4/Poll.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Poll/Model/Mysql4/Poll/Answer.php
+++ b/app/code/core/Mage/Poll/Model/Mysql4/Poll/Answer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Poll

--- a/app/code/core/Mage/Poll/Model/Mysql4/Poll/Answer.php
+++ b/app/code/core/Mage/Poll/Model/Mysql4/Poll/Answer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Poll

--- a/app/code/core/Mage/Poll/Model/Mysql4/Poll/Answer.php
+++ b/app/code/core/Mage/Poll/Model/Mysql4/Poll/Answer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Poll/Model/Mysql4/Poll/Answer/Collection.php
+++ b/app/code/core/Mage/Poll/Model/Mysql4/Poll/Answer/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Poll

--- a/app/code/core/Mage/Poll/Model/Mysql4/Poll/Answer/Collection.php
+++ b/app/code/core/Mage/Poll/Model/Mysql4/Poll/Answer/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Poll

--- a/app/code/core/Mage/Poll/Model/Mysql4/Poll/Answer/Collection.php
+++ b/app/code/core/Mage/Poll/Model/Mysql4/Poll/Answer/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Poll/Model/Mysql4/Poll/Collection.php
+++ b/app/code/core/Mage/Poll/Model/Mysql4/Poll/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Poll

--- a/app/code/core/Mage/Poll/Model/Mysql4/Poll/Collection.php
+++ b/app/code/core/Mage/Poll/Model/Mysql4/Poll/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Poll

--- a/app/code/core/Mage/Poll/Model/Mysql4/Poll/Collection.php
+++ b/app/code/core/Mage/Poll/Model/Mysql4/Poll/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Poll/Model/Mysql4/Poll/Vote.php
+++ b/app/code/core/Mage/Poll/Model/Mysql4/Poll/Vote.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Poll

--- a/app/code/core/Mage/Poll/Model/Mysql4/Poll/Vote.php
+++ b/app/code/core/Mage/Poll/Model/Mysql4/Poll/Vote.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Poll

--- a/app/code/core/Mage/Poll/Model/Mysql4/Poll/Vote.php
+++ b/app/code/core/Mage/Poll/Model/Mysql4/Poll/Vote.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Poll/Model/Poll.php
+++ b/app/code/core/Mage/Poll/Model/Poll.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Poll

--- a/app/code/core/Mage/Poll/Model/Poll.php
+++ b/app/code/core/Mage/Poll/Model/Poll.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Poll

--- a/app/code/core/Mage/Poll/Model/Poll.php
+++ b/app/code/core/Mage/Poll/Model/Poll.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Poll/Model/Poll/Answer.php
+++ b/app/code/core/Mage/Poll/Model/Poll/Answer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Poll

--- a/app/code/core/Mage/Poll/Model/Poll/Answer.php
+++ b/app/code/core/Mage/Poll/Model/Poll/Answer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Poll

--- a/app/code/core/Mage/Poll/Model/Poll/Answer.php
+++ b/app/code/core/Mage/Poll/Model/Poll/Answer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Poll/Model/Poll/Vote.php
+++ b/app/code/core/Mage/Poll/Model/Poll/Vote.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Poll

--- a/app/code/core/Mage/Poll/Model/Poll/Vote.php
+++ b/app/code/core/Mage/Poll/Model/Poll/Vote.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Poll

--- a/app/code/core/Mage/Poll/Model/Poll/Vote.php
+++ b/app/code/core/Mage/Poll/Model/Poll/Vote.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Poll/Model/Resource/Poll.php
+++ b/app/code/core/Mage/Poll/Model/Resource/Poll.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Poll

--- a/app/code/core/Mage/Poll/Model/Resource/Poll.php
+++ b/app/code/core/Mage/Poll/Model/Resource/Poll.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Poll

--- a/app/code/core/Mage/Poll/Model/Resource/Poll.php
+++ b/app/code/core/Mage/Poll/Model/Resource/Poll.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Poll/Model/Resource/Poll/Answer.php
+++ b/app/code/core/Mage/Poll/Model/Resource/Poll/Answer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Poll

--- a/app/code/core/Mage/Poll/Model/Resource/Poll/Answer.php
+++ b/app/code/core/Mage/Poll/Model/Resource/Poll/Answer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Poll

--- a/app/code/core/Mage/Poll/Model/Resource/Poll/Answer.php
+++ b/app/code/core/Mage/Poll/Model/Resource/Poll/Answer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Poll/Model/Resource/Poll/Answer/Collection.php
+++ b/app/code/core/Mage/Poll/Model/Resource/Poll/Answer/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Poll

--- a/app/code/core/Mage/Poll/Model/Resource/Poll/Answer/Collection.php
+++ b/app/code/core/Mage/Poll/Model/Resource/Poll/Answer/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Poll

--- a/app/code/core/Mage/Poll/Model/Resource/Poll/Answer/Collection.php
+++ b/app/code/core/Mage/Poll/Model/Resource/Poll/Answer/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Poll/Model/Resource/Poll/Collection.php
+++ b/app/code/core/Mage/Poll/Model/Resource/Poll/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Poll

--- a/app/code/core/Mage/Poll/Model/Resource/Poll/Collection.php
+++ b/app/code/core/Mage/Poll/Model/Resource/Poll/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Poll

--- a/app/code/core/Mage/Poll/Model/Resource/Poll/Collection.php
+++ b/app/code/core/Mage/Poll/Model/Resource/Poll/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Poll/Model/Resource/Poll/Vote.php
+++ b/app/code/core/Mage/Poll/Model/Resource/Poll/Vote.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Poll

--- a/app/code/core/Mage/Poll/Model/Resource/Poll/Vote.php
+++ b/app/code/core/Mage/Poll/Model/Resource/Poll/Vote.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Poll

--- a/app/code/core/Mage/Poll/Model/Resource/Poll/Vote.php
+++ b/app/code/core/Mage/Poll/Model/Resource/Poll/Vote.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Poll/controllers/VoteController.php
+++ b/app/code/core/Mage/Poll/controllers/VoteController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Poll

--- a/app/code/core/Mage/Poll/controllers/VoteController.php
+++ b/app/code/core/Mage/Poll/controllers/VoteController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Poll

--- a/app/code/core/Mage/Poll/controllers/VoteController.php
+++ b/app/code/core/Mage/Poll/controllers/VoteController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Poll/data/poll_setup/data-install-1.6.0.0.php
+++ b/app/code/core/Mage/Poll/data/poll_setup/data-install-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Poll

--- a/app/code/core/Mage/Poll/data/poll_setup/data-install-1.6.0.0.php
+++ b/app/code/core/Mage/Poll/data/poll_setup/data-install-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Poll

--- a/app/code/core/Mage/Poll/data/poll_setup/data-install-1.6.0.0.php
+++ b/app/code/core/Mage/Poll/data/poll_setup/data-install-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Poll/etc/adminhtml.xml
+++ b/app/code/core/Mage/Poll/etc/adminhtml.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Poll

--- a/app/code/core/Mage/Poll/etc/adminhtml.xml
+++ b/app/code/core/Mage/Poll/etc/adminhtml.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Poll

--- a/app/code/core/Mage/Poll/etc/adminhtml.xml
+++ b/app/code/core/Mage/Poll/etc/adminhtml.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Poll/etc/config.xml
+++ b/app/code/core/Mage/Poll/etc/config.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Poll

--- a/app/code/core/Mage/Poll/etc/config.xml
+++ b/app/code/core/Mage/Poll/etc/config.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Poll

--- a/app/code/core/Mage/Poll/etc/config.xml
+++ b/app/code/core/Mage/Poll/etc/config.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Poll/etc/system.xml
+++ b/app/code/core/Mage/Poll/etc/system.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Poll

--- a/app/code/core/Mage/Poll/etc/system.xml
+++ b/app/code/core/Mage/Poll/etc/system.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Poll

--- a/app/code/core/Mage/Poll/etc/system.xml
+++ b/app/code/core/Mage/Poll/etc/system.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Poll/sql/poll_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Poll/sql/poll_setup/install-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Poll

--- a/app/code/core/Mage/Poll/sql/poll_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Poll/sql/poll_setup/install-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Poll

--- a/app/code/core/Mage/Poll/sql/poll_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Poll/sql/poll_setup/install-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Poll/sql/poll_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/Poll/sql/poll_setup/mysql4-install-0.7.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Poll

--- a/app/code/core/Mage/Poll/sql/poll_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/Poll/sql/poll_setup/mysql4-install-0.7.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Poll

--- a/app/code/core/Mage/Poll/sql/poll_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/Poll/sql/poll_setup/mysql4-install-0.7.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Poll/sql/poll_setup/mysql4-upgrade-0.6.0-0.6.1.php
+++ b/app/code/core/Mage/Poll/sql/poll_setup/mysql4-upgrade-0.6.0-0.6.1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Poll

--- a/app/code/core/Mage/Poll/sql/poll_setup/mysql4-upgrade-0.6.0-0.6.1.php
+++ b/app/code/core/Mage/Poll/sql/poll_setup/mysql4-upgrade-0.6.0-0.6.1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Poll

--- a/app/code/core/Mage/Poll/sql/poll_setup/mysql4-upgrade-0.6.0-0.6.1.php
+++ b/app/code/core/Mage/Poll/sql/poll_setup/mysql4-upgrade-0.6.0-0.6.1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Poll/sql/poll_setup/mysql4-upgrade-0.7.1-0.7.2.php
+++ b/app/code/core/Mage/Poll/sql/poll_setup/mysql4-upgrade-0.7.1-0.7.2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Poll

--- a/app/code/core/Mage/Poll/sql/poll_setup/mysql4-upgrade-0.7.1-0.7.2.php
+++ b/app/code/core/Mage/Poll/sql/poll_setup/mysql4-upgrade-0.7.1-0.7.2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Poll

--- a/app/code/core/Mage/Poll/sql/poll_setup/mysql4-upgrade-0.7.1-0.7.2.php
+++ b/app/code/core/Mage/Poll/sql/poll_setup/mysql4-upgrade-0.7.1-0.7.2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Poll/sql/poll_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/Poll/sql/poll_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Poll

--- a/app/code/core/Mage/Poll/sql/poll_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/Poll/sql/poll_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Poll

--- a/app/code/core/Mage/Poll/sql/poll_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/Poll/sql/poll_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Poll/sql/poll_setup/mysql4-upgrade-1.6.0.0-1.6.0.1.php
+++ b/app/code/core/Mage/Poll/sql/poll_setup/mysql4-upgrade-1.6.0.0-1.6.0.1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Poll

--- a/app/code/core/Mage/Poll/sql/poll_setup/mysql4-upgrade-1.6.0.0-1.6.0.1.php
+++ b/app/code/core/Mage/Poll/sql/poll_setup/mysql4-upgrade-1.6.0.0-1.6.0.1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Poll

--- a/app/code/core/Mage/Poll/sql/poll_setup/mysql4-upgrade-1.6.0.0-1.6.0.1.php
+++ b/app/code/core/Mage/Poll/sql/poll_setup/mysql4-upgrade-1.6.0.0-1.6.0.1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ProductAlert/Block/Email/Abstract.php
+++ b/app/code/core/Mage/ProductAlert/Block/Email/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ProductAlert

--- a/app/code/core/Mage/ProductAlert/Block/Email/Abstract.php
+++ b/app/code/core/Mage/ProductAlert/Block/Email/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ProductAlert/Block/Email/Abstract.php
+++ b/app/code/core/Mage/ProductAlert/Block/Email/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ProductAlert

--- a/app/code/core/Mage/ProductAlert/Block/Email/Price.php
+++ b/app/code/core/Mage/ProductAlert/Block/Email/Price.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ProductAlert

--- a/app/code/core/Mage/ProductAlert/Block/Email/Price.php
+++ b/app/code/core/Mage/ProductAlert/Block/Email/Price.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ProductAlert/Block/Email/Price.php
+++ b/app/code/core/Mage/ProductAlert/Block/Email/Price.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ProductAlert

--- a/app/code/core/Mage/ProductAlert/Block/Email/Stock.php
+++ b/app/code/core/Mage/ProductAlert/Block/Email/Stock.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ProductAlert

--- a/app/code/core/Mage/ProductAlert/Block/Email/Stock.php
+++ b/app/code/core/Mage/ProductAlert/Block/Email/Stock.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ProductAlert/Block/Email/Stock.php
+++ b/app/code/core/Mage/ProductAlert/Block/Email/Stock.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ProductAlert

--- a/app/code/core/Mage/ProductAlert/Block/Price.php
+++ b/app/code/core/Mage/ProductAlert/Block/Price.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ProductAlert

--- a/app/code/core/Mage/ProductAlert/Block/Price.php
+++ b/app/code/core/Mage/ProductAlert/Block/Price.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ProductAlert/Block/Price.php
+++ b/app/code/core/Mage/ProductAlert/Block/Price.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ProductAlert

--- a/app/code/core/Mage/ProductAlert/Block/Product/View.php
+++ b/app/code/core/Mage/ProductAlert/Block/Product/View.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ProductAlert

--- a/app/code/core/Mage/ProductAlert/Block/Product/View.php
+++ b/app/code/core/Mage/ProductAlert/Block/Product/View.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ProductAlert/Block/Product/View.php
+++ b/app/code/core/Mage/ProductAlert/Block/Product/View.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ProductAlert

--- a/app/code/core/Mage/ProductAlert/Block/Stock.php
+++ b/app/code/core/Mage/ProductAlert/Block/Stock.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ProductAlert

--- a/app/code/core/Mage/ProductAlert/Block/Stock.php
+++ b/app/code/core/Mage/ProductAlert/Block/Stock.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ProductAlert/Block/Stock.php
+++ b/app/code/core/Mage/ProductAlert/Block/Stock.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ProductAlert

--- a/app/code/core/Mage/ProductAlert/Helper/Data.php
+++ b/app/code/core/Mage/ProductAlert/Helper/Data.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ProductAlert

--- a/app/code/core/Mage/ProductAlert/Helper/Data.php
+++ b/app/code/core/Mage/ProductAlert/Helper/Data.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ProductAlert/Helper/Data.php
+++ b/app/code/core/Mage/ProductAlert/Helper/Data.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ProductAlert

--- a/app/code/core/Mage/ProductAlert/Model/Email.php
+++ b/app/code/core/Mage/ProductAlert/Model/Email.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ProductAlert

--- a/app/code/core/Mage/ProductAlert/Model/Email.php
+++ b/app/code/core/Mage/ProductAlert/Model/Email.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ProductAlert/Model/Email.php
+++ b/app/code/core/Mage/ProductAlert/Model/Email.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ProductAlert

--- a/app/code/core/Mage/ProductAlert/Model/Mysql4/Price.php
+++ b/app/code/core/Mage/ProductAlert/Model/Mysql4/Price.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ProductAlert

--- a/app/code/core/Mage/ProductAlert/Model/Mysql4/Price.php
+++ b/app/code/core/Mage/ProductAlert/Model/Mysql4/Price.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ProductAlert/Model/Mysql4/Price.php
+++ b/app/code/core/Mage/ProductAlert/Model/Mysql4/Price.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ProductAlert

--- a/app/code/core/Mage/ProductAlert/Model/Mysql4/Price/Collection.php
+++ b/app/code/core/Mage/ProductAlert/Model/Mysql4/Price/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ProductAlert

--- a/app/code/core/Mage/ProductAlert/Model/Mysql4/Price/Collection.php
+++ b/app/code/core/Mage/ProductAlert/Model/Mysql4/Price/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ProductAlert/Model/Mysql4/Price/Collection.php
+++ b/app/code/core/Mage/ProductAlert/Model/Mysql4/Price/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ProductAlert

--- a/app/code/core/Mage/ProductAlert/Model/Mysql4/Price/Customer/Collection.php
+++ b/app/code/core/Mage/ProductAlert/Model/Mysql4/Price/Customer/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ProductAlert

--- a/app/code/core/Mage/ProductAlert/Model/Mysql4/Price/Customer/Collection.php
+++ b/app/code/core/Mage/ProductAlert/Model/Mysql4/Price/Customer/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ProductAlert/Model/Mysql4/Price/Customer/Collection.php
+++ b/app/code/core/Mage/ProductAlert/Model/Mysql4/Price/Customer/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ProductAlert

--- a/app/code/core/Mage/ProductAlert/Model/Mysql4/Stock.php
+++ b/app/code/core/Mage/ProductAlert/Model/Mysql4/Stock.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ProductAlert

--- a/app/code/core/Mage/ProductAlert/Model/Mysql4/Stock.php
+++ b/app/code/core/Mage/ProductAlert/Model/Mysql4/Stock.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ProductAlert/Model/Mysql4/Stock.php
+++ b/app/code/core/Mage/ProductAlert/Model/Mysql4/Stock.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ProductAlert

--- a/app/code/core/Mage/ProductAlert/Model/Mysql4/Stock/Collection.php
+++ b/app/code/core/Mage/ProductAlert/Model/Mysql4/Stock/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ProductAlert

--- a/app/code/core/Mage/ProductAlert/Model/Mysql4/Stock/Collection.php
+++ b/app/code/core/Mage/ProductAlert/Model/Mysql4/Stock/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ProductAlert/Model/Mysql4/Stock/Collection.php
+++ b/app/code/core/Mage/ProductAlert/Model/Mysql4/Stock/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ProductAlert

--- a/app/code/core/Mage/ProductAlert/Model/Mysql4/Stock/Customer/Collection.php
+++ b/app/code/core/Mage/ProductAlert/Model/Mysql4/Stock/Customer/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ProductAlert

--- a/app/code/core/Mage/ProductAlert/Model/Mysql4/Stock/Customer/Collection.php
+++ b/app/code/core/Mage/ProductAlert/Model/Mysql4/Stock/Customer/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ProductAlert/Model/Mysql4/Stock/Customer/Collection.php
+++ b/app/code/core/Mage/ProductAlert/Model/Mysql4/Stock/Customer/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ProductAlert

--- a/app/code/core/Mage/ProductAlert/Model/Observer.php
+++ b/app/code/core/Mage/ProductAlert/Model/Observer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ProductAlert

--- a/app/code/core/Mage/ProductAlert/Model/Observer.php
+++ b/app/code/core/Mage/ProductAlert/Model/Observer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ProductAlert/Model/Observer.php
+++ b/app/code/core/Mage/ProductAlert/Model/Observer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ProductAlert

--- a/app/code/core/Mage/ProductAlert/Model/Price.php
+++ b/app/code/core/Mage/ProductAlert/Model/Price.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ProductAlert

--- a/app/code/core/Mage/ProductAlert/Model/Price.php
+++ b/app/code/core/Mage/ProductAlert/Model/Price.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ProductAlert/Model/Price.php
+++ b/app/code/core/Mage/ProductAlert/Model/Price.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ProductAlert

--- a/app/code/core/Mage/ProductAlert/Model/Resource/Abstract.php
+++ b/app/code/core/Mage/ProductAlert/Model/Resource/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ProductAlert

--- a/app/code/core/Mage/ProductAlert/Model/Resource/Abstract.php
+++ b/app/code/core/Mage/ProductAlert/Model/Resource/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ProductAlert/Model/Resource/Abstract.php
+++ b/app/code/core/Mage/ProductAlert/Model/Resource/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ProductAlert

--- a/app/code/core/Mage/ProductAlert/Model/Resource/Price.php
+++ b/app/code/core/Mage/ProductAlert/Model/Resource/Price.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ProductAlert

--- a/app/code/core/Mage/ProductAlert/Model/Resource/Price.php
+++ b/app/code/core/Mage/ProductAlert/Model/Resource/Price.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ProductAlert/Model/Resource/Price.php
+++ b/app/code/core/Mage/ProductAlert/Model/Resource/Price.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ProductAlert

--- a/app/code/core/Mage/ProductAlert/Model/Resource/Price/Collection.php
+++ b/app/code/core/Mage/ProductAlert/Model/Resource/Price/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ProductAlert

--- a/app/code/core/Mage/ProductAlert/Model/Resource/Price/Collection.php
+++ b/app/code/core/Mage/ProductAlert/Model/Resource/Price/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ProductAlert/Model/Resource/Price/Collection.php
+++ b/app/code/core/Mage/ProductAlert/Model/Resource/Price/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ProductAlert

--- a/app/code/core/Mage/ProductAlert/Model/Resource/Price/Customer/Collection.php
+++ b/app/code/core/Mage/ProductAlert/Model/Resource/Price/Customer/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ProductAlert

--- a/app/code/core/Mage/ProductAlert/Model/Resource/Price/Customer/Collection.php
+++ b/app/code/core/Mage/ProductAlert/Model/Resource/Price/Customer/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ProductAlert/Model/Resource/Price/Customer/Collection.php
+++ b/app/code/core/Mage/ProductAlert/Model/Resource/Price/Customer/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ProductAlert

--- a/app/code/core/Mage/ProductAlert/Model/Resource/Stock.php
+++ b/app/code/core/Mage/ProductAlert/Model/Resource/Stock.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ProductAlert

--- a/app/code/core/Mage/ProductAlert/Model/Resource/Stock.php
+++ b/app/code/core/Mage/ProductAlert/Model/Resource/Stock.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ProductAlert/Model/Resource/Stock.php
+++ b/app/code/core/Mage/ProductAlert/Model/Resource/Stock.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ProductAlert

--- a/app/code/core/Mage/ProductAlert/Model/Resource/Stock/Collection.php
+++ b/app/code/core/Mage/ProductAlert/Model/Resource/Stock/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ProductAlert

--- a/app/code/core/Mage/ProductAlert/Model/Resource/Stock/Collection.php
+++ b/app/code/core/Mage/ProductAlert/Model/Resource/Stock/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ProductAlert/Model/Resource/Stock/Collection.php
+++ b/app/code/core/Mage/ProductAlert/Model/Resource/Stock/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ProductAlert

--- a/app/code/core/Mage/ProductAlert/Model/Resource/Stock/Customer/Collection.php
+++ b/app/code/core/Mage/ProductAlert/Model/Resource/Stock/Customer/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ProductAlert

--- a/app/code/core/Mage/ProductAlert/Model/Resource/Stock/Customer/Collection.php
+++ b/app/code/core/Mage/ProductAlert/Model/Resource/Stock/Customer/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ProductAlert/Model/Resource/Stock/Customer/Collection.php
+++ b/app/code/core/Mage/ProductAlert/Model/Resource/Stock/Customer/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ProductAlert

--- a/app/code/core/Mage/ProductAlert/Model/Stock.php
+++ b/app/code/core/Mage/ProductAlert/Model/Stock.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ProductAlert

--- a/app/code/core/Mage/ProductAlert/Model/Stock.php
+++ b/app/code/core/Mage/ProductAlert/Model/Stock.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ProductAlert/Model/Stock.php
+++ b/app/code/core/Mage/ProductAlert/Model/Stock.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ProductAlert

--- a/app/code/core/Mage/ProductAlert/controllers/AddController.php
+++ b/app/code/core/Mage/ProductAlert/controllers/AddController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ProductAlert

--- a/app/code/core/Mage/ProductAlert/controllers/AddController.php
+++ b/app/code/core/Mage/ProductAlert/controllers/AddController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ProductAlert/controllers/AddController.php
+++ b/app/code/core/Mage/ProductAlert/controllers/AddController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ProductAlert

--- a/app/code/core/Mage/ProductAlert/controllers/UnsubscribeController.php
+++ b/app/code/core/Mage/ProductAlert/controllers/UnsubscribeController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ProductAlert

--- a/app/code/core/Mage/ProductAlert/controllers/UnsubscribeController.php
+++ b/app/code/core/Mage/ProductAlert/controllers/UnsubscribeController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ProductAlert/controllers/UnsubscribeController.php
+++ b/app/code/core/Mage/ProductAlert/controllers/UnsubscribeController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ProductAlert

--- a/app/code/core/Mage/ProductAlert/etc/config.xml
+++ b/app/code/core/Mage/ProductAlert/etc/config.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ProductAlert

--- a/app/code/core/Mage/ProductAlert/etc/config.xml
+++ b/app/code/core/Mage/ProductAlert/etc/config.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ProductAlert

--- a/app/code/core/Mage/ProductAlert/etc/config.xml
+++ b/app/code/core/Mage/ProductAlert/etc/config.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ProductAlert/etc/system.xml
+++ b/app/code/core/Mage/ProductAlert/etc/system.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ProductAlert

--- a/app/code/core/Mage/ProductAlert/etc/system.xml
+++ b/app/code/core/Mage/ProductAlert/etc/system.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ProductAlert

--- a/app/code/core/Mage/ProductAlert/etc/system.xml
+++ b/app/code/core/Mage/ProductAlert/etc/system.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ProductAlert/sql/productalert_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/ProductAlert/sql/productalert_setup/install-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ProductAlert

--- a/app/code/core/Mage/ProductAlert/sql/productalert_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/ProductAlert/sql/productalert_setup/install-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ProductAlert/sql/productalert_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/ProductAlert/sql/productalert_setup/install-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ProductAlert

--- a/app/code/core/Mage/ProductAlert/sql/productalert_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/ProductAlert/sql/productalert_setup/mysql4-install-0.7.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ProductAlert

--- a/app/code/core/Mage/ProductAlert/sql/productalert_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/ProductAlert/sql/productalert_setup/mysql4-install-0.7.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ProductAlert/sql/productalert_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/ProductAlert/sql/productalert_setup/mysql4-install-0.7.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ProductAlert

--- a/app/code/core/Mage/ProductAlert/sql/productalert_setup/mysql4-upgrade-0.7.1-0.7.2.php
+++ b/app/code/core/Mage/ProductAlert/sql/productalert_setup/mysql4-upgrade-0.7.1-0.7.2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ProductAlert

--- a/app/code/core/Mage/ProductAlert/sql/productalert_setup/mysql4-upgrade-0.7.1-0.7.2.php
+++ b/app/code/core/Mage/ProductAlert/sql/productalert_setup/mysql4-upgrade-0.7.1-0.7.2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ProductAlert/sql/productalert_setup/mysql4-upgrade-0.7.1-0.7.2.php
+++ b/app/code/core/Mage/ProductAlert/sql/productalert_setup/mysql4-upgrade-0.7.1-0.7.2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ProductAlert

--- a/app/code/core/Mage/ProductAlert/sql/productalert_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/ProductAlert/sql/productalert_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ProductAlert

--- a/app/code/core/Mage/ProductAlert/sql/productalert_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/ProductAlert/sql/productalert_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/ProductAlert/sql/productalert_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/ProductAlert/sql/productalert_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ProductAlert

--- a/app/code/core/Mage/Rating/Block/Entity/Detailed.php
+++ b/app/code/core/Mage/Rating/Block/Entity/Detailed.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Rating

--- a/app/code/core/Mage/Rating/Block/Entity/Detailed.php
+++ b/app/code/core/Mage/Rating/Block/Entity/Detailed.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Rating/Block/Entity/Detailed.php
+++ b/app/code/core/Mage/Rating/Block/Entity/Detailed.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Rating

--- a/app/code/core/Mage/Rating/Helper/Data.php
+++ b/app/code/core/Mage/Rating/Helper/Data.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Rating

--- a/app/code/core/Mage/Rating/Helper/Data.php
+++ b/app/code/core/Mage/Rating/Helper/Data.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Rating/Helper/Data.php
+++ b/app/code/core/Mage/Rating/Helper/Data.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Rating

--- a/app/code/core/Mage/Rating/Model/Mysql4/Rating.php
+++ b/app/code/core/Mage/Rating/Model/Mysql4/Rating.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Rating

--- a/app/code/core/Mage/Rating/Model/Mysql4/Rating.php
+++ b/app/code/core/Mage/Rating/Model/Mysql4/Rating.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Rating/Model/Mysql4/Rating.php
+++ b/app/code/core/Mage/Rating/Model/Mysql4/Rating.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Rating

--- a/app/code/core/Mage/Rating/Model/Mysql4/Rating/Collection.php
+++ b/app/code/core/Mage/Rating/Model/Mysql4/Rating/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Rating

--- a/app/code/core/Mage/Rating/Model/Mysql4/Rating/Collection.php
+++ b/app/code/core/Mage/Rating/Model/Mysql4/Rating/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Rating/Model/Mysql4/Rating/Collection.php
+++ b/app/code/core/Mage/Rating/Model/Mysql4/Rating/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Rating

--- a/app/code/core/Mage/Rating/Model/Mysql4/Rating/Entity.php
+++ b/app/code/core/Mage/Rating/Model/Mysql4/Rating/Entity.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Rating

--- a/app/code/core/Mage/Rating/Model/Mysql4/Rating/Entity.php
+++ b/app/code/core/Mage/Rating/Model/Mysql4/Rating/Entity.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Rating/Model/Mysql4/Rating/Entity.php
+++ b/app/code/core/Mage/Rating/Model/Mysql4/Rating/Entity.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Rating

--- a/app/code/core/Mage/Rating/Model/Mysql4/Rating/Option.php
+++ b/app/code/core/Mage/Rating/Model/Mysql4/Rating/Option.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Rating

--- a/app/code/core/Mage/Rating/Model/Mysql4/Rating/Option.php
+++ b/app/code/core/Mage/Rating/Model/Mysql4/Rating/Option.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Rating/Model/Mysql4/Rating/Option.php
+++ b/app/code/core/Mage/Rating/Model/Mysql4/Rating/Option.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Rating

--- a/app/code/core/Mage/Rating/Model/Mysql4/Rating/Option/Collection.php
+++ b/app/code/core/Mage/Rating/Model/Mysql4/Rating/Option/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Rating

--- a/app/code/core/Mage/Rating/Model/Mysql4/Rating/Option/Collection.php
+++ b/app/code/core/Mage/Rating/Model/Mysql4/Rating/Option/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Rating/Model/Mysql4/Rating/Option/Collection.php
+++ b/app/code/core/Mage/Rating/Model/Mysql4/Rating/Option/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Rating

--- a/app/code/core/Mage/Rating/Model/Mysql4/Rating/Option/Vote.php
+++ b/app/code/core/Mage/Rating/Model/Mysql4/Rating/Option/Vote.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Rating

--- a/app/code/core/Mage/Rating/Model/Mysql4/Rating/Option/Vote.php
+++ b/app/code/core/Mage/Rating/Model/Mysql4/Rating/Option/Vote.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Rating/Model/Mysql4/Rating/Option/Vote.php
+++ b/app/code/core/Mage/Rating/Model/Mysql4/Rating/Option/Vote.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Rating

--- a/app/code/core/Mage/Rating/Model/Mysql4/Rating/Option/Vote/Collection.php
+++ b/app/code/core/Mage/Rating/Model/Mysql4/Rating/Option/Vote/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Rating

--- a/app/code/core/Mage/Rating/Model/Mysql4/Rating/Option/Vote/Collection.php
+++ b/app/code/core/Mage/Rating/Model/Mysql4/Rating/Option/Vote/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Rating/Model/Mysql4/Rating/Option/Vote/Collection.php
+++ b/app/code/core/Mage/Rating/Model/Mysql4/Rating/Option/Vote/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Rating

--- a/app/code/core/Mage/Rating/Model/Observer.php
+++ b/app/code/core/Mage/Rating/Model/Observer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Rating

--- a/app/code/core/Mage/Rating/Model/Observer.php
+++ b/app/code/core/Mage/Rating/Model/Observer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Rating/Model/Observer.php
+++ b/app/code/core/Mage/Rating/Model/Observer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Rating

--- a/app/code/core/Mage/Rating/Model/Rating.php
+++ b/app/code/core/Mage/Rating/Model/Rating.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Rating

--- a/app/code/core/Mage/Rating/Model/Rating.php
+++ b/app/code/core/Mage/Rating/Model/Rating.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Rating/Model/Rating.php
+++ b/app/code/core/Mage/Rating/Model/Rating.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Rating

--- a/app/code/core/Mage/Rating/Model/Rating/Entity.php
+++ b/app/code/core/Mage/Rating/Model/Rating/Entity.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Rating

--- a/app/code/core/Mage/Rating/Model/Rating/Entity.php
+++ b/app/code/core/Mage/Rating/Model/Rating/Entity.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Rating/Model/Rating/Entity.php
+++ b/app/code/core/Mage/Rating/Model/Rating/Entity.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Rating

--- a/app/code/core/Mage/Rating/Model/Rating/Option.php
+++ b/app/code/core/Mage/Rating/Model/Rating/Option.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Rating

--- a/app/code/core/Mage/Rating/Model/Rating/Option.php
+++ b/app/code/core/Mage/Rating/Model/Rating/Option.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Rating/Model/Rating/Option.php
+++ b/app/code/core/Mage/Rating/Model/Rating/Option.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Rating

--- a/app/code/core/Mage/Rating/Model/Rating/Option/Vote.php
+++ b/app/code/core/Mage/Rating/Model/Rating/Option/Vote.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Rating

--- a/app/code/core/Mage/Rating/Model/Rating/Option/Vote.php
+++ b/app/code/core/Mage/Rating/Model/Rating/Option/Vote.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Rating/Model/Rating/Option/Vote.php
+++ b/app/code/core/Mage/Rating/Model/Rating/Option/Vote.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Rating

--- a/app/code/core/Mage/Rating/Model/Resource/Rating.php
+++ b/app/code/core/Mage/Rating/Model/Resource/Rating.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Rating

--- a/app/code/core/Mage/Rating/Model/Resource/Rating.php
+++ b/app/code/core/Mage/Rating/Model/Resource/Rating.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Rating/Model/Resource/Rating.php
+++ b/app/code/core/Mage/Rating/Model/Resource/Rating.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Rating

--- a/app/code/core/Mage/Rating/Model/Resource/Rating/Collection.php
+++ b/app/code/core/Mage/Rating/Model/Resource/Rating/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Rating

--- a/app/code/core/Mage/Rating/Model/Resource/Rating/Collection.php
+++ b/app/code/core/Mage/Rating/Model/Resource/Rating/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Rating/Model/Resource/Rating/Collection.php
+++ b/app/code/core/Mage/Rating/Model/Resource/Rating/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Rating

--- a/app/code/core/Mage/Rating/Model/Resource/Rating/Entity.php
+++ b/app/code/core/Mage/Rating/Model/Resource/Rating/Entity.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Rating

--- a/app/code/core/Mage/Rating/Model/Resource/Rating/Entity.php
+++ b/app/code/core/Mage/Rating/Model/Resource/Rating/Entity.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Rating/Model/Resource/Rating/Entity.php
+++ b/app/code/core/Mage/Rating/Model/Resource/Rating/Entity.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Rating

--- a/app/code/core/Mage/Rating/Model/Resource/Rating/Option.php
+++ b/app/code/core/Mage/Rating/Model/Resource/Rating/Option.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Rating

--- a/app/code/core/Mage/Rating/Model/Resource/Rating/Option.php
+++ b/app/code/core/Mage/Rating/Model/Resource/Rating/Option.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Rating/Model/Resource/Rating/Option.php
+++ b/app/code/core/Mage/Rating/Model/Resource/Rating/Option.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Rating

--- a/app/code/core/Mage/Rating/Model/Resource/Rating/Option/Collection.php
+++ b/app/code/core/Mage/Rating/Model/Resource/Rating/Option/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Rating

--- a/app/code/core/Mage/Rating/Model/Resource/Rating/Option/Collection.php
+++ b/app/code/core/Mage/Rating/Model/Resource/Rating/Option/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Rating/Model/Resource/Rating/Option/Collection.php
+++ b/app/code/core/Mage/Rating/Model/Resource/Rating/Option/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Rating

--- a/app/code/core/Mage/Rating/Model/Resource/Rating/Option/Vote.php
+++ b/app/code/core/Mage/Rating/Model/Resource/Rating/Option/Vote.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Rating

--- a/app/code/core/Mage/Rating/Model/Resource/Rating/Option/Vote.php
+++ b/app/code/core/Mage/Rating/Model/Resource/Rating/Option/Vote.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Rating/Model/Resource/Rating/Option/Vote.php
+++ b/app/code/core/Mage/Rating/Model/Resource/Rating/Option/Vote.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Rating

--- a/app/code/core/Mage/Rating/Model/Resource/Rating/Option/Vote/Collection.php
+++ b/app/code/core/Mage/Rating/Model/Resource/Rating/Option/Vote/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Rating

--- a/app/code/core/Mage/Rating/Model/Resource/Rating/Option/Vote/Collection.php
+++ b/app/code/core/Mage/Rating/Model/Resource/Rating/Option/Vote/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Rating/Model/Resource/Rating/Option/Vote/Collection.php
+++ b/app/code/core/Mage/Rating/Model/Resource/Rating/Option/Vote/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Rating

--- a/app/code/core/Mage/Rating/data/rating_setup/data-install-1.6.0.0.php
+++ b/app/code/core/Mage/Rating/data/rating_setup/data-install-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Rating

--- a/app/code/core/Mage/Rating/data/rating_setup/data-install-1.6.0.0.php
+++ b/app/code/core/Mage/Rating/data/rating_setup/data-install-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Rating/data/rating_setup/data-install-1.6.0.0.php
+++ b/app/code/core/Mage/Rating/data/rating_setup/data-install-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Rating

--- a/app/code/core/Mage/Rating/etc/adminhtml.xml
+++ b/app/code/core/Mage/Rating/etc/adminhtml.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Rating

--- a/app/code/core/Mage/Rating/etc/adminhtml.xml
+++ b/app/code/core/Mage/Rating/etc/adminhtml.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Rating

--- a/app/code/core/Mage/Rating/etc/adminhtml.xml
+++ b/app/code/core/Mage/Rating/etc/adminhtml.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Rating/etc/config.xml
+++ b/app/code/core/Mage/Rating/etc/config.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Rating

--- a/app/code/core/Mage/Rating/etc/config.xml
+++ b/app/code/core/Mage/Rating/etc/config.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Rating

--- a/app/code/core/Mage/Rating/etc/config.xml
+++ b/app/code/core/Mage/Rating/etc/config.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Rating/sql/rating_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Rating/sql/rating_setup/install-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Rating

--- a/app/code/core/Mage/Rating/sql/rating_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Rating/sql/rating_setup/install-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Rating/sql/rating_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Rating/sql/rating_setup/install-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Rating

--- a/app/code/core/Mage/Rating/sql/rating_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/Rating/sql/rating_setup/mysql4-install-0.7.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Rating

--- a/app/code/core/Mage/Rating/sql/rating_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/Rating/sql/rating_setup/mysql4-install-0.7.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Rating/sql/rating_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/Rating/sql/rating_setup/mysql4-install-0.7.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Rating

--- a/app/code/core/Mage/Rating/sql/rating_setup/mysql4-upgrade-0.7.0-0.7.1.php
+++ b/app/code/core/Mage/Rating/sql/rating_setup/mysql4-upgrade-0.7.0-0.7.1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Rating

--- a/app/code/core/Mage/Rating/sql/rating_setup/mysql4-upgrade-0.7.0-0.7.1.php
+++ b/app/code/core/Mage/Rating/sql/rating_setup/mysql4-upgrade-0.7.0-0.7.1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Rating/sql/rating_setup/mysql4-upgrade-0.7.0-0.7.1.php
+++ b/app/code/core/Mage/Rating/sql/rating_setup/mysql4-upgrade-0.7.0-0.7.1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Rating

--- a/app/code/core/Mage/Rating/sql/rating_setup/mysql4-upgrade-0.7.1-0.7.2.php
+++ b/app/code/core/Mage/Rating/sql/rating_setup/mysql4-upgrade-0.7.1-0.7.2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Rating

--- a/app/code/core/Mage/Rating/sql/rating_setup/mysql4-upgrade-0.7.1-0.7.2.php
+++ b/app/code/core/Mage/Rating/sql/rating_setup/mysql4-upgrade-0.7.1-0.7.2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Rating/sql/rating_setup/mysql4-upgrade-0.7.1-0.7.2.php
+++ b/app/code/core/Mage/Rating/sql/rating_setup/mysql4-upgrade-0.7.1-0.7.2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Rating

--- a/app/code/core/Mage/Rating/sql/rating_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/Rating/sql/rating_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Rating

--- a/app/code/core/Mage/Rating/sql/rating_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/Rating/sql/rating_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Rating/sql/rating_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/Rating/sql/rating_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Rating

--- a/app/code/core/Mage/Rating/sql/rating_setup/mysql4-upgrade-1.6.0.0-1.6.0.1.php
+++ b/app/code/core/Mage/Rating/sql/rating_setup/mysql4-upgrade-1.6.0.0-1.6.0.1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Rating

--- a/app/code/core/Mage/Rating/sql/rating_setup/mysql4-upgrade-1.6.0.0-1.6.0.1.php
+++ b/app/code/core/Mage/Rating/sql/rating_setup/mysql4-upgrade-1.6.0.0-1.6.0.1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Rating/sql/rating_setup/mysql4-upgrade-1.6.0.0-1.6.0.1.php
+++ b/app/code/core/Mage/Rating/sql/rating_setup/mysql4-upgrade-1.6.0.0-1.6.0.1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Rating

--- a/app/code/core/Mage/Reports/Block/Product/Abstract.php
+++ b/app/code/core/Mage/Reports/Block/Product/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Block/Product/Abstract.php
+++ b/app/code/core/Mage/Reports/Block/Product/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Block/Product/Abstract.php
+++ b/app/code/core/Mage/Reports/Block/Product/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Block/Product/Compared.php
+++ b/app/code/core/Mage/Reports/Block/Product/Compared.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Block/Product/Compared.php
+++ b/app/code/core/Mage/Reports/Block/Product/Compared.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Block/Product/Compared.php
+++ b/app/code/core/Mage/Reports/Block/Product/Compared.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Block/Product/Viewed.php
+++ b/app/code/core/Mage/Reports/Block/Product/Viewed.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Block/Product/Viewed.php
+++ b/app/code/core/Mage/Reports/Block/Product/Viewed.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Block/Product/Viewed.php
+++ b/app/code/core/Mage/Reports/Block/Product/Viewed.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Block/Product/Widget/Compared.php
+++ b/app/code/core/Mage/Reports/Block/Product/Widget/Compared.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Block/Product/Widget/Compared.php
+++ b/app/code/core/Mage/Reports/Block/Product/Widget/Compared.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Block/Product/Widget/Compared.php
+++ b/app/code/core/Mage/Reports/Block/Product/Widget/Compared.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Block/Product/Widget/Viewed.php
+++ b/app/code/core/Mage/Reports/Block/Product/Widget/Viewed.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Block/Product/Widget/Viewed.php
+++ b/app/code/core/Mage/Reports/Block/Product/Widget/Viewed.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Block/Product/Widget/Viewed.php
+++ b/app/code/core/Mage/Reports/Block/Product/Widget/Viewed.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Exception.php
+++ b/app/code/core/Mage/Reports/Exception.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Exception.php
+++ b/app/code/core/Mage/Reports/Exception.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Exception.php
+++ b/app/code/core/Mage/Reports/Exception.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Helper/Data.php
+++ b/app/code/core/Mage/Reports/Helper/Data.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Helper/Data.php
+++ b/app/code/core/Mage/Reports/Helper/Data.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Helper/Data.php
+++ b/app/code/core/Mage/Reports/Helper/Data.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Config.php
+++ b/app/code/core/Mage/Reports/Model/Config.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Config.php
+++ b/app/code/core/Mage/Reports/Model/Config.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Config.php
+++ b/app/code/core/Mage/Reports/Model/Config.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Event.php
+++ b/app/code/core/Mage/Reports/Model/Event.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Event.php
+++ b/app/code/core/Mage/Reports/Model/Event.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Event.php
+++ b/app/code/core/Mage/Reports/Model/Event.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Event/Observer.php
+++ b/app/code/core/Mage/Reports/Model/Event/Observer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Event/Observer.php
+++ b/app/code/core/Mage/Reports/Model/Event/Observer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Event/Observer.php
+++ b/app/code/core/Mage/Reports/Model/Event/Observer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Event/Type.php
+++ b/app/code/core/Mage/Reports/Model/Event/Type.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Event/Type.php
+++ b/app/code/core/Mage/Reports/Model/Event/Type.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Event/Type.php
+++ b/app/code/core/Mage/Reports/Model/Event/Type.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Flag.php
+++ b/app/code/core/Mage/Reports/Model/Flag.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Flag.php
+++ b/app/code/core/Mage/Reports/Model/Flag.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Flag.php
+++ b/app/code/core/Mage/Reports/Model/Flag.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Grouped/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Grouped/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Grouped/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Grouped/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Grouped/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Grouped/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Mysql4/Accounts/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Accounts/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Mysql4/Accounts/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Accounts/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Mysql4/Accounts/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Accounts/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Mysql4/Coupons/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Coupons/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Mysql4/Coupons/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Coupons/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Mysql4/Coupons/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Coupons/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Mysql4/Customer/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Customer/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Mysql4/Customer/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Customer/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Mysql4/Customer/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Customer/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Mysql4/Customer/Orders/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Customer/Orders/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Mysql4/Customer/Orders/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Customer/Orders/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Mysql4/Customer/Orders/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Customer/Orders/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Mysql4/Customer/Totals/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Customer/Totals/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Mysql4/Customer/Totals/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Customer/Totals/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Mysql4/Customer/Totals/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Customer/Totals/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Mysql4/Entity/Summary/Collection/Abstract.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Entity/Summary/Collection/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Mysql4/Entity/Summary/Collection/Abstract.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Entity/Summary/Collection/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Mysql4/Entity/Summary/Collection/Abstract.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Entity/Summary/Collection/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Mysql4/Event.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Event.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Mysql4/Event.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Event.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Mysql4/Event.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Event.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Mysql4/Event/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Event/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Mysql4/Event/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Event/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Mysql4/Event/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Event/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Mysql4/Event/Type.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Event/Type.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Mysql4/Event/Type.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Event/Type.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Mysql4/Event/Type.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Event/Type.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Mysql4/Event/Type/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Event/Type/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Mysql4/Event/Type/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Event/Type/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Mysql4/Event/Type/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Event/Type/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Mysql4/Invoiced/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Invoiced/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Mysql4/Invoiced/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Invoiced/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Mysql4/Invoiced/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Invoiced/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Mysql4/Order/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Order/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Mysql4/Order/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Order/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Mysql4/Order/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Order/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Mysql4/Product/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Product/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Mysql4/Product/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Product/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Mysql4/Product/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Product/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Mysql4/Product/Downloads/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Product/Downloads/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Mysql4/Product/Downloads/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Product/Downloads/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Mysql4/Product/Downloads/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Product/Downloads/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Mysql4/Product/Index/Abstract.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Product/Index/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Mysql4/Product/Index/Abstract.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Product/Index/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Mysql4/Product/Index/Abstract.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Product/Index/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Mysql4/Product/Index/Collection/Abstract.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Product/Index/Collection/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Mysql4/Product/Index/Collection/Abstract.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Product/Index/Collection/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Mysql4/Product/Index/Collection/Abstract.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Product/Index/Collection/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Mysql4/Product/Index/Compared.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Product/Index/Compared.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Mysql4/Product/Index/Compared.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Product/Index/Compared.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Mysql4/Product/Index/Compared.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Product/Index/Compared.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Mysql4/Product/Index/Compared/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Product/Index/Compared/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Mysql4/Product/Index/Compared/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Product/Index/Compared/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Mysql4/Product/Index/Compared/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Product/Index/Compared/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Mysql4/Product/Index/Viewed.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Product/Index/Viewed.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Mysql4/Product/Index/Viewed.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Product/Index/Viewed.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Mysql4/Product/Index/Viewed.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Product/Index/Viewed.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Mysql4/Product/Index/Viewed/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Product/Index/Viewed/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Mysql4/Product/Index/Viewed/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Product/Index/Viewed/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Mysql4/Product/Index/Viewed/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Product/Index/Viewed/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Mysql4/Product/Lowstock/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Product/Lowstock/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Mysql4/Product/Lowstock/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Product/Lowstock/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Mysql4/Product/Lowstock/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Product/Lowstock/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Mysql4/Product/Ordered/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Product/Ordered/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Mysql4/Product/Ordered/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Product/Ordered/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Mysql4/Product/Ordered/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Product/Ordered/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Mysql4/Product/Sold/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Product/Sold/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Mysql4/Product/Sold/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Product/Sold/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Mysql4/Product/Sold/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Product/Sold/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Mysql4/Product/Viewed/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Product/Viewed/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Mysql4/Product/Viewed/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Product/Viewed/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Mysql4/Product/Viewed/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Product/Viewed/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Mysql4/Quote/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Quote/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Mysql4/Quote/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Quote/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Mysql4/Quote/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Quote/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Mysql4/Refunded/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Refunded/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Mysql4/Refunded/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Refunded/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Mysql4/Refunded/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Refunded/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Mysql4/Report/Abstract.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Report/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Mysql4/Report/Abstract.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Report/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Mysql4/Report/Abstract.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Report/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Mysql4/Report/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Report/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Mysql4/Report/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Report/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Mysql4/Report/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Report/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Mysql4/Review/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Review/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Mysql4/Review/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Review/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Mysql4/Review/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Review/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Mysql4/Review/Customer/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Review/Customer/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Mysql4/Review/Customer/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Review/Customer/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Mysql4/Review/Customer/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Review/Customer/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Mysql4/Review/Product/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Review/Product/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Mysql4/Review/Product/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Review/Product/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Mysql4/Review/Product/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Review/Product/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Mysql4/Shipping/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Shipping/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Mysql4/Shipping/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Shipping/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Mysql4/Shipping/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Shipping/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Mysql4/Shopcart/Product/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Shopcart/Product/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Mysql4/Shopcart/Product/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Shopcart/Product/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Mysql4/Shopcart/Product/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Shopcart/Product/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Mysql4/Tag/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Tag/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Mysql4/Tag/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Tag/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Mysql4/Tag/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Tag/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Mysql4/Tag/Customer/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Tag/Customer/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Mysql4/Tag/Customer/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Tag/Customer/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Mysql4/Tag/Customer/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Tag/Customer/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Mysql4/Tag/Product/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Tag/Product/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Mysql4/Tag/Product/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Tag/Product/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Mysql4/Tag/Product/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Tag/Product/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Mysql4/Tax/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Tax/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Mysql4/Tax/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Tax/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Mysql4/Tax/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Tax/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Mysql4/Wishlist/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Wishlist/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Mysql4/Wishlist/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Wishlist/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Mysql4/Wishlist/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Wishlist/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Mysql4/Wishlist/Product/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Wishlist/Product/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Mysql4/Wishlist/Product/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Wishlist/Product/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Mysql4/Wishlist/Product/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Mysql4/Wishlist/Product/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Product/Index/Abstract.php
+++ b/app/code/core/Mage/Reports/Model/Product/Index/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Product/Index/Abstract.php
+++ b/app/code/core/Mage/Reports/Model/Product/Index/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Product/Index/Abstract.php
+++ b/app/code/core/Mage/Reports/Model/Product/Index/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Product/Index/Compared.php
+++ b/app/code/core/Mage/Reports/Model/Product/Index/Compared.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Product/Index/Compared.php
+++ b/app/code/core/Mage/Reports/Model/Product/Index/Compared.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Product/Index/Compared.php
+++ b/app/code/core/Mage/Reports/Model/Product/Index/Compared.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Product/Index/Viewed.php
+++ b/app/code/core/Mage/Reports/Model/Product/Index/Viewed.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Product/Index/Viewed.php
+++ b/app/code/core/Mage/Reports/Model/Product/Index/Viewed.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Product/Index/Viewed.php
+++ b/app/code/core/Mage/Reports/Model/Product/Index/Viewed.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Report.php
+++ b/app/code/core/Mage/Reports/Model/Report.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Report.php
+++ b/app/code/core/Mage/Reports/Model/Report.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Report.php
+++ b/app/code/core/Mage/Reports/Model/Report.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Resource/Accounts/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Accounts/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Resource/Accounts/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Accounts/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Resource/Accounts/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Accounts/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Resource/Coupons/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Coupons/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Resource/Coupons/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Coupons/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Resource/Coupons/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Coupons/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Resource/Customer/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Customer/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Resource/Customer/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Customer/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Resource/Customer/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Customer/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Resource/Customer/Orders/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Customer/Orders/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Resource/Customer/Orders/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Customer/Orders/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Resource/Customer/Orders/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Customer/Orders/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Resource/Customer/Totals/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Customer/Totals/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Resource/Customer/Totals/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Customer/Totals/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Resource/Customer/Totals/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Customer/Totals/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Resource/Entity/Summary/Collection/Abstract.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Entity/Summary/Collection/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Resource/Entity/Summary/Collection/Abstract.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Entity/Summary/Collection/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Resource/Entity/Summary/Collection/Abstract.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Entity/Summary/Collection/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Resource/Event.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Event.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Resource/Event.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Event.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Resource/Event.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Event.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Resource/Event/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Event/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Resource/Event/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Event/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Resource/Event/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Event/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Resource/Event/Type.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Event/Type.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Resource/Event/Type.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Event/Type.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Resource/Event/Type.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Event/Type.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Resource/Event/Type/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Event/Type/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Resource/Event/Type/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Event/Type/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Resource/Event/Type/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Event/Type/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Resource/Helper/Interface.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Helper/Interface.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Resource/Helper/Interface.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Helper/Interface.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Resource/Helper/Interface.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Helper/Interface.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Resource/Helper/Mysql4.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Helper/Mysql4.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Resource/Helper/Mysql4.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Helper/Mysql4.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Resource/Helper/Mysql4.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Helper/Mysql4.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Resource/Invoiced/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Invoiced/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Resource/Invoiced/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Invoiced/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Resource/Invoiced/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Invoiced/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Resource/Order/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Order/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Resource/Order/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Order/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Resource/Order/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Order/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Resource/Product/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Product/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Resource/Product/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Product/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Resource/Product/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Product/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Resource/Product/Downloads/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Product/Downloads/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Resource/Product/Downloads/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Product/Downloads/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Resource/Product/Downloads/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Product/Downloads/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Resource/Product/Index/Abstract.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Product/Index/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Resource/Product/Index/Abstract.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Product/Index/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Resource/Product/Index/Abstract.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Product/Index/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Resource/Product/Index/Collection/Abstract.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Product/Index/Collection/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Resource/Product/Index/Collection/Abstract.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Product/Index/Collection/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Resource/Product/Index/Collection/Abstract.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Product/Index/Collection/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Resource/Product/Index/Compared.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Product/Index/Compared.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Resource/Product/Index/Compared.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Product/Index/Compared.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Resource/Product/Index/Compared.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Product/Index/Compared.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Resource/Product/Index/Compared/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Product/Index/Compared/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Resource/Product/Index/Compared/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Product/Index/Compared/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Resource/Product/Index/Compared/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Product/Index/Compared/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Resource/Product/Index/Viewed.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Product/Index/Viewed.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Resource/Product/Index/Viewed.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Product/Index/Viewed.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Resource/Product/Index/Viewed.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Product/Index/Viewed.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Resource/Product/Index/Viewed/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Product/Index/Viewed/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Resource/Product/Index/Viewed/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Product/Index/Viewed/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Resource/Product/Index/Viewed/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Product/Index/Viewed/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Resource/Product/Lowstock/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Product/Lowstock/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Resource/Product/Lowstock/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Product/Lowstock/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Resource/Product/Lowstock/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Product/Lowstock/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Resource/Product/Ordered/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Product/Ordered/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Resource/Product/Ordered/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Product/Ordered/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Resource/Product/Ordered/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Product/Ordered/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Resource/Product/Sold/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Product/Sold/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Resource/Product/Sold/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Product/Sold/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Resource/Product/Sold/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Product/Sold/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Resource/Product/Viewed/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Product/Viewed/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Resource/Product/Viewed/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Product/Viewed/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Resource/Product/Viewed/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Product/Viewed/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Resource/Quote/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Quote/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Resource/Quote/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Quote/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Resource/Quote/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Quote/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Resource/Refunded/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Refunded/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Resource/Refunded/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Refunded/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Resource/Refunded/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Refunded/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Resource/Report/Abstract.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Report/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Resource/Report/Abstract.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Report/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Resource/Report/Abstract.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Report/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Resource/Report/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Report/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Resource/Report/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Report/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Resource/Report/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Report/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Resource/Report/Collection/Abstract.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Report/Collection/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Resource/Report/Collection/Abstract.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Report/Collection/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Resource/Report/Collection/Abstract.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Report/Collection/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Resource/Report/Product/Viewed.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Report/Product/Viewed.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Resource/Report/Product/Viewed.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Report/Product/Viewed.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Resource/Report/Product/Viewed.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Report/Product/Viewed.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Resource/Report/Product/Viewed/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Report/Product/Viewed/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Resource/Report/Product/Viewed/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Report/Product/Viewed/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Resource/Report/Product/Viewed/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Report/Product/Viewed/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Resource/Review/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Review/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Resource/Review/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Review/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Resource/Review/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Review/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Resource/Review/Customer/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Review/Customer/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Resource/Review/Customer/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Review/Customer/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Resource/Review/Customer/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Review/Customer/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Resource/Review/Product/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Review/Product/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Resource/Review/Product/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Review/Product/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Resource/Review/Product/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Review/Product/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Resource/Shipping/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Shipping/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Resource/Shipping/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Shipping/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Resource/Shipping/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Shipping/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Resource/Shopcart/Product/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Shopcart/Product/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Resource/Shopcart/Product/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Shopcart/Product/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Resource/Shopcart/Product/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Shopcart/Product/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Resource/Tag/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Tag/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Resource/Tag/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Tag/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Resource/Tag/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Tag/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Resource/Tag/Customer/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Tag/Customer/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Resource/Tag/Customer/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Tag/Customer/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Resource/Tag/Customer/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Tag/Customer/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Resource/Tag/Product/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Tag/Product/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Resource/Tag/Product/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Tag/Product/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Resource/Tag/Product/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Tag/Product/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Resource/Tax/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Tax/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Resource/Tax/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Tax/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Resource/Tax/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Tax/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Resource/Wishlist/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Wishlist/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Resource/Wishlist/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Wishlist/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Resource/Wishlist/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Wishlist/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Resource/Wishlist/Product/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Wishlist/Product/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Resource/Wishlist/Product/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Wishlist/Product/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Resource/Wishlist/Product/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Wishlist/Product/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Session.php
+++ b/app/code/core/Mage/Reports/Model/Session.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Session.php
+++ b/app/code/core/Mage/Reports/Model/Session.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Session.php
+++ b/app/code/core/Mage/Reports/Model/Session.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Test.php
+++ b/app/code/core/Mage/Reports/Model/Test.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Test.php
+++ b/app/code/core/Mage/Reports/Model/Test.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Test.php
+++ b/app/code/core/Mage/Reports/Model/Test.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Totals.php
+++ b/app/code/core/Mage/Reports/Model/Totals.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/Model/Totals.php
+++ b/app/code/core/Mage/Reports/Model/Totals.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/Model/Totals.php
+++ b/app/code/core/Mage/Reports/Model/Totals.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/data/reports_setup/data-install-1.6.0.0.php
+++ b/app/code/core/Mage/Reports/data/reports_setup/data-install-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/data/reports_setup/data-install-1.6.0.0.php
+++ b/app/code/core/Mage/Reports/data/reports_setup/data-install-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/data/reports_setup/data-install-1.6.0.0.php
+++ b/app/code/core/Mage/Reports/data/reports_setup/data-install-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/etc/adminhtml.xml
+++ b/app/code/core/Mage/Reports/etc/adminhtml.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/etc/adminhtml.xml
+++ b/app/code/core/Mage/Reports/etc/adminhtml.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/etc/adminhtml.xml
+++ b/app/code/core/Mage/Reports/etc/adminhtml.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/etc/config.xml
+++ b/app/code/core/Mage/Reports/etc/config.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/etc/config.xml
+++ b/app/code/core/Mage/Reports/etc/config.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/etc/config.xml
+++ b/app/code/core/Mage/Reports/etc/config.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/etc/system.xml
+++ b/app/code/core/Mage/Reports/etc/system.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/etc/system.xml
+++ b/app/code/core/Mage/Reports/etc/system.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/etc/system.xml
+++ b/app/code/core/Mage/Reports/etc/system.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/etc/widget.xml
+++ b/app/code/core/Mage/Reports/etc/widget.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/etc/widget.xml
+++ b/app/code/core/Mage/Reports/etc/widget.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/etc/widget.xml
+++ b/app/code/core/Mage/Reports/etc/widget.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/sql/reports_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Reports/sql/reports_setup/install-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/sql/reports_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Reports/sql/reports_setup/install-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/sql/reports_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Reports/sql/reports_setup/install-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/sql/reports_setup/mysql4-install-0.7.1.php
+++ b/app/code/core/Mage/Reports/sql/reports_setup/mysql4-install-0.7.1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/sql/reports_setup/mysql4-install-0.7.1.php
+++ b/app/code/core/Mage/Reports/sql/reports_setup/mysql4-install-0.7.1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/sql/reports_setup/mysql4-install-0.7.1.php
+++ b/app/code/core/Mage/Reports/sql/reports_setup/mysql4-install-0.7.1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/sql/reports_setup/mysql4-install-1.5.0.0.php
+++ b/app/code/core/Mage/Reports/sql/reports_setup/mysql4-install-1.5.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/sql/reports_setup/mysql4-install-1.5.0.0.php
+++ b/app/code/core/Mage/Reports/sql/reports_setup/mysql4-install-1.5.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/sql/reports_setup/mysql4-install-1.5.0.0.php
+++ b/app/code/core/Mage/Reports/sql/reports_setup/mysql4-install-1.5.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/sql/reports_setup/mysql4-install-1.6.0.0.php
+++ b/app/code/core/Mage/Reports/sql/reports_setup/mysql4-install-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/sql/reports_setup/mysql4-install-1.6.0.0.php
+++ b/app/code/core/Mage/Reports/sql/reports_setup/mysql4-install-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/sql/reports_setup/mysql4-install-1.6.0.0.php
+++ b/app/code/core/Mage/Reports/sql/reports_setup/mysql4-install-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/sql/reports_setup/mysql4-upgrade-0.7.0-0.7.1.php
+++ b/app/code/core/Mage/Reports/sql/reports_setup/mysql4-upgrade-0.7.0-0.7.1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/sql/reports_setup/mysql4-upgrade-0.7.0-0.7.1.php
+++ b/app/code/core/Mage/Reports/sql/reports_setup/mysql4-upgrade-0.7.0-0.7.1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/sql/reports_setup/mysql4-upgrade-0.7.0-0.7.1.php
+++ b/app/code/core/Mage/Reports/sql/reports_setup/mysql4-upgrade-0.7.0-0.7.1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/sql/reports_setup/mysql4-upgrade-0.7.1-0.7.2.php
+++ b/app/code/core/Mage/Reports/sql/reports_setup/mysql4-upgrade-0.7.1-0.7.2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/sql/reports_setup/mysql4-upgrade-0.7.1-0.7.2.php
+++ b/app/code/core/Mage/Reports/sql/reports_setup/mysql4-upgrade-0.7.1-0.7.2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/sql/reports_setup/mysql4-upgrade-0.7.1-0.7.2.php
+++ b/app/code/core/Mage/Reports/sql/reports_setup/mysql4-upgrade-0.7.1-0.7.2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/sql/reports_setup/mysql4-upgrade-0.7.2-0.7.3.php
+++ b/app/code/core/Mage/Reports/sql/reports_setup/mysql4-upgrade-0.7.2-0.7.3.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/sql/reports_setup/mysql4-upgrade-0.7.2-0.7.3.php
+++ b/app/code/core/Mage/Reports/sql/reports_setup/mysql4-upgrade-0.7.2-0.7.3.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/sql/reports_setup/mysql4-upgrade-0.7.2-0.7.3.php
+++ b/app/code/core/Mage/Reports/sql/reports_setup/mysql4-upgrade-0.7.2-0.7.3.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/sql/reports_setup/mysql4-upgrade-0.7.3-0.7.4.php
+++ b/app/code/core/Mage/Reports/sql/reports_setup/mysql4-upgrade-0.7.3-0.7.4.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/sql/reports_setup/mysql4-upgrade-0.7.3-0.7.4.php
+++ b/app/code/core/Mage/Reports/sql/reports_setup/mysql4-upgrade-0.7.3-0.7.4.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/sql/reports_setup/mysql4-upgrade-0.7.3-0.7.4.php
+++ b/app/code/core/Mage/Reports/sql/reports_setup/mysql4-upgrade-0.7.3-0.7.4.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/sql/reports_setup/mysql4-upgrade-0.7.4-0.7.5.php
+++ b/app/code/core/Mage/Reports/sql/reports_setup/mysql4-upgrade-0.7.4-0.7.5.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/sql/reports_setup/mysql4-upgrade-0.7.4-0.7.5.php
+++ b/app/code/core/Mage/Reports/sql/reports_setup/mysql4-upgrade-0.7.4-0.7.5.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/sql/reports_setup/mysql4-upgrade-0.7.4-0.7.5.php
+++ b/app/code/core/Mage/Reports/sql/reports_setup/mysql4-upgrade-0.7.4-0.7.5.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/sql/reports_setup/mysql4-upgrade-0.7.5-0.7.7.php
+++ b/app/code/core/Mage/Reports/sql/reports_setup/mysql4-upgrade-0.7.5-0.7.7.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/sql/reports_setup/mysql4-upgrade-0.7.5-0.7.7.php
+++ b/app/code/core/Mage/Reports/sql/reports_setup/mysql4-upgrade-0.7.5-0.7.7.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/sql/reports_setup/mysql4-upgrade-0.7.5-0.7.7.php
+++ b/app/code/core/Mage/Reports/sql/reports_setup/mysql4-upgrade-0.7.5-0.7.7.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/sql/reports_setup/mysql4-upgrade-0.7.7-0.7.8.php
+++ b/app/code/core/Mage/Reports/sql/reports_setup/mysql4-upgrade-0.7.7-0.7.8.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/sql/reports_setup/mysql4-upgrade-0.7.7-0.7.8.php
+++ b/app/code/core/Mage/Reports/sql/reports_setup/mysql4-upgrade-0.7.7-0.7.8.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/sql/reports_setup/mysql4-upgrade-0.7.7-0.7.8.php
+++ b/app/code/core/Mage/Reports/sql/reports_setup/mysql4-upgrade-0.7.7-0.7.8.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/sql/reports_setup/mysql4-upgrade-0.7.8-0.7.9.php
+++ b/app/code/core/Mage/Reports/sql/reports_setup/mysql4-upgrade-0.7.8-0.7.9.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/sql/reports_setup/mysql4-upgrade-0.7.8-0.7.9.php
+++ b/app/code/core/Mage/Reports/sql/reports_setup/mysql4-upgrade-0.7.8-0.7.9.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/sql/reports_setup/mysql4-upgrade-0.7.8-0.7.9.php
+++ b/app/code/core/Mage/Reports/sql/reports_setup/mysql4-upgrade-0.7.8-0.7.9.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/sql/reports_setup/mysql4-upgrade-0.7.9-0.7.10.php
+++ b/app/code/core/Mage/Reports/sql/reports_setup/mysql4-upgrade-0.7.9-0.7.10.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/sql/reports_setup/mysql4-upgrade-0.7.9-0.7.10.php
+++ b/app/code/core/Mage/Reports/sql/reports_setup/mysql4-upgrade-0.7.9-0.7.10.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/sql/reports_setup/mysql4-upgrade-0.7.9-0.7.10.php
+++ b/app/code/core/Mage/Reports/sql/reports_setup/mysql4-upgrade-0.7.9-0.7.10.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/sql/reports_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/Reports/sql/reports_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/sql/reports_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/Reports/sql/reports_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/sql/reports_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/Reports/sql/reports_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/sql/reports_setup/upgrade-1.6.0.0-1.6.0.0.1.php
+++ b/app/code/core/Mage/Reports/sql/reports_setup/upgrade-1.6.0.0-1.6.0.0.1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Reports/sql/reports_setup/upgrade-1.6.0.0-1.6.0.0.1.php
+++ b/app/code/core/Mage/Reports/sql/reports_setup/upgrade-1.6.0.0-1.6.0.0.1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Reports/sql/reports_setup/upgrade-1.6.0.0-1.6.0.0.1.php
+++ b/app/code/core/Mage/Reports/sql/reports_setup/upgrade-1.6.0.0-1.6.0.0.1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/code/core/Mage/Review/Block/Customer/List.php
+++ b/app/code/core/Mage/Review/Block/Customer/List.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Review/Block/Customer/List.php
+++ b/app/code/core/Mage/Review/Block/Customer/List.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Review

--- a/app/code/core/Mage/Review/Block/Customer/List.php
+++ b/app/code/core/Mage/Review/Block/Customer/List.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Review

--- a/app/code/core/Mage/Review/Block/Customer/Recent.php
+++ b/app/code/core/Mage/Review/Block/Customer/Recent.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Review/Block/Customer/Recent.php
+++ b/app/code/core/Mage/Review/Block/Customer/Recent.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Review

--- a/app/code/core/Mage/Review/Block/Customer/Recent.php
+++ b/app/code/core/Mage/Review/Block/Customer/Recent.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Review

--- a/app/code/core/Mage/Review/Block/Customer/View.php
+++ b/app/code/core/Mage/Review/Block/Customer/View.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Review/Block/Customer/View.php
+++ b/app/code/core/Mage/Review/Block/Customer/View.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Review

--- a/app/code/core/Mage/Review/Block/Customer/View.php
+++ b/app/code/core/Mage/Review/Block/Customer/View.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Review

--- a/app/code/core/Mage/Review/Block/Form.php
+++ b/app/code/core/Mage/Review/Block/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Review/Block/Form.php
+++ b/app/code/core/Mage/Review/Block/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Review

--- a/app/code/core/Mage/Review/Block/Form.php
+++ b/app/code/core/Mage/Review/Block/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Review

--- a/app/code/core/Mage/Review/Block/Helper.php
+++ b/app/code/core/Mage/Review/Block/Helper.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Review/Block/Helper.php
+++ b/app/code/core/Mage/Review/Block/Helper.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Review

--- a/app/code/core/Mage/Review/Block/Helper.php
+++ b/app/code/core/Mage/Review/Block/Helper.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Review

--- a/app/code/core/Mage/Review/Block/Product/View.php
+++ b/app/code/core/Mage/Review/Block/Product/View.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Review/Block/Product/View.php
+++ b/app/code/core/Mage/Review/Block/Product/View.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Review

--- a/app/code/core/Mage/Review/Block/Product/View.php
+++ b/app/code/core/Mage/Review/Block/Product/View.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Review

--- a/app/code/core/Mage/Review/Block/Product/View/List.php
+++ b/app/code/core/Mage/Review/Block/Product/View/List.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Review/Block/Product/View/List.php
+++ b/app/code/core/Mage/Review/Block/Product/View/List.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Review

--- a/app/code/core/Mage/Review/Block/Product/View/List.php
+++ b/app/code/core/Mage/Review/Block/Product/View/List.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Review

--- a/app/code/core/Mage/Review/Block/View.php
+++ b/app/code/core/Mage/Review/Block/View.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Review/Block/View.php
+++ b/app/code/core/Mage/Review/Block/View.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Review

--- a/app/code/core/Mage/Review/Block/View.php
+++ b/app/code/core/Mage/Review/Block/View.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Review

--- a/app/code/core/Mage/Review/Helper/Data.php
+++ b/app/code/core/Mage/Review/Helper/Data.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Review/Helper/Data.php
+++ b/app/code/core/Mage/Review/Helper/Data.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Review

--- a/app/code/core/Mage/Review/Helper/Data.php
+++ b/app/code/core/Mage/Review/Helper/Data.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Review

--- a/app/code/core/Mage/Review/Model/Mysql4/Review.php
+++ b/app/code/core/Mage/Review/Model/Mysql4/Review.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Review/Model/Mysql4/Review.php
+++ b/app/code/core/Mage/Review/Model/Mysql4/Review.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Review

--- a/app/code/core/Mage/Review/Model/Mysql4/Review.php
+++ b/app/code/core/Mage/Review/Model/Mysql4/Review.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Review

--- a/app/code/core/Mage/Review/Model/Mysql4/Review/Collection.php
+++ b/app/code/core/Mage/Review/Model/Mysql4/Review/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Review/Model/Mysql4/Review/Collection.php
+++ b/app/code/core/Mage/Review/Model/Mysql4/Review/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Review

--- a/app/code/core/Mage/Review/Model/Mysql4/Review/Collection.php
+++ b/app/code/core/Mage/Review/Model/Mysql4/Review/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Review

--- a/app/code/core/Mage/Review/Model/Mysql4/Review/Product/Collection.php
+++ b/app/code/core/Mage/Review/Model/Mysql4/Review/Product/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Review/Model/Mysql4/Review/Product/Collection.php
+++ b/app/code/core/Mage/Review/Model/Mysql4/Review/Product/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Review

--- a/app/code/core/Mage/Review/Model/Mysql4/Review/Product/Collection.php
+++ b/app/code/core/Mage/Review/Model/Mysql4/Review/Product/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Review

--- a/app/code/core/Mage/Review/Model/Mysql4/Review/Status/Collection.php
+++ b/app/code/core/Mage/Review/Model/Mysql4/Review/Status/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Review/Model/Mysql4/Review/Status/Collection.php
+++ b/app/code/core/Mage/Review/Model/Mysql4/Review/Status/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Review

--- a/app/code/core/Mage/Review/Model/Mysql4/Review/Status/Collection.php
+++ b/app/code/core/Mage/Review/Model/Mysql4/Review/Status/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Review

--- a/app/code/core/Mage/Review/Model/Mysql4/Review/Summary.php
+++ b/app/code/core/Mage/Review/Model/Mysql4/Review/Summary.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Review/Model/Mysql4/Review/Summary.php
+++ b/app/code/core/Mage/Review/Model/Mysql4/Review/Summary.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Review

--- a/app/code/core/Mage/Review/Model/Mysql4/Review/Summary.php
+++ b/app/code/core/Mage/Review/Model/Mysql4/Review/Summary.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Review

--- a/app/code/core/Mage/Review/Model/Mysql4/Review/Summary/Collection.php
+++ b/app/code/core/Mage/Review/Model/Mysql4/Review/Summary/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Review/Model/Mysql4/Review/Summary/Collection.php
+++ b/app/code/core/Mage/Review/Model/Mysql4/Review/Summary/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Review

--- a/app/code/core/Mage/Review/Model/Mysql4/Review/Summary/Collection.php
+++ b/app/code/core/Mage/Review/Model/Mysql4/Review/Summary/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Review

--- a/app/code/core/Mage/Review/Model/Observer.php
+++ b/app/code/core/Mage/Review/Model/Observer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Review/Model/Observer.php
+++ b/app/code/core/Mage/Review/Model/Observer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Review

--- a/app/code/core/Mage/Review/Model/Observer.php
+++ b/app/code/core/Mage/Review/Model/Observer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Review

--- a/app/code/core/Mage/Review/Model/Resource/Review.php
+++ b/app/code/core/Mage/Review/Model/Resource/Review.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Review/Model/Resource/Review.php
+++ b/app/code/core/Mage/Review/Model/Resource/Review.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Review

--- a/app/code/core/Mage/Review/Model/Resource/Review.php
+++ b/app/code/core/Mage/Review/Model/Resource/Review.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Review

--- a/app/code/core/Mage/Review/Model/Resource/Review/Collection.php
+++ b/app/code/core/Mage/Review/Model/Resource/Review/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Review/Model/Resource/Review/Collection.php
+++ b/app/code/core/Mage/Review/Model/Resource/Review/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Review

--- a/app/code/core/Mage/Review/Model/Resource/Review/Collection.php
+++ b/app/code/core/Mage/Review/Model/Resource/Review/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Review

--- a/app/code/core/Mage/Review/Model/Resource/Review/Product/Collection.php
+++ b/app/code/core/Mage/Review/Model/Resource/Review/Product/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Review/Model/Resource/Review/Product/Collection.php
+++ b/app/code/core/Mage/Review/Model/Resource/Review/Product/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Review

--- a/app/code/core/Mage/Review/Model/Resource/Review/Product/Collection.php
+++ b/app/code/core/Mage/Review/Model/Resource/Review/Product/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Review

--- a/app/code/core/Mage/Review/Model/Resource/Review/Status.php
+++ b/app/code/core/Mage/Review/Model/Resource/Review/Status.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Review/Model/Resource/Review/Status.php
+++ b/app/code/core/Mage/Review/Model/Resource/Review/Status.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Review

--- a/app/code/core/Mage/Review/Model/Resource/Review/Status.php
+++ b/app/code/core/Mage/Review/Model/Resource/Review/Status.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Review

--- a/app/code/core/Mage/Review/Model/Resource/Review/Status/Collection.php
+++ b/app/code/core/Mage/Review/Model/Resource/Review/Status/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Review/Model/Resource/Review/Status/Collection.php
+++ b/app/code/core/Mage/Review/Model/Resource/Review/Status/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Review

--- a/app/code/core/Mage/Review/Model/Resource/Review/Status/Collection.php
+++ b/app/code/core/Mage/Review/Model/Resource/Review/Status/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Review

--- a/app/code/core/Mage/Review/Model/Resource/Review/Summary.php
+++ b/app/code/core/Mage/Review/Model/Resource/Review/Summary.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Review/Model/Resource/Review/Summary.php
+++ b/app/code/core/Mage/Review/Model/Resource/Review/Summary.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Review

--- a/app/code/core/Mage/Review/Model/Resource/Review/Summary.php
+++ b/app/code/core/Mage/Review/Model/Resource/Review/Summary.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Review

--- a/app/code/core/Mage/Review/Model/Resource/Review/Summary/Collection.php
+++ b/app/code/core/Mage/Review/Model/Resource/Review/Summary/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Review/Model/Resource/Review/Summary/Collection.php
+++ b/app/code/core/Mage/Review/Model/Resource/Review/Summary/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Review

--- a/app/code/core/Mage/Review/Model/Resource/Review/Summary/Collection.php
+++ b/app/code/core/Mage/Review/Model/Resource/Review/Summary/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Review

--- a/app/code/core/Mage/Review/Model/Review.php
+++ b/app/code/core/Mage/Review/Model/Review.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Review/Model/Review.php
+++ b/app/code/core/Mage/Review/Model/Review.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Review

--- a/app/code/core/Mage/Review/Model/Review.php
+++ b/app/code/core/Mage/Review/Model/Review.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Review

--- a/app/code/core/Mage/Review/Model/Review/Status.php
+++ b/app/code/core/Mage/Review/Model/Review/Status.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Review/Model/Review/Status.php
+++ b/app/code/core/Mage/Review/Model/Review/Status.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Review

--- a/app/code/core/Mage/Review/Model/Review/Status.php
+++ b/app/code/core/Mage/Review/Model/Review/Status.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Review

--- a/app/code/core/Mage/Review/Model/Review/Summary.php
+++ b/app/code/core/Mage/Review/Model/Review/Summary.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Review/Model/Review/Summary.php
+++ b/app/code/core/Mage/Review/Model/Review/Summary.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Review

--- a/app/code/core/Mage/Review/Model/Review/Summary.php
+++ b/app/code/core/Mage/Review/Model/Review/Summary.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Review

--- a/app/code/core/Mage/Review/Model/Session.php
+++ b/app/code/core/Mage/Review/Model/Session.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Review/Model/Session.php
+++ b/app/code/core/Mage/Review/Model/Session.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Review

--- a/app/code/core/Mage/Review/Model/Session.php
+++ b/app/code/core/Mage/Review/Model/Session.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Review

--- a/app/code/core/Mage/Review/controllers/CustomerController.php
+++ b/app/code/core/Mage/Review/controllers/CustomerController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Review/controllers/CustomerController.php
+++ b/app/code/core/Mage/Review/controllers/CustomerController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Review

--- a/app/code/core/Mage/Review/controllers/CustomerController.php
+++ b/app/code/core/Mage/Review/controllers/CustomerController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Review

--- a/app/code/core/Mage/Review/controllers/ProductController.php
+++ b/app/code/core/Mage/Review/controllers/ProductController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Review/controllers/ProductController.php
+++ b/app/code/core/Mage/Review/controllers/ProductController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Review

--- a/app/code/core/Mage/Review/controllers/ProductController.php
+++ b/app/code/core/Mage/Review/controllers/ProductController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Review

--- a/app/code/core/Mage/Review/data/review_setup/data-install-1.6.0.0.php
+++ b/app/code/core/Mage/Review/data/review_setup/data-install-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Review/data/review_setup/data-install-1.6.0.0.php
+++ b/app/code/core/Mage/Review/data/review_setup/data-install-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Review

--- a/app/code/core/Mage/Review/data/review_setup/data-install-1.6.0.0.php
+++ b/app/code/core/Mage/Review/data/review_setup/data-install-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Review

--- a/app/code/core/Mage/Review/etc/adminhtml.xml
+++ b/app/code/core/Mage/Review/etc/adminhtml.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Review

--- a/app/code/core/Mage/Review/etc/adminhtml.xml
+++ b/app/code/core/Mage/Review/etc/adminhtml.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Review

--- a/app/code/core/Mage/Review/etc/adminhtml.xml
+++ b/app/code/core/Mage/Review/etc/adminhtml.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Review/etc/config.xml
+++ b/app/code/core/Mage/Review/etc/config.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Review

--- a/app/code/core/Mage/Review/etc/config.xml
+++ b/app/code/core/Mage/Review/etc/config.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Review

--- a/app/code/core/Mage/Review/etc/config.xml
+++ b/app/code/core/Mage/Review/etc/config.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Review/etc/system.xml
+++ b/app/code/core/Mage/Review/etc/system.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Review

--- a/app/code/core/Mage/Review/etc/system.xml
+++ b/app/code/core/Mage/Review/etc/system.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Review

--- a/app/code/core/Mage/Review/etc/system.xml
+++ b/app/code/core/Mage/Review/etc/system.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Review/sql/review_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Review/sql/review_setup/install-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Review/sql/review_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Review/sql/review_setup/install-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Review

--- a/app/code/core/Mage/Review/sql/review_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Review/sql/review_setup/install-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Review

--- a/app/code/core/Mage/Review/sql/review_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/Review/sql/review_setup/mysql4-install-0.7.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Review/sql/review_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/Review/sql/review_setup/mysql4-install-0.7.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Review

--- a/app/code/core/Mage/Review/sql/review_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/Review/sql/review_setup/mysql4-install-0.7.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Review

--- a/app/code/core/Mage/Review/sql/review_setup/mysql4-upgrade-0.7.0-0.7.1.php
+++ b/app/code/core/Mage/Review/sql/review_setup/mysql4-upgrade-0.7.0-0.7.1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Review/sql/review_setup/mysql4-upgrade-0.7.0-0.7.1.php
+++ b/app/code/core/Mage/Review/sql/review_setup/mysql4-upgrade-0.7.0-0.7.1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Review

--- a/app/code/core/Mage/Review/sql/review_setup/mysql4-upgrade-0.7.0-0.7.1.php
+++ b/app/code/core/Mage/Review/sql/review_setup/mysql4-upgrade-0.7.0-0.7.1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Review

--- a/app/code/core/Mage/Review/sql/review_setup/mysql4-upgrade-0.7.1-0.7.2.php
+++ b/app/code/core/Mage/Review/sql/review_setup/mysql4-upgrade-0.7.1-0.7.2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Review/sql/review_setup/mysql4-upgrade-0.7.1-0.7.2.php
+++ b/app/code/core/Mage/Review/sql/review_setup/mysql4-upgrade-0.7.1-0.7.2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Review

--- a/app/code/core/Mage/Review/sql/review_setup/mysql4-upgrade-0.7.1-0.7.2.php
+++ b/app/code/core/Mage/Review/sql/review_setup/mysql4-upgrade-0.7.1-0.7.2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Review

--- a/app/code/core/Mage/Review/sql/review_setup/mysql4-upgrade-0.7.2-0.7.3.php
+++ b/app/code/core/Mage/Review/sql/review_setup/mysql4-upgrade-0.7.2-0.7.3.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Review/sql/review_setup/mysql4-upgrade-0.7.2-0.7.3.php
+++ b/app/code/core/Mage/Review/sql/review_setup/mysql4-upgrade-0.7.2-0.7.3.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Review

--- a/app/code/core/Mage/Review/sql/review_setup/mysql4-upgrade-0.7.2-0.7.3.php
+++ b/app/code/core/Mage/Review/sql/review_setup/mysql4-upgrade-0.7.2-0.7.3.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Review

--- a/app/code/core/Mage/Review/sql/review_setup/mysql4-upgrade-0.7.3-0.7.4.php
+++ b/app/code/core/Mage/Review/sql/review_setup/mysql4-upgrade-0.7.3-0.7.4.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Review/sql/review_setup/mysql4-upgrade-0.7.3-0.7.4.php
+++ b/app/code/core/Mage/Review/sql/review_setup/mysql4-upgrade-0.7.3-0.7.4.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Review

--- a/app/code/core/Mage/Review/sql/review_setup/mysql4-upgrade-0.7.3-0.7.4.php
+++ b/app/code/core/Mage/Review/sql/review_setup/mysql4-upgrade-0.7.3-0.7.4.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Review

--- a/app/code/core/Mage/Review/sql/review_setup/mysql4-upgrade-0.7.4-0.7.5.php
+++ b/app/code/core/Mage/Review/sql/review_setup/mysql4-upgrade-0.7.4-0.7.5.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Review/sql/review_setup/mysql4-upgrade-0.7.4-0.7.5.php
+++ b/app/code/core/Mage/Review/sql/review_setup/mysql4-upgrade-0.7.4-0.7.5.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Review

--- a/app/code/core/Mage/Review/sql/review_setup/mysql4-upgrade-0.7.4-0.7.5.php
+++ b/app/code/core/Mage/Review/sql/review_setup/mysql4-upgrade-0.7.4-0.7.5.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Review

--- a/app/code/core/Mage/Review/sql/review_setup/mysql4-upgrade-0.7.5-0.7.6.php
+++ b/app/code/core/Mage/Review/sql/review_setup/mysql4-upgrade-0.7.5-0.7.6.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Review/sql/review_setup/mysql4-upgrade-0.7.5-0.7.6.php
+++ b/app/code/core/Mage/Review/sql/review_setup/mysql4-upgrade-0.7.5-0.7.6.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Review

--- a/app/code/core/Mage/Review/sql/review_setup/mysql4-upgrade-0.7.5-0.7.6.php
+++ b/app/code/core/Mage/Review/sql/review_setup/mysql4-upgrade-0.7.5-0.7.6.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Review

--- a/app/code/core/Mage/Review/sql/review_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/Review/sql/review_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Review/sql/review_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/Review/sql/review_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Review

--- a/app/code/core/Mage/Review/sql/review_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/Review/sql/review_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Review

--- a/app/code/core/Mage/Rss/Block/Abstract.php
+++ b/app/code/core/Mage/Rss/Block/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Rss

--- a/app/code/core/Mage/Rss/Block/Abstract.php
+++ b/app/code/core/Mage/Rss/Block/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Rss/Block/Abstract.php
+++ b/app/code/core/Mage/Rss/Block/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Rss

--- a/app/code/core/Mage/Rss/Block/Catalog/Abstract.php
+++ b/app/code/core/Mage/Rss/Block/Catalog/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Rss

--- a/app/code/core/Mage/Rss/Block/Catalog/Abstract.php
+++ b/app/code/core/Mage/Rss/Block/Catalog/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Rss/Block/Catalog/Abstract.php
+++ b/app/code/core/Mage/Rss/Block/Catalog/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Rss

--- a/app/code/core/Mage/Rss/Block/Catalog/Category.php
+++ b/app/code/core/Mage/Rss/Block/Catalog/Category.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Rss

--- a/app/code/core/Mage/Rss/Block/Catalog/Category.php
+++ b/app/code/core/Mage/Rss/Block/Catalog/Category.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Rss/Block/Catalog/Category.php
+++ b/app/code/core/Mage/Rss/Block/Catalog/Category.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Rss

--- a/app/code/core/Mage/Rss/Block/Catalog/New.php
+++ b/app/code/core/Mage/Rss/Block/Catalog/New.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Rss

--- a/app/code/core/Mage/Rss/Block/Catalog/New.php
+++ b/app/code/core/Mage/Rss/Block/Catalog/New.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Rss/Block/Catalog/New.php
+++ b/app/code/core/Mage/Rss/Block/Catalog/New.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Rss

--- a/app/code/core/Mage/Rss/Block/Catalog/NotifyStock.php
+++ b/app/code/core/Mage/Rss/Block/Catalog/NotifyStock.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Rss

--- a/app/code/core/Mage/Rss/Block/Catalog/NotifyStock.php
+++ b/app/code/core/Mage/Rss/Block/Catalog/NotifyStock.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Rss/Block/Catalog/NotifyStock.php
+++ b/app/code/core/Mage/Rss/Block/Catalog/NotifyStock.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Rss

--- a/app/code/core/Mage/Rss/Block/Catalog/Review.php
+++ b/app/code/core/Mage/Rss/Block/Catalog/Review.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Rss

--- a/app/code/core/Mage/Rss/Block/Catalog/Review.php
+++ b/app/code/core/Mage/Rss/Block/Catalog/Review.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Rss/Block/Catalog/Review.php
+++ b/app/code/core/Mage/Rss/Block/Catalog/Review.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Rss

--- a/app/code/core/Mage/Rss/Block/Catalog/Salesrule.php
+++ b/app/code/core/Mage/Rss/Block/Catalog/Salesrule.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Rss

--- a/app/code/core/Mage/Rss/Block/Catalog/Salesrule.php
+++ b/app/code/core/Mage/Rss/Block/Catalog/Salesrule.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Rss/Block/Catalog/Salesrule.php
+++ b/app/code/core/Mage/Rss/Block/Catalog/Salesrule.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Rss

--- a/app/code/core/Mage/Rss/Block/Catalog/Special.php
+++ b/app/code/core/Mage/Rss/Block/Catalog/Special.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Rss

--- a/app/code/core/Mage/Rss/Block/Catalog/Special.php
+++ b/app/code/core/Mage/Rss/Block/Catalog/Special.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Rss/Block/Catalog/Special.php
+++ b/app/code/core/Mage/Rss/Block/Catalog/Special.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Rss

--- a/app/code/core/Mage/Rss/Block/Catalog/Tag.php
+++ b/app/code/core/Mage/Rss/Block/Catalog/Tag.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Rss

--- a/app/code/core/Mage/Rss/Block/Catalog/Tag.php
+++ b/app/code/core/Mage/Rss/Block/Catalog/Tag.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Rss/Block/Catalog/Tag.php
+++ b/app/code/core/Mage/Rss/Block/Catalog/Tag.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Rss

--- a/app/code/core/Mage/Rss/Block/List.php
+++ b/app/code/core/Mage/Rss/Block/List.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Rss

--- a/app/code/core/Mage/Rss/Block/List.php
+++ b/app/code/core/Mage/Rss/Block/List.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Rss/Block/List.php
+++ b/app/code/core/Mage/Rss/Block/List.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Rss

--- a/app/code/core/Mage/Rss/Block/Order/Details.php
+++ b/app/code/core/Mage/Rss/Block/Order/Details.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Rss

--- a/app/code/core/Mage/Rss/Block/Order/Details.php
+++ b/app/code/core/Mage/Rss/Block/Order/Details.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Rss/Block/Order/Details.php
+++ b/app/code/core/Mage/Rss/Block/Order/Details.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Rss

--- a/app/code/core/Mage/Rss/Block/Order/New.php
+++ b/app/code/core/Mage/Rss/Block/Order/New.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Rss

--- a/app/code/core/Mage/Rss/Block/Order/New.php
+++ b/app/code/core/Mage/Rss/Block/Order/New.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Rss/Block/Order/New.php
+++ b/app/code/core/Mage/Rss/Block/Order/New.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Rss

--- a/app/code/core/Mage/Rss/Block/Order/Status.php
+++ b/app/code/core/Mage/Rss/Block/Order/Status.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Rss

--- a/app/code/core/Mage/Rss/Block/Order/Status.php
+++ b/app/code/core/Mage/Rss/Block/Order/Status.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Rss/Block/Order/Status.php
+++ b/app/code/core/Mage/Rss/Block/Order/Status.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Rss

--- a/app/code/core/Mage/Rss/Block/Wishlist.php
+++ b/app/code/core/Mage/Rss/Block/Wishlist.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Rss

--- a/app/code/core/Mage/Rss/Block/Wishlist.php
+++ b/app/code/core/Mage/Rss/Block/Wishlist.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Rss/Block/Wishlist.php
+++ b/app/code/core/Mage/Rss/Block/Wishlist.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Rss

--- a/app/code/core/Mage/Rss/Controller/Abstract.php
+++ b/app/code/core/Mage/Rss/Controller/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Rss

--- a/app/code/core/Mage/Rss/Controller/Abstract.php
+++ b/app/code/core/Mage/Rss/Controller/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Rss/Controller/Abstract.php
+++ b/app/code/core/Mage/Rss/Controller/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Rss

--- a/app/code/core/Mage/Rss/Helper/Catalog.php
+++ b/app/code/core/Mage/Rss/Helper/Catalog.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Rss

--- a/app/code/core/Mage/Rss/Helper/Catalog.php
+++ b/app/code/core/Mage/Rss/Helper/Catalog.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Rss/Helper/Catalog.php
+++ b/app/code/core/Mage/Rss/Helper/Catalog.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Rss

--- a/app/code/core/Mage/Rss/Helper/Data.php
+++ b/app/code/core/Mage/Rss/Helper/Data.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Rss

--- a/app/code/core/Mage/Rss/Helper/Data.php
+++ b/app/code/core/Mage/Rss/Helper/Data.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Rss/Helper/Data.php
+++ b/app/code/core/Mage/Rss/Helper/Data.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Rss

--- a/app/code/core/Mage/Rss/Helper/Order.php
+++ b/app/code/core/Mage/Rss/Helper/Order.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Rss

--- a/app/code/core/Mage/Rss/Helper/Order.php
+++ b/app/code/core/Mage/Rss/Helper/Order.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Rss/Helper/Order.php
+++ b/app/code/core/Mage/Rss/Helper/Order.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Rss

--- a/app/code/core/Mage/Rss/Model/Mysql4/Order.php
+++ b/app/code/core/Mage/Rss/Model/Mysql4/Order.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Rss

--- a/app/code/core/Mage/Rss/Model/Mysql4/Order.php
+++ b/app/code/core/Mage/Rss/Model/Mysql4/Order.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Rss/Model/Mysql4/Order.php
+++ b/app/code/core/Mage/Rss/Model/Mysql4/Order.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Rss

--- a/app/code/core/Mage/Rss/Model/Observer.php
+++ b/app/code/core/Mage/Rss/Model/Observer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Rss

--- a/app/code/core/Mage/Rss/Model/Observer.php
+++ b/app/code/core/Mage/Rss/Model/Observer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Rss/Model/Observer.php
+++ b/app/code/core/Mage/Rss/Model/Observer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Rss

--- a/app/code/core/Mage/Rss/Model/Resource/Order.php
+++ b/app/code/core/Mage/Rss/Model/Resource/Order.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Rss

--- a/app/code/core/Mage/Rss/Model/Resource/Order.php
+++ b/app/code/core/Mage/Rss/Model/Resource/Order.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Rss/Model/Resource/Order.php
+++ b/app/code/core/Mage/Rss/Model/Resource/Order.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Rss

--- a/app/code/core/Mage/Rss/Model/Rss.php
+++ b/app/code/core/Mage/Rss/Model/Rss.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Rss

--- a/app/code/core/Mage/Rss/Model/Rss.php
+++ b/app/code/core/Mage/Rss/Model/Rss.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Rss/Model/Rss.php
+++ b/app/code/core/Mage/Rss/Model/Rss.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Rss

--- a/app/code/core/Mage/Rss/Model/Session.php
+++ b/app/code/core/Mage/Rss/Model/Session.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Rss

--- a/app/code/core/Mage/Rss/Model/Session.php
+++ b/app/code/core/Mage/Rss/Model/Session.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Rss/Model/Session.php
+++ b/app/code/core/Mage/Rss/Model/Session.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Rss

--- a/app/code/core/Mage/Rss/Model/System/Config/Backend/Links.php
+++ b/app/code/core/Mage/Rss/Model/System/Config/Backend/Links.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Rss

--- a/app/code/core/Mage/Rss/Model/System/Config/Backend/Links.php
+++ b/app/code/core/Mage/Rss/Model/System/Config/Backend/Links.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Rss/Model/System/Config/Backend/Links.php
+++ b/app/code/core/Mage/Rss/Model/System/Config/Backend/Links.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Rss

--- a/app/code/core/Mage/Rss/controllers/CatalogController.php
+++ b/app/code/core/Mage/Rss/controllers/CatalogController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Rss

--- a/app/code/core/Mage/Rss/controllers/CatalogController.php
+++ b/app/code/core/Mage/Rss/controllers/CatalogController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Rss/controllers/CatalogController.php
+++ b/app/code/core/Mage/Rss/controllers/CatalogController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Rss

--- a/app/code/core/Mage/Rss/controllers/IndexController.php
+++ b/app/code/core/Mage/Rss/controllers/IndexController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Rss

--- a/app/code/core/Mage/Rss/controllers/IndexController.php
+++ b/app/code/core/Mage/Rss/controllers/IndexController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Rss/controllers/IndexController.php
+++ b/app/code/core/Mage/Rss/controllers/IndexController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Rss

--- a/app/code/core/Mage/Rss/controllers/OrderController.php
+++ b/app/code/core/Mage/Rss/controllers/OrderController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Rss

--- a/app/code/core/Mage/Rss/controllers/OrderController.php
+++ b/app/code/core/Mage/Rss/controllers/OrderController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Rss/controllers/OrderController.php
+++ b/app/code/core/Mage/Rss/controllers/OrderController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Rss

--- a/app/code/core/Mage/Rss/data/rss_setup/data-install-1.6.0.0.php
+++ b/app/code/core/Mage/Rss/data/rss_setup/data-install-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Rss

--- a/app/code/core/Mage/Rss/data/rss_setup/data-install-1.6.0.0.php
+++ b/app/code/core/Mage/Rss/data/rss_setup/data-install-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Rss/data/rss_setup/data-install-1.6.0.0.php
+++ b/app/code/core/Mage/Rss/data/rss_setup/data-install-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Rss

--- a/app/code/core/Mage/Rss/etc/adminhtml.xml
+++ b/app/code/core/Mage/Rss/etc/adminhtml.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Rss

--- a/app/code/core/Mage/Rss/etc/adminhtml.xml
+++ b/app/code/core/Mage/Rss/etc/adminhtml.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Rss/etc/adminhtml.xml
+++ b/app/code/core/Mage/Rss/etc/adminhtml.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Rss

--- a/app/code/core/Mage/Rss/etc/config.xml
+++ b/app/code/core/Mage/Rss/etc/config.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Rss

--- a/app/code/core/Mage/Rss/etc/config.xml
+++ b/app/code/core/Mage/Rss/etc/config.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Rss/etc/config.xml
+++ b/app/code/core/Mage/Rss/etc/config.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Rss

--- a/app/code/core/Mage/Rss/etc/system.xml
+++ b/app/code/core/Mage/Rss/etc/system.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Rss

--- a/app/code/core/Mage/Rss/etc/system.xml
+++ b/app/code/core/Mage/Rss/etc/system.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Rss/etc/system.xml
+++ b/app/code/core/Mage/Rss/etc/system.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Rss

--- a/app/code/core/Mage/Rule/Block/Actions.php
+++ b/app/code/core/Mage/Rule/Block/Actions.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Rule/Block/Actions.php
+++ b/app/code/core/Mage/Rule/Block/Actions.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Rule

--- a/app/code/core/Mage/Rule/Block/Actions.php
+++ b/app/code/core/Mage/Rule/Block/Actions.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Rule

--- a/app/code/core/Mage/Rule/Block/Conditions.php
+++ b/app/code/core/Mage/Rule/Block/Conditions.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Rule/Block/Conditions.php
+++ b/app/code/core/Mage/Rule/Block/Conditions.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Rule

--- a/app/code/core/Mage/Rule/Block/Conditions.php
+++ b/app/code/core/Mage/Rule/Block/Conditions.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Rule

--- a/app/code/core/Mage/Rule/Block/Editable.php
+++ b/app/code/core/Mage/Rule/Block/Editable.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Rule/Block/Editable.php
+++ b/app/code/core/Mage/Rule/Block/Editable.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Rule

--- a/app/code/core/Mage/Rule/Block/Editable.php
+++ b/app/code/core/Mage/Rule/Block/Editable.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Rule

--- a/app/code/core/Mage/Rule/Block/Newchild.php
+++ b/app/code/core/Mage/Rule/Block/Newchild.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Rule/Block/Newchild.php
+++ b/app/code/core/Mage/Rule/Block/Newchild.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Rule

--- a/app/code/core/Mage/Rule/Block/Newchild.php
+++ b/app/code/core/Mage/Rule/Block/Newchild.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Rule

--- a/app/code/core/Mage/Rule/Block/Rule.php
+++ b/app/code/core/Mage/Rule/Block/Rule.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Rule/Block/Rule.php
+++ b/app/code/core/Mage/Rule/Block/Rule.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Rule

--- a/app/code/core/Mage/Rule/Block/Rule.php
+++ b/app/code/core/Mage/Rule/Block/Rule.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Rule

--- a/app/code/core/Mage/Rule/Helper/Data.php
+++ b/app/code/core/Mage/Rule/Helper/Data.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Rule/Helper/Data.php
+++ b/app/code/core/Mage/Rule/Helper/Data.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Rule

--- a/app/code/core/Mage/Rule/Helper/Data.php
+++ b/app/code/core/Mage/Rule/Helper/Data.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Rule

--- a/app/code/core/Mage/Rule/Model/Abstract.php
+++ b/app/code/core/Mage/Rule/Model/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Rule/Model/Abstract.php
+++ b/app/code/core/Mage/Rule/Model/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Rule

--- a/app/code/core/Mage/Rule/Model/Abstract.php
+++ b/app/code/core/Mage/Rule/Model/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Rule

--- a/app/code/core/Mage/Rule/Model/Action/Abstract.php
+++ b/app/code/core/Mage/Rule/Model/Action/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Rule/Model/Action/Abstract.php
+++ b/app/code/core/Mage/Rule/Model/Action/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Rule

--- a/app/code/core/Mage/Rule/Model/Action/Abstract.php
+++ b/app/code/core/Mage/Rule/Model/Action/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Rule

--- a/app/code/core/Mage/Rule/Model/Action/Collection.php
+++ b/app/code/core/Mage/Rule/Model/Action/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Rule/Model/Action/Collection.php
+++ b/app/code/core/Mage/Rule/Model/Action/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Rule

--- a/app/code/core/Mage/Rule/Model/Action/Collection.php
+++ b/app/code/core/Mage/Rule/Model/Action/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Rule

--- a/app/code/core/Mage/Rule/Model/Action/Interface.php
+++ b/app/code/core/Mage/Rule/Model/Action/Interface.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Rule/Model/Action/Interface.php
+++ b/app/code/core/Mage/Rule/Model/Action/Interface.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Rule

--- a/app/code/core/Mage/Rule/Model/Action/Interface.php
+++ b/app/code/core/Mage/Rule/Model/Action/Interface.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Rule

--- a/app/code/core/Mage/Rule/Model/Condition/Abstract.php
+++ b/app/code/core/Mage/Rule/Model/Condition/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Rule/Model/Condition/Abstract.php
+++ b/app/code/core/Mage/Rule/Model/Condition/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Rule

--- a/app/code/core/Mage/Rule/Model/Condition/Abstract.php
+++ b/app/code/core/Mage/Rule/Model/Condition/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Rule

--- a/app/code/core/Mage/Rule/Model/Condition/Combine.php
+++ b/app/code/core/Mage/Rule/Model/Condition/Combine.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Rule/Model/Condition/Combine.php
+++ b/app/code/core/Mage/Rule/Model/Condition/Combine.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Rule

--- a/app/code/core/Mage/Rule/Model/Condition/Combine.php
+++ b/app/code/core/Mage/Rule/Model/Condition/Combine.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Rule

--- a/app/code/core/Mage/Rule/Model/Condition/Interface.php
+++ b/app/code/core/Mage/Rule/Model/Condition/Interface.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Rule/Model/Condition/Interface.php
+++ b/app/code/core/Mage/Rule/Model/Condition/Interface.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Rule

--- a/app/code/core/Mage/Rule/Model/Condition/Interface.php
+++ b/app/code/core/Mage/Rule/Model/Condition/Interface.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Rule

--- a/app/code/core/Mage/Rule/Model/Condition/Product/Abstract.php
+++ b/app/code/core/Mage/Rule/Model/Condition/Product/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Rule/Model/Condition/Product/Abstract.php
+++ b/app/code/core/Mage/Rule/Model/Condition/Product/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Rule

--- a/app/code/core/Mage/Rule/Model/Condition/Product/Abstract.php
+++ b/app/code/core/Mage/Rule/Model/Condition/Product/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Rule

--- a/app/code/core/Mage/Rule/Model/Environment.php
+++ b/app/code/core/Mage/Rule/Model/Environment.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Rule/Model/Environment.php
+++ b/app/code/core/Mage/Rule/Model/Environment.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Rule

--- a/app/code/core/Mage/Rule/Model/Environment.php
+++ b/app/code/core/Mage/Rule/Model/Environment.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Rule

--- a/app/code/core/Mage/Rule/Model/Mysql4/Rule.php
+++ b/app/code/core/Mage/Rule/Model/Mysql4/Rule.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Rule/Model/Mysql4/Rule.php
+++ b/app/code/core/Mage/Rule/Model/Mysql4/Rule.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Rule

--- a/app/code/core/Mage/Rule/Model/Mysql4/Rule.php
+++ b/app/code/core/Mage/Rule/Model/Mysql4/Rule.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Rule

--- a/app/code/core/Mage/Rule/Model/Mysql4/Rule/Collection.php
+++ b/app/code/core/Mage/Rule/Model/Mysql4/Rule/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Rule/Model/Mysql4/Rule/Collection.php
+++ b/app/code/core/Mage/Rule/Model/Mysql4/Rule/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Rule

--- a/app/code/core/Mage/Rule/Model/Mysql4/Rule/Collection.php
+++ b/app/code/core/Mage/Rule/Model/Mysql4/Rule/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Rule

--- a/app/code/core/Mage/Rule/Model/Renderer/Actions.php
+++ b/app/code/core/Mage/Rule/Model/Renderer/Actions.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Rule/Model/Renderer/Actions.php
+++ b/app/code/core/Mage/Rule/Model/Renderer/Actions.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Rule

--- a/app/code/core/Mage/Rule/Model/Renderer/Actions.php
+++ b/app/code/core/Mage/Rule/Model/Renderer/Actions.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Rule

--- a/app/code/core/Mage/Rule/Model/Renderer/Conditions.php
+++ b/app/code/core/Mage/Rule/Model/Renderer/Conditions.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Rule/Model/Renderer/Conditions.php
+++ b/app/code/core/Mage/Rule/Model/Renderer/Conditions.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Rule

--- a/app/code/core/Mage/Rule/Model/Renderer/Conditions.php
+++ b/app/code/core/Mage/Rule/Model/Renderer/Conditions.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Rule

--- a/app/code/core/Mage/Rule/Model/Resource/Abstract.php
+++ b/app/code/core/Mage/Rule/Model/Resource/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Rule/Model/Resource/Abstract.php
+++ b/app/code/core/Mage/Rule/Model/Resource/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Rule

--- a/app/code/core/Mage/Rule/Model/Resource/Abstract.php
+++ b/app/code/core/Mage/Rule/Model/Resource/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Rule

--- a/app/code/core/Mage/Rule/Model/Resource/Rule.php
+++ b/app/code/core/Mage/Rule/Model/Resource/Rule.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Rule/Model/Resource/Rule.php
+++ b/app/code/core/Mage/Rule/Model/Resource/Rule.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Rule

--- a/app/code/core/Mage/Rule/Model/Resource/Rule.php
+++ b/app/code/core/Mage/Rule/Model/Resource/Rule.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Rule

--- a/app/code/core/Mage/Rule/Model/Resource/Rule/Collection.php
+++ b/app/code/core/Mage/Rule/Model/Resource/Rule/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Rule/Model/Resource/Rule/Collection.php
+++ b/app/code/core/Mage/Rule/Model/Resource/Rule/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Rule

--- a/app/code/core/Mage/Rule/Model/Resource/Rule/Collection.php
+++ b/app/code/core/Mage/Rule/Model/Resource/Rule/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Rule

--- a/app/code/core/Mage/Rule/Model/Resource/Rule/Collection/Abstract.php
+++ b/app/code/core/Mage/Rule/Model/Resource/Rule/Collection/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Rule/Model/Resource/Rule/Collection/Abstract.php
+++ b/app/code/core/Mage/Rule/Model/Resource/Rule/Collection/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Rule

--- a/app/code/core/Mage/Rule/Model/Resource/Rule/Collection/Abstract.php
+++ b/app/code/core/Mage/Rule/Model/Resource/Rule/Collection/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Rule

--- a/app/code/core/Mage/Rule/Model/Resource/Rule/Condition/SqlBuilder.php
+++ b/app/code/core/Mage/Rule/Model/Resource/Rule/Condition/SqlBuilder.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Rule/Model/Resource/Rule/Condition/SqlBuilder.php
+++ b/app/code/core/Mage/Rule/Model/Resource/Rule/Condition/SqlBuilder.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Rule

--- a/app/code/core/Mage/Rule/Model/Resource/Rule/Condition/SqlBuilder.php
+++ b/app/code/core/Mage/Rule/Model/Resource/Rule/Condition/SqlBuilder.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Rule

--- a/app/code/core/Mage/Rule/Model/Rule.php
+++ b/app/code/core/Mage/Rule/Model/Rule.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Rule/Model/Rule.php
+++ b/app/code/core/Mage/Rule/Model/Rule.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Rule

--- a/app/code/core/Mage/Rule/Model/Rule.php
+++ b/app/code/core/Mage/Rule/Model/Rule.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Rule

--- a/app/code/core/Mage/Rule/etc/config.xml
+++ b/app/code/core/Mage/Rule/etc/config.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Rule

--- a/app/code/core/Mage/Rule/etc/config.xml
+++ b/app/code/core/Mage/Rule/etc/config.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Rule

--- a/app/code/core/Mage/Rule/etc/config.xml
+++ b/app/code/core/Mage/Rule/etc/config.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Block/Adminhtml/Billing/Agreement.php
+++ b/app/code/core/Mage/Sales/Block/Adminhtml/Billing/Agreement.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Block/Adminhtml/Billing/Agreement.php
+++ b/app/code/core/Mage/Sales/Block/Adminhtml/Billing/Agreement.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Adminhtml/Billing/Agreement.php
+++ b/app/code/core/Mage/Sales/Block/Adminhtml/Billing/Agreement.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Adminhtml/Billing/Agreement/Grid.php
+++ b/app/code/core/Mage/Sales/Block/Adminhtml/Billing/Agreement/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Block/Adminhtml/Billing/Agreement/Grid.php
+++ b/app/code/core/Mage/Sales/Block/Adminhtml/Billing/Agreement/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Adminhtml/Billing/Agreement/Grid.php
+++ b/app/code/core/Mage/Sales/Block/Adminhtml/Billing/Agreement/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Adminhtml/Billing/Agreement/View.php
+++ b/app/code/core/Mage/Sales/Block/Adminhtml/Billing/Agreement/View.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Block/Adminhtml/Billing/Agreement/View.php
+++ b/app/code/core/Mage/Sales/Block/Adminhtml/Billing/Agreement/View.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Adminhtml/Billing/Agreement/View.php
+++ b/app/code/core/Mage/Sales/Block/Adminhtml/Billing/Agreement/View.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Adminhtml/Billing/Agreement/View/Form.php
+++ b/app/code/core/Mage/Sales/Block/Adminhtml/Billing/Agreement/View/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Block/Adminhtml/Billing/Agreement/View/Form.php
+++ b/app/code/core/Mage/Sales/Block/Adminhtml/Billing/Agreement/View/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Adminhtml/Billing/Agreement/View/Form.php
+++ b/app/code/core/Mage/Sales/Block/Adminhtml/Billing/Agreement/View/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Adminhtml/Billing/Agreement/View/Tab/Info.php
+++ b/app/code/core/Mage/Sales/Block/Adminhtml/Billing/Agreement/View/Tab/Info.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Block/Adminhtml/Billing/Agreement/View/Tab/Info.php
+++ b/app/code/core/Mage/Sales/Block/Adminhtml/Billing/Agreement/View/Tab/Info.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Adminhtml/Billing/Agreement/View/Tab/Info.php
+++ b/app/code/core/Mage/Sales/Block/Adminhtml/Billing/Agreement/View/Tab/Info.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Adminhtml/Billing/Agreement/View/Tab/Orders.php
+++ b/app/code/core/Mage/Sales/Block/Adminhtml/Billing/Agreement/View/Tab/Orders.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Block/Adminhtml/Billing/Agreement/View/Tab/Orders.php
+++ b/app/code/core/Mage/Sales/Block/Adminhtml/Billing/Agreement/View/Tab/Orders.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Adminhtml/Billing/Agreement/View/Tab/Orders.php
+++ b/app/code/core/Mage/Sales/Block/Adminhtml/Billing/Agreement/View/Tab/Orders.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Adminhtml/Billing/Agreement/View/Tabs.php
+++ b/app/code/core/Mage/Sales/Block/Adminhtml/Billing/Agreement/View/Tabs.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Block/Adminhtml/Billing/Agreement/View/Tabs.php
+++ b/app/code/core/Mage/Sales/Block/Adminhtml/Billing/Agreement/View/Tabs.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Adminhtml/Billing/Agreement/View/Tabs.php
+++ b/app/code/core/Mage/Sales/Block/Adminhtml/Billing/Agreement/View/Tabs.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Adminhtml/Customer/Edit/Tab/Agreement.php
+++ b/app/code/core/Mage/Sales/Block/Adminhtml/Customer/Edit/Tab/Agreement.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Block/Adminhtml/Customer/Edit/Tab/Agreement.php
+++ b/app/code/core/Mage/Sales/Block/Adminhtml/Customer/Edit/Tab/Agreement.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Adminhtml/Customer/Edit/Tab/Agreement.php
+++ b/app/code/core/Mage/Sales/Block/Adminhtml/Customer/Edit/Tab/Agreement.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Adminhtml/Customer/Edit/Tab/Recurring/Profile.php
+++ b/app/code/core/Mage/Sales/Block/Adminhtml/Customer/Edit/Tab/Recurring/Profile.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Block/Adminhtml/Customer/Edit/Tab/Recurring/Profile.php
+++ b/app/code/core/Mage/Sales/Block/Adminhtml/Customer/Edit/Tab/Recurring/Profile.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Adminhtml/Customer/Edit/Tab/Recurring/Profile.php
+++ b/app/code/core/Mage/Sales/Block/Adminhtml/Customer/Edit/Tab/Recurring/Profile.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Adminhtml/Recurring/Profile.php
+++ b/app/code/core/Mage/Sales/Block/Adminhtml/Recurring/Profile.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Block/Adminhtml/Recurring/Profile.php
+++ b/app/code/core/Mage/Sales/Block/Adminhtml/Recurring/Profile.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Adminhtml/Recurring/Profile.php
+++ b/app/code/core/Mage/Sales/Block/Adminhtml/Recurring/Profile.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Adminhtml/Recurring/Profile/Edit/Form.php
+++ b/app/code/core/Mage/Sales/Block/Adminhtml/Recurring/Profile/Edit/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Block/Adminhtml/Recurring/Profile/Edit/Form.php
+++ b/app/code/core/Mage/Sales/Block/Adminhtml/Recurring/Profile/Edit/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Adminhtml/Recurring/Profile/Edit/Form.php
+++ b/app/code/core/Mage/Sales/Block/Adminhtml/Recurring/Profile/Edit/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Adminhtml/Recurring/Profile/Grid.php
+++ b/app/code/core/Mage/Sales/Block/Adminhtml/Recurring/Profile/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Block/Adminhtml/Recurring/Profile/Grid.php
+++ b/app/code/core/Mage/Sales/Block/Adminhtml/Recurring/Profile/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Adminhtml/Recurring/Profile/Grid.php
+++ b/app/code/core/Mage/Sales/Block/Adminhtml/Recurring/Profile/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Adminhtml/Recurring/Profile/View.php
+++ b/app/code/core/Mage/Sales/Block/Adminhtml/Recurring/Profile/View.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Block/Adminhtml/Recurring/Profile/View.php
+++ b/app/code/core/Mage/Sales/Block/Adminhtml/Recurring/Profile/View.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Adminhtml/Recurring/Profile/View.php
+++ b/app/code/core/Mage/Sales/Block/Adminhtml/Recurring/Profile/View.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Adminhtml/Recurring/Profile/View/Getawayinfo.php
+++ b/app/code/core/Mage/Sales/Block/Adminhtml/Recurring/Profile/View/Getawayinfo.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Block/Adminhtml/Recurring/Profile/View/Getawayinfo.php
+++ b/app/code/core/Mage/Sales/Block/Adminhtml/Recurring/Profile/View/Getawayinfo.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Adminhtml/Recurring/Profile/View/Getawayinfo.php
+++ b/app/code/core/Mage/Sales/Block/Adminhtml/Recurring/Profile/View/Getawayinfo.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Adminhtml/Recurring/Profile/View/Info.php
+++ b/app/code/core/Mage/Sales/Block/Adminhtml/Recurring/Profile/View/Info.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Block/Adminhtml/Recurring/Profile/View/Info.php
+++ b/app/code/core/Mage/Sales/Block/Adminhtml/Recurring/Profile/View/Info.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Adminhtml/Recurring/Profile/View/Info.php
+++ b/app/code/core/Mage/Sales/Block/Adminhtml/Recurring/Profile/View/Info.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Adminhtml/Recurring/Profile/View/Items.php
+++ b/app/code/core/Mage/Sales/Block/Adminhtml/Recurring/Profile/View/Items.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Block/Adminhtml/Recurring/Profile/View/Items.php
+++ b/app/code/core/Mage/Sales/Block/Adminhtml/Recurring/Profile/View/Items.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Adminhtml/Recurring/Profile/View/Items.php
+++ b/app/code/core/Mage/Sales/Block/Adminhtml/Recurring/Profile/View/Items.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Adminhtml/Recurring/Profile/View/Tab/Info.php
+++ b/app/code/core/Mage/Sales/Block/Adminhtml/Recurring/Profile/View/Tab/Info.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Block/Adminhtml/Recurring/Profile/View/Tab/Info.php
+++ b/app/code/core/Mage/Sales/Block/Adminhtml/Recurring/Profile/View/Tab/Info.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Adminhtml/Recurring/Profile/View/Tab/Info.php
+++ b/app/code/core/Mage/Sales/Block/Adminhtml/Recurring/Profile/View/Tab/Info.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Adminhtml/Recurring/Profile/View/Tab/Orders.php
+++ b/app/code/core/Mage/Sales/Block/Adminhtml/Recurring/Profile/View/Tab/Orders.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Block/Adminhtml/Recurring/Profile/View/Tab/Orders.php
+++ b/app/code/core/Mage/Sales/Block/Adminhtml/Recurring/Profile/View/Tab/Orders.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Adminhtml/Recurring/Profile/View/Tab/Orders.php
+++ b/app/code/core/Mage/Sales/Block/Adminhtml/Recurring/Profile/View/Tab/Orders.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Adminhtml/Report/Filter/Form.php
+++ b/app/code/core/Mage/Sales/Block/Adminhtml/Report/Filter/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Block/Adminhtml/Report/Filter/Form.php
+++ b/app/code/core/Mage/Sales/Block/Adminhtml/Report/Filter/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Adminhtml/Report/Filter/Form.php
+++ b/app/code/core/Mage/Sales/Block/Adminhtml/Report/Filter/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Adminhtml/Report/Filter/Form/Coupon.php
+++ b/app/code/core/Mage/Sales/Block/Adminhtml/Report/Filter/Form/Coupon.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Block/Adminhtml/Report/Filter/Form/Coupon.php
+++ b/app/code/core/Mage/Sales/Block/Adminhtml/Report/Filter/Form/Coupon.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Adminhtml/Report/Filter/Form/Coupon.php
+++ b/app/code/core/Mage/Sales/Block/Adminhtml/Report/Filter/Form/Coupon.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Adminhtml/Report/Filter/Form/Order.php
+++ b/app/code/core/Mage/Sales/Block/Adminhtml/Report/Filter/Form/Order.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Block/Adminhtml/Report/Filter/Form/Order.php
+++ b/app/code/core/Mage/Sales/Block/Adminhtml/Report/Filter/Form/Order.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Adminhtml/Report/Filter/Form/Order.php
+++ b/app/code/core/Mage/Sales/Block/Adminhtml/Report/Filter/Form/Order.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Billing/Agreement/View.php
+++ b/app/code/core/Mage/Sales/Block/Billing/Agreement/View.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Block/Billing/Agreement/View.php
+++ b/app/code/core/Mage/Sales/Block/Billing/Agreement/View.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Billing/Agreement/View.php
+++ b/app/code/core/Mage/Sales/Block/Billing/Agreement/View.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Billing/Agreements.php
+++ b/app/code/core/Mage/Sales/Block/Billing/Agreements.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Block/Billing/Agreements.php
+++ b/app/code/core/Mage/Sales/Block/Billing/Agreements.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Billing/Agreements.php
+++ b/app/code/core/Mage/Sales/Block/Billing/Agreements.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Guest/Links.php
+++ b/app/code/core/Mage/Sales/Block/Guest/Links.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Block/Guest/Links.php
+++ b/app/code/core/Mage/Sales/Block/Guest/Links.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Guest/Links.php
+++ b/app/code/core/Mage/Sales/Block/Guest/Links.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Items/Abstract.php
+++ b/app/code/core/Mage/Sales/Block/Items/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Block/Items/Abstract.php
+++ b/app/code/core/Mage/Sales/Block/Items/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Items/Abstract.php
+++ b/app/code/core/Mage/Sales/Block/Items/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Order/Comments.php
+++ b/app/code/core/Mage/Sales/Block/Order/Comments.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Block/Order/Comments.php
+++ b/app/code/core/Mage/Sales/Block/Order/Comments.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Order/Comments.php
+++ b/app/code/core/Mage/Sales/Block/Order/Comments.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Order/Creditmemo.php
+++ b/app/code/core/Mage/Sales/Block/Order/Creditmemo.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Block/Order/Creditmemo.php
+++ b/app/code/core/Mage/Sales/Block/Order/Creditmemo.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Order/Creditmemo.php
+++ b/app/code/core/Mage/Sales/Block/Order/Creditmemo.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Order/Creditmemo/Items.php
+++ b/app/code/core/Mage/Sales/Block/Order/Creditmemo/Items.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Block/Order/Creditmemo/Items.php
+++ b/app/code/core/Mage/Sales/Block/Order/Creditmemo/Items.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Order/Creditmemo/Items.php
+++ b/app/code/core/Mage/Sales/Block/Order/Creditmemo/Items.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Order/Creditmemo/Totals.php
+++ b/app/code/core/Mage/Sales/Block/Order/Creditmemo/Totals.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Block/Order/Creditmemo/Totals.php
+++ b/app/code/core/Mage/Sales/Block/Order/Creditmemo/Totals.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Order/Creditmemo/Totals.php
+++ b/app/code/core/Mage/Sales/Block/Order/Creditmemo/Totals.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Order/Details.php
+++ b/app/code/core/Mage/Sales/Block/Order/Details.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Block/Order/Details.php
+++ b/app/code/core/Mage/Sales/Block/Order/Details.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Order/Details.php
+++ b/app/code/core/Mage/Sales/Block/Order/Details.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Order/Email/Creditmemo/Items.php
+++ b/app/code/core/Mage/Sales/Block/Order/Email/Creditmemo/Items.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Block/Order/Email/Creditmemo/Items.php
+++ b/app/code/core/Mage/Sales/Block/Order/Email/Creditmemo/Items.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Order/Email/Creditmemo/Items.php
+++ b/app/code/core/Mage/Sales/Block/Order/Email/Creditmemo/Items.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Order/Email/Invoice/Items.php
+++ b/app/code/core/Mage/Sales/Block/Order/Email/Invoice/Items.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Block/Order/Email/Invoice/Items.php
+++ b/app/code/core/Mage/Sales/Block/Order/Email/Invoice/Items.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Order/Email/Invoice/Items.php
+++ b/app/code/core/Mage/Sales/Block/Order/Email/Invoice/Items.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Order/Email/Items.php
+++ b/app/code/core/Mage/Sales/Block/Order/Email/Items.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Block/Order/Email/Items.php
+++ b/app/code/core/Mage/Sales/Block/Order/Email/Items.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Order/Email/Items.php
+++ b/app/code/core/Mage/Sales/Block/Order/Email/Items.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Order/Email/Items/Default.php
+++ b/app/code/core/Mage/Sales/Block/Order/Email/Items/Default.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Block/Order/Email/Items/Default.php
+++ b/app/code/core/Mage/Sales/Block/Order/Email/Items/Default.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Order/Email/Items/Default.php
+++ b/app/code/core/Mage/Sales/Block/Order/Email/Items/Default.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Order/Email/Items/Order/Default.php
+++ b/app/code/core/Mage/Sales/Block/Order/Email/Items/Order/Default.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Block/Order/Email/Items/Order/Default.php
+++ b/app/code/core/Mage/Sales/Block/Order/Email/Items/Order/Default.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Order/Email/Items/Order/Default.php
+++ b/app/code/core/Mage/Sales/Block/Order/Email/Items/Order/Default.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Order/Email/Items/Order/Grouped.php
+++ b/app/code/core/Mage/Sales/Block/Order/Email/Items/Order/Grouped.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Block/Order/Email/Items/Order/Grouped.php
+++ b/app/code/core/Mage/Sales/Block/Order/Email/Items/Order/Grouped.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Order/Email/Items/Order/Grouped.php
+++ b/app/code/core/Mage/Sales/Block/Order/Email/Items/Order/Grouped.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Order/Email/Shipment/Items.php
+++ b/app/code/core/Mage/Sales/Block/Order/Email/Shipment/Items.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Block/Order/Email/Shipment/Items.php
+++ b/app/code/core/Mage/Sales/Block/Order/Email/Shipment/Items.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Order/Email/Shipment/Items.php
+++ b/app/code/core/Mage/Sales/Block/Order/Email/Shipment/Items.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Order/History.php
+++ b/app/code/core/Mage/Sales/Block/Order/History.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Block/Order/History.php
+++ b/app/code/core/Mage/Sales/Block/Order/History.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Order/History.php
+++ b/app/code/core/Mage/Sales/Block/Order/History.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Order/Info.php
+++ b/app/code/core/Mage/Sales/Block/Order/Info.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Block/Order/Info.php
+++ b/app/code/core/Mage/Sales/Block/Order/Info.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Order/Info.php
+++ b/app/code/core/Mage/Sales/Block/Order/Info.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Order/Info/Buttons.php
+++ b/app/code/core/Mage/Sales/Block/Order/Info/Buttons.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Block/Order/Info/Buttons.php
+++ b/app/code/core/Mage/Sales/Block/Order/Info/Buttons.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Order/Info/Buttons.php
+++ b/app/code/core/Mage/Sales/Block/Order/Info/Buttons.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Order/Invoice.php
+++ b/app/code/core/Mage/Sales/Block/Order/Invoice.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Block/Order/Invoice.php
+++ b/app/code/core/Mage/Sales/Block/Order/Invoice.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Order/Invoice.php
+++ b/app/code/core/Mage/Sales/Block/Order/Invoice.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Order/Invoice/Items.php
+++ b/app/code/core/Mage/Sales/Block/Order/Invoice/Items.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Block/Order/Invoice/Items.php
+++ b/app/code/core/Mage/Sales/Block/Order/Invoice/Items.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Order/Invoice/Items.php
+++ b/app/code/core/Mage/Sales/Block/Order/Invoice/Items.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Order/Invoice/Totals.php
+++ b/app/code/core/Mage/Sales/Block/Order/Invoice/Totals.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Block/Order/Invoice/Totals.php
+++ b/app/code/core/Mage/Sales/Block/Order/Invoice/Totals.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Order/Invoice/Totals.php
+++ b/app/code/core/Mage/Sales/Block/Order/Invoice/Totals.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Order/Item/Renderer/Default.php
+++ b/app/code/core/Mage/Sales/Block/Order/Item/Renderer/Default.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Block/Order/Item/Renderer/Default.php
+++ b/app/code/core/Mage/Sales/Block/Order/Item/Renderer/Default.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Order/Item/Renderer/Default.php
+++ b/app/code/core/Mage/Sales/Block/Order/Item/Renderer/Default.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Order/Item/Renderer/Grouped.php
+++ b/app/code/core/Mage/Sales/Block/Order/Item/Renderer/Grouped.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Block/Order/Item/Renderer/Grouped.php
+++ b/app/code/core/Mage/Sales/Block/Order/Item/Renderer/Grouped.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Order/Item/Renderer/Grouped.php
+++ b/app/code/core/Mage/Sales/Block/Order/Item/Renderer/Grouped.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Order/Items.php
+++ b/app/code/core/Mage/Sales/Block/Order/Items.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Block/Order/Items.php
+++ b/app/code/core/Mage/Sales/Block/Order/Items.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Order/Items.php
+++ b/app/code/core/Mage/Sales/Block/Order/Items.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Order/Print.php
+++ b/app/code/core/Mage/Sales/Block/Order/Print.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Block/Order/Print.php
+++ b/app/code/core/Mage/Sales/Block/Order/Print.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Order/Print.php
+++ b/app/code/core/Mage/Sales/Block/Order/Print.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Order/Print/Creditmemo.php
+++ b/app/code/core/Mage/Sales/Block/Order/Print/Creditmemo.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Block/Order/Print/Creditmemo.php
+++ b/app/code/core/Mage/Sales/Block/Order/Print/Creditmemo.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Order/Print/Creditmemo.php
+++ b/app/code/core/Mage/Sales/Block/Order/Print/Creditmemo.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Order/Print/Invoice.php
+++ b/app/code/core/Mage/Sales/Block/Order/Print/Invoice.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Block/Order/Print/Invoice.php
+++ b/app/code/core/Mage/Sales/Block/Order/Print/Invoice.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Order/Print/Invoice.php
+++ b/app/code/core/Mage/Sales/Block/Order/Print/Invoice.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Order/Print/Shipment.php
+++ b/app/code/core/Mage/Sales/Block/Order/Print/Shipment.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Block/Order/Print/Shipment.php
+++ b/app/code/core/Mage/Sales/Block/Order/Print/Shipment.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Order/Print/Shipment.php
+++ b/app/code/core/Mage/Sales/Block/Order/Print/Shipment.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Order/Recent.php
+++ b/app/code/core/Mage/Sales/Block/Order/Recent.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Block/Order/Recent.php
+++ b/app/code/core/Mage/Sales/Block/Order/Recent.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Order/Recent.php
+++ b/app/code/core/Mage/Sales/Block/Order/Recent.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Order/Shipment.php
+++ b/app/code/core/Mage/Sales/Block/Order/Shipment.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Block/Order/Shipment.php
+++ b/app/code/core/Mage/Sales/Block/Order/Shipment.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Order/Shipment.php
+++ b/app/code/core/Mage/Sales/Block/Order/Shipment.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Order/Shipment/Items.php
+++ b/app/code/core/Mage/Sales/Block/Order/Shipment/Items.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Block/Order/Shipment/Items.php
+++ b/app/code/core/Mage/Sales/Block/Order/Shipment/Items.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Order/Shipment/Items.php
+++ b/app/code/core/Mage/Sales/Block/Order/Shipment/Items.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Order/Tax.php
+++ b/app/code/core/Mage/Sales/Block/Order/Tax.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Block/Order/Tax.php
+++ b/app/code/core/Mage/Sales/Block/Order/Tax.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Order/Tax.php
+++ b/app/code/core/Mage/Sales/Block/Order/Tax.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Order/Totals.php
+++ b/app/code/core/Mage/Sales/Block/Order/Totals.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Block/Order/Totals.php
+++ b/app/code/core/Mage/Sales/Block/Order/Totals.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Order/Totals.php
+++ b/app/code/core/Mage/Sales/Block/Order/Totals.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Order/View.php
+++ b/app/code/core/Mage/Sales/Block/Order/View.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Block/Order/View.php
+++ b/app/code/core/Mage/Sales/Block/Order/View.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Order/View.php
+++ b/app/code/core/Mage/Sales/Block/Order/View.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Payment/Form/Billing/Agreement.php
+++ b/app/code/core/Mage/Sales/Block/Payment/Form/Billing/Agreement.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Block/Payment/Form/Billing/Agreement.php
+++ b/app/code/core/Mage/Sales/Block/Payment/Form/Billing/Agreement.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Payment/Form/Billing/Agreement.php
+++ b/app/code/core/Mage/Sales/Block/Payment/Form/Billing/Agreement.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Payment/Info/Billing/Agreement.php
+++ b/app/code/core/Mage/Sales/Block/Payment/Info/Billing/Agreement.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Block/Payment/Info/Billing/Agreement.php
+++ b/app/code/core/Mage/Sales/Block/Payment/Info/Billing/Agreement.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Payment/Info/Billing/Agreement.php
+++ b/app/code/core/Mage/Sales/Block/Payment/Info/Billing/Agreement.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Recurring/Profile/View.php
+++ b/app/code/core/Mage/Sales/Block/Recurring/Profile/View.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Block/Recurring/Profile/View.php
+++ b/app/code/core/Mage/Sales/Block/Recurring/Profile/View.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Recurring/Profile/View.php
+++ b/app/code/core/Mage/Sales/Block/Recurring/Profile/View.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Recurring/Profiles.php
+++ b/app/code/core/Mage/Sales/Block/Recurring/Profiles.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Block/Recurring/Profiles.php
+++ b/app/code/core/Mage/Sales/Block/Recurring/Profiles.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Recurring/Profiles.php
+++ b/app/code/core/Mage/Sales/Block/Recurring/Profiles.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Reorder/Sidebar.php
+++ b/app/code/core/Mage/Sales/Block/Reorder/Sidebar.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Block/Reorder/Sidebar.php
+++ b/app/code/core/Mage/Sales/Block/Reorder/Sidebar.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Reorder/Sidebar.php
+++ b/app/code/core/Mage/Sales/Block/Reorder/Sidebar.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Widget/Guest/Form.php
+++ b/app/code/core/Mage/Sales/Block/Widget/Guest/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Block/Widget/Guest/Form.php
+++ b/app/code/core/Mage/Sales/Block/Widget/Guest/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Block/Widget/Guest/Form.php
+++ b/app/code/core/Mage/Sales/Block/Widget/Guest/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Controller/Abstract.php
+++ b/app/code/core/Mage/Sales/Controller/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Controller/Abstract.php
+++ b/app/code/core/Mage/Sales/Controller/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Controller/Abstract.php
+++ b/app/code/core/Mage/Sales/Controller/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Exception.php
+++ b/app/code/core/Mage/Sales/Exception.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Exception.php
+++ b/app/code/core/Mage/Sales/Exception.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Exception.php
+++ b/app/code/core/Mage/Sales/Exception.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Helper/Data.php
+++ b/app/code/core/Mage/Sales/Helper/Data.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Helper/Data.php
+++ b/app/code/core/Mage/Sales/Helper/Data.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Helper/Data.php
+++ b/app/code/core/Mage/Sales/Helper/Data.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Helper/Guest.php
+++ b/app/code/core/Mage/Sales/Helper/Guest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Helper/Guest.php
+++ b/app/code/core/Mage/Sales/Helper/Guest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Helper/Guest.php
+++ b/app/code/core/Mage/Sales/Helper/Guest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Helper/Reorder.php
+++ b/app/code/core/Mage/Sales/Helper/Reorder.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Helper/Reorder.php
+++ b/app/code/core/Mage/Sales/Helper/Reorder.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Helper/Reorder.php
+++ b/app/code/core/Mage/Sales/Helper/Reorder.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Abstract.php
+++ b/app/code/core/Mage/Sales/Model/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Abstract.php
+++ b/app/code/core/Mage/Sales/Model/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Abstract.php
+++ b/app/code/core/Mage/Sales/Model/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Api/Resource.php
+++ b/app/code/core/Mage/Sales/Model/Api/Resource.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Api/Resource.php
+++ b/app/code/core/Mage/Sales/Model/Api/Resource.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Api/Resource.php
+++ b/app/code/core/Mage/Sales/Model/Api/Resource.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Api2/Order.php
+++ b/app/code/core/Mage/Sales/Model/Api2/Order.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Api2/Order.php
+++ b/app/code/core/Mage/Sales/Model/Api2/Order.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Api2/Order.php
+++ b/app/code/core/Mage/Sales/Model/Api2/Order.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Api2/Order/Address.php
+++ b/app/code/core/Mage/Sales/Model/Api2/Order/Address.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Api2/Order/Address.php
+++ b/app/code/core/Mage/Sales/Model/Api2/Order/Address.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Api2/Order/Address.php
+++ b/app/code/core/Mage/Sales/Model/Api2/Order/Address.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Api2/Order/Address/Rest.php
+++ b/app/code/core/Mage/Sales/Model/Api2/Order/Address/Rest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Api2/Order/Address/Rest.php
+++ b/app/code/core/Mage/Sales/Model/Api2/Order/Address/Rest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Api2/Order/Address/Rest.php
+++ b/app/code/core/Mage/Sales/Model/Api2/Order/Address/Rest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Api2/Order/Address/Rest/Admin/V1.php
+++ b/app/code/core/Mage/Sales/Model/Api2/Order/Address/Rest/Admin/V1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Api2/Order/Address/Rest/Admin/V1.php
+++ b/app/code/core/Mage/Sales/Model/Api2/Order/Address/Rest/Admin/V1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Api2/Order/Address/Rest/Admin/V1.php
+++ b/app/code/core/Mage/Sales/Model/Api2/Order/Address/Rest/Admin/V1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Api2/Order/Address/Rest/Customer/V1.php
+++ b/app/code/core/Mage/Sales/Model/Api2/Order/Address/Rest/Customer/V1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Api2/Order/Address/Rest/Customer/V1.php
+++ b/app/code/core/Mage/Sales/Model/Api2/Order/Address/Rest/Customer/V1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Api2/Order/Address/Rest/Customer/V1.php
+++ b/app/code/core/Mage/Sales/Model/Api2/Order/Address/Rest/Customer/V1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Api2/Order/Comment.php
+++ b/app/code/core/Mage/Sales/Model/Api2/Order/Comment.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Api2/Order/Comment.php
+++ b/app/code/core/Mage/Sales/Model/Api2/Order/Comment.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Api2/Order/Comment.php
+++ b/app/code/core/Mage/Sales/Model/Api2/Order/Comment.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Api2/Order/Comment/Rest.php
+++ b/app/code/core/Mage/Sales/Model/Api2/Order/Comment/Rest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Api2/Order/Comment/Rest.php
+++ b/app/code/core/Mage/Sales/Model/Api2/Order/Comment/Rest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Api2/Order/Comment/Rest.php
+++ b/app/code/core/Mage/Sales/Model/Api2/Order/Comment/Rest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Api2/Order/Comment/Rest/Admin/V1.php
+++ b/app/code/core/Mage/Sales/Model/Api2/Order/Comment/Rest/Admin/V1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Api2/Order/Comment/Rest/Admin/V1.php
+++ b/app/code/core/Mage/Sales/Model/Api2/Order/Comment/Rest/Admin/V1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Api2/Order/Comment/Rest/Admin/V1.php
+++ b/app/code/core/Mage/Sales/Model/Api2/Order/Comment/Rest/Admin/V1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Api2/Order/Comment/Rest/Customer/V1.php
+++ b/app/code/core/Mage/Sales/Model/Api2/Order/Comment/Rest/Customer/V1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Api2/Order/Comment/Rest/Customer/V1.php
+++ b/app/code/core/Mage/Sales/Model/Api2/Order/Comment/Rest/Customer/V1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Api2/Order/Comment/Rest/Customer/V1.php
+++ b/app/code/core/Mage/Sales/Model/Api2/Order/Comment/Rest/Customer/V1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Api2/Order/Item.php
+++ b/app/code/core/Mage/Sales/Model/Api2/Order/Item.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Api2/Order/Item.php
+++ b/app/code/core/Mage/Sales/Model/Api2/Order/Item.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Api2/Order/Item.php
+++ b/app/code/core/Mage/Sales/Model/Api2/Order/Item.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Api2/Order/Item/Rest.php
+++ b/app/code/core/Mage/Sales/Model/Api2/Order/Item/Rest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Api2/Order/Item/Rest.php
+++ b/app/code/core/Mage/Sales/Model/Api2/Order/Item/Rest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Api2/Order/Item/Rest.php
+++ b/app/code/core/Mage/Sales/Model/Api2/Order/Item/Rest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Api2/Order/Item/Rest/Admin/V1.php
+++ b/app/code/core/Mage/Sales/Model/Api2/Order/Item/Rest/Admin/V1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Api2/Order/Item/Rest/Admin/V1.php
+++ b/app/code/core/Mage/Sales/Model/Api2/Order/Item/Rest/Admin/V1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Api2/Order/Item/Rest/Admin/V1.php
+++ b/app/code/core/Mage/Sales/Model/Api2/Order/Item/Rest/Admin/V1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Api2/Order/Item/Rest/Customer/V1.php
+++ b/app/code/core/Mage/Sales/Model/Api2/Order/Item/Rest/Customer/V1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Api2/Order/Item/Rest/Customer/V1.php
+++ b/app/code/core/Mage/Sales/Model/Api2/Order/Item/Rest/Customer/V1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Api2/Order/Item/Rest/Customer/V1.php
+++ b/app/code/core/Mage/Sales/Model/Api2/Order/Item/Rest/Customer/V1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Api2/Order/Rest.php
+++ b/app/code/core/Mage/Sales/Model/Api2/Order/Rest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Api2/Order/Rest.php
+++ b/app/code/core/Mage/Sales/Model/Api2/Order/Rest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Api2/Order/Rest.php
+++ b/app/code/core/Mage/Sales/Model/Api2/Order/Rest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Api2/Order/Rest/Admin/V1.php
+++ b/app/code/core/Mage/Sales/Model/Api2/Order/Rest/Admin/V1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Api2/Order/Rest/Admin/V1.php
+++ b/app/code/core/Mage/Sales/Model/Api2/Order/Rest/Admin/V1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Api2/Order/Rest/Admin/V1.php
+++ b/app/code/core/Mage/Sales/Model/Api2/Order/Rest/Admin/V1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Api2/Order/Rest/Customer/V1.php
+++ b/app/code/core/Mage/Sales/Model/Api2/Order/Rest/Customer/V1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Api2/Order/Rest/Customer/V1.php
+++ b/app/code/core/Mage/Sales/Model/Api2/Order/Rest/Customer/V1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Api2/Order/Rest/Customer/V1.php
+++ b/app/code/core/Mage/Sales/Model/Api2/Order/Rest/Customer/V1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Billing/Agreement.php
+++ b/app/code/core/Mage/Sales/Model/Billing/Agreement.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Billing/Agreement.php
+++ b/app/code/core/Mage/Sales/Model/Billing/Agreement.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Billing/Agreement.php
+++ b/app/code/core/Mage/Sales/Model/Billing/Agreement.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Config.php
+++ b/app/code/core/Mage/Sales/Model/Config.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Config.php
+++ b/app/code/core/Mage/Sales/Model/Config.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Config.php
+++ b/app/code/core/Mage/Sales/Model/Config.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Config/Ordered.php
+++ b/app/code/core/Mage/Sales/Model/Config/Ordered.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Config/Ordered.php
+++ b/app/code/core/Mage/Sales/Model/Config/Ordered.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Config/Ordered.php
+++ b/app/code/core/Mage/Sales/Model/Config/Ordered.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Convert/Order.php
+++ b/app/code/core/Mage/Sales/Model/Convert/Order.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Convert/Order.php
+++ b/app/code/core/Mage/Sales/Model/Convert/Order.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Convert/Order.php
+++ b/app/code/core/Mage/Sales/Model/Convert/Order.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Convert/Quote.php
+++ b/app/code/core/Mage/Sales/Model/Convert/Quote.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Convert/Quote.php
+++ b/app/code/core/Mage/Sales/Model/Convert/Quote.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Convert/Quote.php
+++ b/app/code/core/Mage/Sales/Model/Convert/Quote.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Email/Template.php
+++ b/app/code/core/Mage/Sales/Model/Email/Template.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Email/Template.php
+++ b/app/code/core/Mage/Sales/Model/Email/Template.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Email/Template.php
+++ b/app/code/core/Mage/Sales/Model/Email/Template.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Order.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Entity/Order.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Order.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Address.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Address.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Address.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Address.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Address.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Address.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Address/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Address/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Address/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Address/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Address/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Address/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Attribute/Backend/Billing.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Attribute/Backend/Billing.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Attribute/Backend/Billing.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Attribute/Backend/Billing.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Attribute/Backend/Billing.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Attribute/Backend/Billing.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Attribute/Backend/Child.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Attribute/Backend/Child.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Attribute/Backend/Child.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Attribute/Backend/Child.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Attribute/Backend/Child.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Attribute/Backend/Child.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Attribute/Backend/Parent.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Attribute/Backend/Parent.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Attribute/Backend/Parent.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Attribute/Backend/Parent.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Attribute/Backend/Parent.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Attribute/Backend/Parent.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Attribute/Backend/Shipping.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Attribute/Backend/Shipping.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Attribute/Backend/Shipping.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Attribute/Backend/Shipping.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Attribute/Backend/Shipping.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Attribute/Backend/Shipping.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Creditmemo.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Creditmemo.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Creditmemo.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Creditmemo.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Creditmemo.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Creditmemo.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Creditmemo/Attribute/Backend/Child.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Creditmemo/Attribute/Backend/Child.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Creditmemo/Attribute/Backend/Child.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Creditmemo/Attribute/Backend/Child.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Creditmemo/Attribute/Backend/Child.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Creditmemo/Attribute/Backend/Child.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Creditmemo/Attribute/Backend/Parent.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Creditmemo/Attribute/Backend/Parent.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Creditmemo/Attribute/Backend/Parent.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Creditmemo/Attribute/Backend/Parent.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Creditmemo/Attribute/Backend/Parent.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Creditmemo/Attribute/Backend/Parent.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Creditmemo/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Creditmemo/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Creditmemo/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Creditmemo/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Creditmemo/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Creditmemo/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Creditmemo/Comment.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Creditmemo/Comment.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Creditmemo/Comment.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Creditmemo/Comment.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Creditmemo/Comment.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Creditmemo/Comment.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Creditmemo/Comment/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Creditmemo/Comment/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Creditmemo/Comment/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Creditmemo/Comment/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Creditmemo/Comment/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Creditmemo/Comment/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Creditmemo/Item.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Creditmemo/Item.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Creditmemo/Item.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Creditmemo/Item.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Creditmemo/Item.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Creditmemo/Item.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Creditmemo/Item/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Creditmemo/Item/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Creditmemo/Item/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Creditmemo/Item/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Creditmemo/Item/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Creditmemo/Item/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Invoice.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Invoice.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Invoice.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Invoice.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Invoice.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Invoice.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Invoice/Attribute/Backend/Child.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Invoice/Attribute/Backend/Child.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Invoice/Attribute/Backend/Child.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Invoice/Attribute/Backend/Child.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Invoice/Attribute/Backend/Child.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Invoice/Attribute/Backend/Child.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Invoice/Attribute/Backend/Item.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Invoice/Attribute/Backend/Item.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Invoice/Attribute/Backend/Item.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Invoice/Attribute/Backend/Item.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Invoice/Attribute/Backend/Item.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Invoice/Attribute/Backend/Item.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Invoice/Attribute/Backend/Order.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Invoice/Attribute/Backend/Order.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Invoice/Attribute/Backend/Order.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Invoice/Attribute/Backend/Order.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Invoice/Attribute/Backend/Order.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Invoice/Attribute/Backend/Order.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Invoice/Attribute/Backend/Parent.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Invoice/Attribute/Backend/Parent.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Invoice/Attribute/Backend/Parent.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Invoice/Attribute/Backend/Parent.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Invoice/Attribute/Backend/Parent.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Invoice/Attribute/Backend/Parent.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Invoice/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Invoice/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Invoice/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Invoice/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Invoice/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Invoice/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Invoice/Comment.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Invoice/Comment.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Invoice/Comment.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Invoice/Comment.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Invoice/Comment.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Invoice/Comment.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Invoice/Comment/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Invoice/Comment/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Invoice/Comment/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Invoice/Comment/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Invoice/Comment/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Invoice/Comment/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Invoice/Item.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Invoice/Item.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Invoice/Item.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Invoice/Item.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Invoice/Item.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Invoice/Item.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Invoice/Item/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Invoice/Item/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Invoice/Item/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Invoice/Item/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Invoice/Item/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Invoice/Item/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Item.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Item.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Item.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Item.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Item.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Item.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Item/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Item/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Item/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Item/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Item/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Item/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Payment.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Payment.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Payment.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Payment.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Payment.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Payment.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Payment/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Payment/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Payment/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Payment/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Payment/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Payment/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Shipment.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Shipment.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Shipment.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Shipment.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Shipment.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Shipment.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Shipment/Attribute/Backend/Child.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Shipment/Attribute/Backend/Child.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Shipment/Attribute/Backend/Child.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Shipment/Attribute/Backend/Child.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Shipment/Attribute/Backend/Child.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Shipment/Attribute/Backend/Child.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Shipment/Attribute/Backend/Parent.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Shipment/Attribute/Backend/Parent.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Shipment/Attribute/Backend/Parent.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Shipment/Attribute/Backend/Parent.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Shipment/Attribute/Backend/Parent.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Shipment/Attribute/Backend/Parent.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Shipment/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Shipment/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Shipment/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Shipment/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Shipment/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Shipment/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Shipment/Comment.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Shipment/Comment.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Shipment/Comment.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Shipment/Comment.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Shipment/Comment.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Shipment/Comment.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Shipment/Comment/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Shipment/Comment/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Shipment/Comment/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Shipment/Comment/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Shipment/Comment/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Shipment/Comment/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Shipment/Item.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Shipment/Item.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Shipment/Item.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Shipment/Item.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Shipment/Item.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Shipment/Item.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Shipment/Item/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Shipment/Item/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Shipment/Item/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Shipment/Item/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Shipment/Item/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Shipment/Item/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Shipment/Track.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Shipment/Track.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Shipment/Track.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Shipment/Track.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Shipment/Track.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Shipment/Track.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Shipment/Track/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Shipment/Track/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Shipment/Track/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Shipment/Track/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Shipment/Track/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Shipment/Track/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Status/History.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Status/History.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Status/History.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Status/History.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Status/History.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Status/History.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Status/History/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Status/History/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Status/History/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Status/History/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Order/Status/History/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Order/Status/History/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Quote.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Quote.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Entity/Quote.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Quote.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Quote.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Quote.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Quote/Address.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Quote/Address.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Entity/Quote/Address.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Quote/Address.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Quote/Address.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Quote/Address.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Attribute/Backend.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Attribute/Backend.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Attribute/Backend.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Attribute/Backend.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Attribute/Backend.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Attribute/Backend.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Attribute/Backend/Child.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Attribute/Backend/Child.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Attribute/Backend/Child.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Attribute/Backend/Child.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Attribute/Backend/Child.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Attribute/Backend/Child.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Attribute/Backend/Parent.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Attribute/Backend/Parent.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Attribute/Backend/Parent.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Attribute/Backend/Parent.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Attribute/Backend/Parent.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Attribute/Backend/Parent.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Attribute/Backend/Region.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Attribute/Backend/Region.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Attribute/Backend/Region.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Attribute/Backend/Region.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Attribute/Backend/Region.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Attribute/Backend/Region.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Attribute/Frontend.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Attribute/Frontend.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Attribute/Frontend.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Attribute/Frontend.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Attribute/Frontend.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Attribute/Frontend.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Attribute/Frontend/Custbalance.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Attribute/Frontend/Custbalance.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Attribute/Frontend/Custbalance.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Attribute/Frontend/Custbalance.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Attribute/Frontend/Custbalance.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Attribute/Frontend/Custbalance.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Attribute/Frontend/Discount.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Attribute/Frontend/Discount.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Attribute/Frontend/Discount.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Attribute/Frontend/Discount.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Attribute/Frontend/Discount.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Attribute/Frontend/Discount.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Attribute/Frontend/Grand.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Attribute/Frontend/Grand.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Attribute/Frontend/Grand.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Attribute/Frontend/Grand.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Attribute/Frontend/Grand.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Attribute/Frontend/Grand.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Attribute/Frontend/Shipping.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Attribute/Frontend/Shipping.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Attribute/Frontend/Shipping.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Attribute/Frontend/Shipping.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Attribute/Frontend/Shipping.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Attribute/Frontend/Shipping.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Attribute/Frontend/Subtotal.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Attribute/Frontend/Subtotal.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Attribute/Frontend/Subtotal.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Attribute/Frontend/Subtotal.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Attribute/Frontend/Subtotal.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Attribute/Frontend/Subtotal.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Attribute/Frontend/Tax.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Attribute/Frontend/Tax.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Attribute/Frontend/Tax.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Attribute/Frontend/Tax.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Attribute/Frontend/Tax.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Attribute/Frontend/Tax.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Item.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Item.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Item.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Item.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Item.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Item.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Item/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Item/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Item/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Item/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Item/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Item/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Rate.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Rate.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Rate.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Rate.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Rate.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Rate.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Rate/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Rate/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Rate/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Rate/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Rate/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Quote/Address/Rate/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Quote/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Quote/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Entity/Quote/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Quote/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Quote/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Quote/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Quote/Item.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Quote/Item.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Entity/Quote/Item.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Quote/Item.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Quote/Item.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Quote/Item.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Quote/Item/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Quote/Item/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Entity/Quote/Item/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Quote/Item/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Quote/Item/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Quote/Item/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Quote/Payment.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Quote/Payment.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Entity/Quote/Payment.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Quote/Payment.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Quote/Payment.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Quote/Payment.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Quote/Payment/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Quote/Payment/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Entity/Quote/Payment/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Quote/Payment/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Quote/Payment/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Quote/Payment/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Sale/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Sale/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Entity/Sale/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Sale/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Sale/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Sale/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Setup.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Setup.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Entity/Setup.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Setup.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Entity/Setup.php
+++ b/app/code/core/Mage/Sales/Model/Entity/Setup.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Abstract.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Abstract.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Abstract.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Billing/Agreement.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Billing/Agreement.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Billing/Agreement.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Billing/Agreement.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Billing/Agreement.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Billing/Agreement.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Billing/Agreement/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Billing/Agreement/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Billing/Agreement/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Billing/Agreement/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Billing/Agreement/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Billing/Agreement/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Collection/Abstract.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Collection/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Collection/Abstract.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Collection/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Collection/Abstract.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Collection/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Abstract.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Abstract.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Abstract.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Address.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Address.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Address.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Address.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Address.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Address.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Address/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Address/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Address/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Address/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Address/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Address/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Attribute/Backend/Billing.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Attribute/Backend/Billing.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Attribute/Backend/Billing.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Attribute/Backend/Billing.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Attribute/Backend/Billing.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Attribute/Backend/Billing.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Attribute/Backend/Child.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Attribute/Backend/Child.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Attribute/Backend/Child.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Attribute/Backend/Child.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Attribute/Backend/Child.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Attribute/Backend/Child.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Attribute/Backend/Parent.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Attribute/Backend/Parent.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Attribute/Backend/Parent.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Attribute/Backend/Parent.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Attribute/Backend/Parent.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Attribute/Backend/Parent.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Attribute/Backend/Shipping.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Attribute/Backend/Shipping.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Attribute/Backend/Shipping.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Attribute/Backend/Shipping.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Attribute/Backend/Shipping.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Attribute/Backend/Shipping.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Collection/Abstract.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Collection/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Collection/Abstract.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Collection/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Collection/Abstract.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Collection/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Comment/Collection/Abstract.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Comment/Collection/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Comment/Collection/Abstract.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Comment/Collection/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Comment/Collection/Abstract.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Comment/Collection/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Creditmemo.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Creditmemo.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Creditmemo.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Creditmemo.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Creditmemo.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Creditmemo.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Creditmemo/Attribute/Backend/Child.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Creditmemo/Attribute/Backend/Child.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Creditmemo/Attribute/Backend/Child.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Creditmemo/Attribute/Backend/Child.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Creditmemo/Attribute/Backend/Child.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Creditmemo/Attribute/Backend/Child.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Creditmemo/Attribute/Backend/Parent.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Creditmemo/Attribute/Backend/Parent.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Creditmemo/Attribute/Backend/Parent.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Creditmemo/Attribute/Backend/Parent.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Creditmemo/Attribute/Backend/Parent.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Creditmemo/Attribute/Backend/Parent.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Creditmemo/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Creditmemo/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Creditmemo/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Creditmemo/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Creditmemo/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Creditmemo/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Creditmemo/Comment.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Creditmemo/Comment.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Creditmemo/Comment.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Creditmemo/Comment.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Creditmemo/Comment.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Creditmemo/Comment.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Creditmemo/Comment/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Creditmemo/Comment/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Creditmemo/Comment/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Creditmemo/Comment/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Creditmemo/Comment/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Creditmemo/Comment/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Creditmemo/Grid/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Creditmemo/Grid/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Creditmemo/Grid/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Creditmemo/Grid/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Creditmemo/Grid/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Creditmemo/Grid/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Creditmemo/Item.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Creditmemo/Item.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Creditmemo/Item.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Creditmemo/Item.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Creditmemo/Item.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Creditmemo/Item.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Creditmemo/Item/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Creditmemo/Item/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Creditmemo/Item/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Creditmemo/Item/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Creditmemo/Item/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Creditmemo/Item/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Grid/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Grid/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Grid/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Grid/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Grid/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Grid/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Invoice.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Invoice.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Invoice.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Invoice.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Invoice.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Invoice.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Invoice/Attribute/Backend/Child.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Invoice/Attribute/Backend/Child.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Invoice/Attribute/Backend/Child.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Invoice/Attribute/Backend/Child.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Invoice/Attribute/Backend/Child.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Invoice/Attribute/Backend/Child.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Invoice/Attribute/Backend/Item.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Invoice/Attribute/Backend/Item.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Invoice/Attribute/Backend/Item.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Invoice/Attribute/Backend/Item.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Invoice/Attribute/Backend/Item.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Invoice/Attribute/Backend/Item.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Invoice/Attribute/Backend/Order.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Invoice/Attribute/Backend/Order.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Invoice/Attribute/Backend/Order.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Invoice/Attribute/Backend/Order.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Invoice/Attribute/Backend/Order.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Invoice/Attribute/Backend/Order.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Invoice/Attribute/Backend/Parent.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Invoice/Attribute/Backend/Parent.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Invoice/Attribute/Backend/Parent.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Invoice/Attribute/Backend/Parent.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Invoice/Attribute/Backend/Parent.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Invoice/Attribute/Backend/Parent.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Invoice/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Invoice/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Invoice/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Invoice/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Invoice/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Invoice/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Invoice/Comment.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Invoice/Comment.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Invoice/Comment.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Invoice/Comment.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Invoice/Comment.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Invoice/Comment.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Invoice/Comment/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Invoice/Comment/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Invoice/Comment/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Invoice/Comment/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Invoice/Comment/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Invoice/Comment/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Invoice/Grid/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Invoice/Grid/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Invoice/Grid/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Invoice/Grid/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Invoice/Grid/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Invoice/Grid/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Invoice/Item.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Invoice/Item.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Invoice/Item.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Invoice/Item.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Invoice/Item.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Invoice/Item.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Invoice/Item/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Invoice/Item/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Invoice/Item/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Invoice/Item/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Invoice/Item/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Invoice/Item/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Item.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Item.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Item.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Item.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Item.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Item.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Item/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Item/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Item/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Item/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Item/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Item/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Payment.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Payment.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Payment.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Payment.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Payment.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Payment.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Payment/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Payment/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Payment/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Payment/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Payment/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Payment/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Payment/Transaction.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Payment/Transaction.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Payment/Transaction.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Payment/Transaction.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Payment/Transaction.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Payment/Transaction.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Payment/Transaction/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Payment/Transaction/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Payment/Transaction/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Payment/Transaction/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Payment/Transaction/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Payment/Transaction/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Shipment.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Shipment.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Shipment.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Shipment.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Shipment.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Shipment.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Shipment/Attribute/Backend/Child.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Shipment/Attribute/Backend/Child.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Shipment/Attribute/Backend/Child.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Shipment/Attribute/Backend/Child.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Shipment/Attribute/Backend/Child.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Shipment/Attribute/Backend/Child.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Shipment/Attribute/Backend/Parent.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Shipment/Attribute/Backend/Parent.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Shipment/Attribute/Backend/Parent.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Shipment/Attribute/Backend/Parent.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Shipment/Attribute/Backend/Parent.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Shipment/Attribute/Backend/Parent.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Shipment/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Shipment/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Shipment/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Shipment/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Shipment/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Shipment/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Shipment/Comment.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Shipment/Comment.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Shipment/Comment.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Shipment/Comment.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Shipment/Comment.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Shipment/Comment.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Shipment/Comment/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Shipment/Comment/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Shipment/Comment/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Shipment/Comment/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Shipment/Comment/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Shipment/Comment/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Shipment/Grid/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Shipment/Grid/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Shipment/Grid/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Shipment/Grid/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Shipment/Grid/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Shipment/Grid/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Shipment/Item.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Shipment/Item.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Shipment/Item.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Shipment/Item.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Shipment/Item.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Shipment/Item.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Shipment/Item/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Shipment/Item/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Shipment/Item/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Shipment/Item/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Shipment/Item/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Shipment/Item/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Shipment/Track.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Shipment/Track.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Shipment/Track.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Shipment/Track.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Shipment/Track.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Shipment/Track.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Shipment/Track/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Shipment/Track/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Shipment/Track/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Shipment/Track/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Shipment/Track/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Shipment/Track/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Status.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Status.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Status.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Status.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Status.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Status.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Status/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Status/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Status/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Status/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Status/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Status/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Status/History.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Status/History.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Status/History.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Status/History.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Status/History.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Status/History.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Status/History/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Status/History/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Status/History/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Status/History/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Status/History/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Status/History/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Tax.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Tax.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Tax.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Tax.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Tax.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Tax.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Tax/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Tax/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Tax/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Tax/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Order/Tax/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Order/Tax/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Quote.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Quote.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Quote.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Quote.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Quote.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Quote.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Attribute/Backend.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Attribute/Backend.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Attribute/Backend.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Attribute/Backend.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Attribute/Backend.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Attribute/Backend.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Attribute/Backend/Child.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Attribute/Backend/Child.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Attribute/Backend/Child.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Attribute/Backend/Child.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Attribute/Backend/Child.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Attribute/Backend/Child.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Attribute/Backend/Parent.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Attribute/Backend/Parent.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Attribute/Backend/Parent.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Attribute/Backend/Parent.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Attribute/Backend/Parent.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Attribute/Backend/Parent.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Attribute/Backend/Region.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Attribute/Backend/Region.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Attribute/Backend/Region.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Attribute/Backend/Region.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Attribute/Backend/Region.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Attribute/Backend/Region.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Attribute/Frontend.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Attribute/Frontend.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Attribute/Frontend.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Attribute/Frontend.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Attribute/Frontend.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Attribute/Frontend.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Attribute/Frontend/Custbalance.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Attribute/Frontend/Custbalance.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Attribute/Frontend/Custbalance.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Attribute/Frontend/Custbalance.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Attribute/Frontend/Custbalance.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Attribute/Frontend/Custbalance.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Attribute/Frontend/Discount.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Attribute/Frontend/Discount.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Attribute/Frontend/Discount.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Attribute/Frontend/Discount.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Attribute/Frontend/Discount.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Attribute/Frontend/Discount.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Attribute/Frontend/Grand.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Attribute/Frontend/Grand.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Attribute/Frontend/Grand.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Attribute/Frontend/Grand.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Attribute/Frontend/Grand.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Attribute/Frontend/Grand.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Attribute/Frontend/Shipping.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Attribute/Frontend/Shipping.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Attribute/Frontend/Shipping.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Attribute/Frontend/Shipping.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Attribute/Frontend/Shipping.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Attribute/Frontend/Shipping.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Attribute/Frontend/Subtotal.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Attribute/Frontend/Subtotal.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Attribute/Frontend/Subtotal.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Attribute/Frontend/Subtotal.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Attribute/Frontend/Subtotal.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Attribute/Frontend/Subtotal.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Attribute/Frontend/Tax.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Attribute/Frontend/Tax.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Attribute/Frontend/Tax.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Attribute/Frontend/Tax.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Attribute/Frontend/Tax.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Attribute/Frontend/Tax.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Item.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Item.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Item.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Item.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Item.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Item.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Item/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Item/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Item/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Item/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Item/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Item/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Rate.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Rate.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Rate.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Rate.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Rate.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Rate.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Rate/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Rate/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Rate/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Rate/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Rate/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Quote/Address/Rate/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Quote/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Quote/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Quote/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Quote/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Quote/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Quote/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Quote/Item.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Quote/Item.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Quote/Item.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Quote/Item.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Quote/Item.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Quote/Item.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Quote/Item/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Quote/Item/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Quote/Item/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Quote/Item/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Quote/Item/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Quote/Item/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Quote/Item/Option.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Quote/Item/Option.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Quote/Item/Option.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Quote/Item/Option.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Quote/Item/Option.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Quote/Item/Option.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Quote/Item/Option/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Quote/Item/Option/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Quote/Item/Option/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Quote/Item/Option/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Quote/Item/Option/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Quote/Item/Option/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Quote/Payment.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Quote/Payment.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Quote/Payment.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Quote/Payment.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Quote/Payment.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Quote/Payment.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Quote/Payment/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Quote/Payment/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Quote/Payment/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Quote/Payment/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Quote/Payment/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Quote/Payment/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Recurring/Profile.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Recurring/Profile.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Recurring/Profile.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Recurring/Profile.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Recurring/Profile.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Recurring/Profile.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Recurring/Profile/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Recurring/Profile/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Recurring/Profile/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Recurring/Profile/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Recurring/Profile/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Recurring/Profile/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Report.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Report.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Report.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Report.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Report.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Report.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Report/Abstract.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Report/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Report/Abstract.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Report/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Report/Abstract.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Report/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Report/Bestsellers.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Report/Bestsellers.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Report/Bestsellers.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Report/Bestsellers.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Report/Bestsellers.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Report/Bestsellers.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Report/Bestsellers/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Report/Bestsellers/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Report/Bestsellers/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Report/Bestsellers/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Report/Bestsellers/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Report/Bestsellers/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Report/Collection/Abstract.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Report/Collection/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Report/Collection/Abstract.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Report/Collection/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Report/Collection/Abstract.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Report/Collection/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Report/Invoiced.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Report/Invoiced.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Report/Invoiced.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Report/Invoiced.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Report/Invoiced.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Report/Invoiced.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Report/Invoiced/Collection/Invoiced.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Report/Invoiced/Collection/Invoiced.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Report/Invoiced/Collection/Invoiced.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Report/Invoiced/Collection/Invoiced.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Report/Invoiced/Collection/Invoiced.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Report/Invoiced/Collection/Invoiced.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Report/Invoiced/Collection/Order.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Report/Invoiced/Collection/Order.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Report/Invoiced/Collection/Order.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Report/Invoiced/Collection/Order.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Report/Invoiced/Collection/Order.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Report/Invoiced/Collection/Order.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Report/Order.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Report/Order.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Report/Order.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Report/Order.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Report/Order.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Report/Order.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Report/Order/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Report/Order/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Report/Order/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Report/Order/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Report/Order/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Report/Order/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Report/Order/Updatedat/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Report/Order/Updatedat/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Report/Order/Updatedat/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Report/Order/Updatedat/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Report/Order/Updatedat/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Report/Order/Updatedat/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Report/Refunded.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Report/Refunded.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Report/Refunded.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Report/Refunded.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Report/Refunded.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Report/Refunded.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Report/Refunded/Collection/Order.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Report/Refunded/Collection/Order.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Report/Refunded/Collection/Order.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Report/Refunded/Collection/Order.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Report/Refunded/Collection/Order.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Report/Refunded/Collection/Order.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Report/Refunded/Collection/Refunded.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Report/Refunded/Collection/Refunded.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Report/Refunded/Collection/Refunded.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Report/Refunded/Collection/Refunded.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Report/Refunded/Collection/Refunded.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Report/Refunded/Collection/Refunded.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Report/Shipping.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Report/Shipping.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Report/Shipping.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Report/Shipping.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Report/Shipping.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Report/Shipping.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Report/Shipping/Collection/Order.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Report/Shipping/Collection/Order.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Report/Shipping/Collection/Order.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Report/Shipping/Collection/Order.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Report/Shipping/Collection/Order.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Report/Shipping/Collection/Order.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Report/Shipping/Collection/Shipment.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Report/Shipping/Collection/Shipment.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Report/Shipping/Collection/Shipment.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Report/Shipping/Collection/Shipment.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Report/Shipping/Collection/Shipment.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Report/Shipping/Collection/Shipment.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Sale/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Sale/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Sale/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Sale/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Sale/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Sale/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Setup.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Setup.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Mysql4/Setup.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Setup.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Mysql4/Setup.php
+++ b/app/code/core/Mage/Sales/Model/Mysql4/Setup.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Observer.php
+++ b/app/code/core/Mage/Sales/Model/Observer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Observer.php
+++ b/app/code/core/Mage/Sales/Model/Observer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Observer.php
+++ b/app/code/core/Mage/Sales/Model/Observer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order.php
+++ b/app/code/core/Mage/Sales/Model/Order.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Order.php
+++ b/app/code/core/Mage/Sales/Model/Order.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order.php
+++ b/app/code/core/Mage/Sales/Model/Order.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Address.php
+++ b/app/code/core/Mage/Sales/Model/Order/Address.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Order/Address.php
+++ b/app/code/core/Mage/Sales/Model/Order/Address.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Address.php
+++ b/app/code/core/Mage/Sales/Model/Order/Address.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Api.php
+++ b/app/code/core/Mage/Sales/Model/Order/Api.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Order/Api.php
+++ b/app/code/core/Mage/Sales/Model/Order/Api.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Api.php
+++ b/app/code/core/Mage/Sales/Model/Order/Api.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Api/V2.php
+++ b/app/code/core/Mage/Sales/Model/Order/Api/V2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Order/Api/V2.php
+++ b/app/code/core/Mage/Sales/Model/Order/Api/V2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Api/V2.php
+++ b/app/code/core/Mage/Sales/Model/Order/Api/V2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Config.php
+++ b/app/code/core/Mage/Sales/Model/Order/Config.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Order/Config.php
+++ b/app/code/core/Mage/Sales/Model/Order/Config.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Config.php
+++ b/app/code/core/Mage/Sales/Model/Order/Config.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Creditmemo.php
+++ b/app/code/core/Mage/Sales/Model/Order/Creditmemo.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Order/Creditmemo.php
+++ b/app/code/core/Mage/Sales/Model/Order/Creditmemo.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Creditmemo.php
+++ b/app/code/core/Mage/Sales/Model/Order/Creditmemo.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Creditmemo/Api.php
+++ b/app/code/core/Mage/Sales/Model/Order/Creditmemo/Api.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Order/Creditmemo/Api.php
+++ b/app/code/core/Mage/Sales/Model/Order/Creditmemo/Api.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Creditmemo/Api.php
+++ b/app/code/core/Mage/Sales/Model/Order/Creditmemo/Api.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Creditmemo/Api/V2.php
+++ b/app/code/core/Mage/Sales/Model/Order/Creditmemo/Api/V2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Order/Creditmemo/Api/V2.php
+++ b/app/code/core/Mage/Sales/Model/Order/Creditmemo/Api/V2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Creditmemo/Api/V2.php
+++ b/app/code/core/Mage/Sales/Model/Order/Creditmemo/Api/V2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Creditmemo/Comment.php
+++ b/app/code/core/Mage/Sales/Model/Order/Creditmemo/Comment.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Order/Creditmemo/Comment.php
+++ b/app/code/core/Mage/Sales/Model/Order/Creditmemo/Comment.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Creditmemo/Comment.php
+++ b/app/code/core/Mage/Sales/Model/Order/Creditmemo/Comment.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Creditmemo/Config.php
+++ b/app/code/core/Mage/Sales/Model/Order/Creditmemo/Config.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Order/Creditmemo/Config.php
+++ b/app/code/core/Mage/Sales/Model/Order/Creditmemo/Config.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Creditmemo/Config.php
+++ b/app/code/core/Mage/Sales/Model/Order/Creditmemo/Config.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Creditmemo/Item.php
+++ b/app/code/core/Mage/Sales/Model/Order/Creditmemo/Item.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Order/Creditmemo/Item.php
+++ b/app/code/core/Mage/Sales/Model/Order/Creditmemo/Item.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Creditmemo/Item.php
+++ b/app/code/core/Mage/Sales/Model/Order/Creditmemo/Item.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Creditmemo/Total/Abstract.php
+++ b/app/code/core/Mage/Sales/Model/Order/Creditmemo/Total/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Order/Creditmemo/Total/Abstract.php
+++ b/app/code/core/Mage/Sales/Model/Order/Creditmemo/Total/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Creditmemo/Total/Abstract.php
+++ b/app/code/core/Mage/Sales/Model/Order/Creditmemo/Total/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Creditmemo/Total/Cost.php
+++ b/app/code/core/Mage/Sales/Model/Order/Creditmemo/Total/Cost.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Order/Creditmemo/Total/Cost.php
+++ b/app/code/core/Mage/Sales/Model/Order/Creditmemo/Total/Cost.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Creditmemo/Total/Cost.php
+++ b/app/code/core/Mage/Sales/Model/Order/Creditmemo/Total/Cost.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Creditmemo/Total/Discount.php
+++ b/app/code/core/Mage/Sales/Model/Order/Creditmemo/Total/Discount.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Order/Creditmemo/Total/Discount.php
+++ b/app/code/core/Mage/Sales/Model/Order/Creditmemo/Total/Discount.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Creditmemo/Total/Discount.php
+++ b/app/code/core/Mage/Sales/Model/Order/Creditmemo/Total/Discount.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Creditmemo/Total/Grand.php
+++ b/app/code/core/Mage/Sales/Model/Order/Creditmemo/Total/Grand.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Order/Creditmemo/Total/Grand.php
+++ b/app/code/core/Mage/Sales/Model/Order/Creditmemo/Total/Grand.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Creditmemo/Total/Grand.php
+++ b/app/code/core/Mage/Sales/Model/Order/Creditmemo/Total/Grand.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Creditmemo/Total/Shipping.php
+++ b/app/code/core/Mage/Sales/Model/Order/Creditmemo/Total/Shipping.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Order/Creditmemo/Total/Shipping.php
+++ b/app/code/core/Mage/Sales/Model/Order/Creditmemo/Total/Shipping.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Creditmemo/Total/Shipping.php
+++ b/app/code/core/Mage/Sales/Model/Order/Creditmemo/Total/Shipping.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Creditmemo/Total/Subtotal.php
+++ b/app/code/core/Mage/Sales/Model/Order/Creditmemo/Total/Subtotal.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Order/Creditmemo/Total/Subtotal.php
+++ b/app/code/core/Mage/Sales/Model/Order/Creditmemo/Total/Subtotal.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Creditmemo/Total/Subtotal.php
+++ b/app/code/core/Mage/Sales/Model/Order/Creditmemo/Total/Subtotal.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Creditmemo/Total/Tax.php
+++ b/app/code/core/Mage/Sales/Model/Order/Creditmemo/Total/Tax.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Order/Creditmemo/Total/Tax.php
+++ b/app/code/core/Mage/Sales/Model/Order/Creditmemo/Total/Tax.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Creditmemo/Total/Tax.php
+++ b/app/code/core/Mage/Sales/Model/Order/Creditmemo/Total/Tax.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Invoice.php
+++ b/app/code/core/Mage/Sales/Model/Order/Invoice.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Order/Invoice.php
+++ b/app/code/core/Mage/Sales/Model/Order/Invoice.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Invoice.php
+++ b/app/code/core/Mage/Sales/Model/Order/Invoice.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Invoice/Api.php
+++ b/app/code/core/Mage/Sales/Model/Order/Invoice/Api.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Order/Invoice/Api.php
+++ b/app/code/core/Mage/Sales/Model/Order/Invoice/Api.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Invoice/Api.php
+++ b/app/code/core/Mage/Sales/Model/Order/Invoice/Api.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Invoice/Api/V2.php
+++ b/app/code/core/Mage/Sales/Model/Order/Invoice/Api/V2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Order/Invoice/Api/V2.php
+++ b/app/code/core/Mage/Sales/Model/Order/Invoice/Api/V2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Invoice/Api/V2.php
+++ b/app/code/core/Mage/Sales/Model/Order/Invoice/Api/V2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Invoice/Comment.php
+++ b/app/code/core/Mage/Sales/Model/Order/Invoice/Comment.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Order/Invoice/Comment.php
+++ b/app/code/core/Mage/Sales/Model/Order/Invoice/Comment.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Invoice/Comment.php
+++ b/app/code/core/Mage/Sales/Model/Order/Invoice/Comment.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Invoice/Config.php
+++ b/app/code/core/Mage/Sales/Model/Order/Invoice/Config.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Order/Invoice/Config.php
+++ b/app/code/core/Mage/Sales/Model/Order/Invoice/Config.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Invoice/Config.php
+++ b/app/code/core/Mage/Sales/Model/Order/Invoice/Config.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Invoice/Item.php
+++ b/app/code/core/Mage/Sales/Model/Order/Invoice/Item.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Order/Invoice/Item.php
+++ b/app/code/core/Mage/Sales/Model/Order/Invoice/Item.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Invoice/Item.php
+++ b/app/code/core/Mage/Sales/Model/Order/Invoice/Item.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Invoice/Total/Abstract.php
+++ b/app/code/core/Mage/Sales/Model/Order/Invoice/Total/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Order/Invoice/Total/Abstract.php
+++ b/app/code/core/Mage/Sales/Model/Order/Invoice/Total/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Invoice/Total/Abstract.php
+++ b/app/code/core/Mage/Sales/Model/Order/Invoice/Total/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Invoice/Total/Cost.php
+++ b/app/code/core/Mage/Sales/Model/Order/Invoice/Total/Cost.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Order/Invoice/Total/Cost.php
+++ b/app/code/core/Mage/Sales/Model/Order/Invoice/Total/Cost.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Invoice/Total/Cost.php
+++ b/app/code/core/Mage/Sales/Model/Order/Invoice/Total/Cost.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Invoice/Total/Discount.php
+++ b/app/code/core/Mage/Sales/Model/Order/Invoice/Total/Discount.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Order/Invoice/Total/Discount.php
+++ b/app/code/core/Mage/Sales/Model/Order/Invoice/Total/Discount.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Invoice/Total/Discount.php
+++ b/app/code/core/Mage/Sales/Model/Order/Invoice/Total/Discount.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Invoice/Total/Grand.php
+++ b/app/code/core/Mage/Sales/Model/Order/Invoice/Total/Grand.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Order/Invoice/Total/Grand.php
+++ b/app/code/core/Mage/Sales/Model/Order/Invoice/Total/Grand.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Invoice/Total/Grand.php
+++ b/app/code/core/Mage/Sales/Model/Order/Invoice/Total/Grand.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Invoice/Total/Shipping.php
+++ b/app/code/core/Mage/Sales/Model/Order/Invoice/Total/Shipping.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Order/Invoice/Total/Shipping.php
+++ b/app/code/core/Mage/Sales/Model/Order/Invoice/Total/Shipping.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Invoice/Total/Shipping.php
+++ b/app/code/core/Mage/Sales/Model/Order/Invoice/Total/Shipping.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Invoice/Total/Subtotal.php
+++ b/app/code/core/Mage/Sales/Model/Order/Invoice/Total/Subtotal.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Order/Invoice/Total/Subtotal.php
+++ b/app/code/core/Mage/Sales/Model/Order/Invoice/Total/Subtotal.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Invoice/Total/Subtotal.php
+++ b/app/code/core/Mage/Sales/Model/Order/Invoice/Total/Subtotal.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Invoice/Total/Tax.php
+++ b/app/code/core/Mage/Sales/Model/Order/Invoice/Total/Tax.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Order/Invoice/Total/Tax.php
+++ b/app/code/core/Mage/Sales/Model/Order/Invoice/Total/Tax.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Invoice/Total/Tax.php
+++ b/app/code/core/Mage/Sales/Model/Order/Invoice/Total/Tax.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Item.php
+++ b/app/code/core/Mage/Sales/Model/Order/Item.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Order/Item.php
+++ b/app/code/core/Mage/Sales/Model/Order/Item.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Item.php
+++ b/app/code/core/Mage/Sales/Model/Order/Item.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Payment.php
+++ b/app/code/core/Mage/Sales/Model/Order/Payment.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Order/Payment.php
+++ b/app/code/core/Mage/Sales/Model/Order/Payment.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Payment.php
+++ b/app/code/core/Mage/Sales/Model/Order/Payment.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Payment/Transaction.php
+++ b/app/code/core/Mage/Sales/Model/Order/Payment/Transaction.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Order/Payment/Transaction.php
+++ b/app/code/core/Mage/Sales/Model/Order/Payment/Transaction.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Payment/Transaction.php
+++ b/app/code/core/Mage/Sales/Model/Order/Payment/Transaction.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Pdf/Abstract.php
+++ b/app/code/core/Mage/Sales/Model/Order/Pdf/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Order/Pdf/Abstract.php
+++ b/app/code/core/Mage/Sales/Model/Order/Pdf/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Pdf/Abstract.php
+++ b/app/code/core/Mage/Sales/Model/Order/Pdf/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Pdf/Creditmemo.php
+++ b/app/code/core/Mage/Sales/Model/Order/Pdf/Creditmemo.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Order/Pdf/Creditmemo.php
+++ b/app/code/core/Mage/Sales/Model/Order/Pdf/Creditmemo.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Pdf/Creditmemo.php
+++ b/app/code/core/Mage/Sales/Model/Order/Pdf/Creditmemo.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Pdf/Invoice.php
+++ b/app/code/core/Mage/Sales/Model/Order/Pdf/Invoice.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Order/Pdf/Invoice.php
+++ b/app/code/core/Mage/Sales/Model/Order/Pdf/Invoice.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Pdf/Invoice.php
+++ b/app/code/core/Mage/Sales/Model/Order/Pdf/Invoice.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Pdf/Items/Abstract.php
+++ b/app/code/core/Mage/Sales/Model/Order/Pdf/Items/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Order/Pdf/Items/Abstract.php
+++ b/app/code/core/Mage/Sales/Model/Order/Pdf/Items/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Pdf/Items/Abstract.php
+++ b/app/code/core/Mage/Sales/Model/Order/Pdf/Items/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Pdf/Items/Creditmemo/Default.php
+++ b/app/code/core/Mage/Sales/Model/Order/Pdf/Items/Creditmemo/Default.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Order/Pdf/Items/Creditmemo/Default.php
+++ b/app/code/core/Mage/Sales/Model/Order/Pdf/Items/Creditmemo/Default.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Pdf/Items/Creditmemo/Default.php
+++ b/app/code/core/Mage/Sales/Model/Order/Pdf/Items/Creditmemo/Default.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Pdf/Items/Creditmemo/Grouped.php
+++ b/app/code/core/Mage/Sales/Model/Order/Pdf/Items/Creditmemo/Grouped.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Order/Pdf/Items/Creditmemo/Grouped.php
+++ b/app/code/core/Mage/Sales/Model/Order/Pdf/Items/Creditmemo/Grouped.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Pdf/Items/Creditmemo/Grouped.php
+++ b/app/code/core/Mage/Sales/Model/Order/Pdf/Items/Creditmemo/Grouped.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Pdf/Items/Invoice/Default.php
+++ b/app/code/core/Mage/Sales/Model/Order/Pdf/Items/Invoice/Default.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Order/Pdf/Items/Invoice/Default.php
+++ b/app/code/core/Mage/Sales/Model/Order/Pdf/Items/Invoice/Default.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Pdf/Items/Invoice/Default.php
+++ b/app/code/core/Mage/Sales/Model/Order/Pdf/Items/Invoice/Default.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Pdf/Items/Invoice/Grouped.php
+++ b/app/code/core/Mage/Sales/Model/Order/Pdf/Items/Invoice/Grouped.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Order/Pdf/Items/Invoice/Grouped.php
+++ b/app/code/core/Mage/Sales/Model/Order/Pdf/Items/Invoice/Grouped.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Pdf/Items/Invoice/Grouped.php
+++ b/app/code/core/Mage/Sales/Model/Order/Pdf/Items/Invoice/Grouped.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Pdf/Items/Shipment/Default.php
+++ b/app/code/core/Mage/Sales/Model/Order/Pdf/Items/Shipment/Default.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Order/Pdf/Items/Shipment/Default.php
+++ b/app/code/core/Mage/Sales/Model/Order/Pdf/Items/Shipment/Default.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Pdf/Items/Shipment/Default.php
+++ b/app/code/core/Mage/Sales/Model/Order/Pdf/Items/Shipment/Default.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Pdf/Shipment.php
+++ b/app/code/core/Mage/Sales/Model/Order/Pdf/Shipment.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Order/Pdf/Shipment.php
+++ b/app/code/core/Mage/Sales/Model/Order/Pdf/Shipment.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Pdf/Shipment.php
+++ b/app/code/core/Mage/Sales/Model/Order/Pdf/Shipment.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Pdf/Shipment/Packaging.php
+++ b/app/code/core/Mage/Sales/Model/Order/Pdf/Shipment/Packaging.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Order/Pdf/Shipment/Packaging.php
+++ b/app/code/core/Mage/Sales/Model/Order/Pdf/Shipment/Packaging.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Pdf/Shipment/Packaging.php
+++ b/app/code/core/Mage/Sales/Model/Order/Pdf/Shipment/Packaging.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Pdf/Total/Default.php
+++ b/app/code/core/Mage/Sales/Model/Order/Pdf/Total/Default.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Order/Pdf/Total/Default.php
+++ b/app/code/core/Mage/Sales/Model/Order/Pdf/Total/Default.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Pdf/Total/Default.php
+++ b/app/code/core/Mage/Sales/Model/Order/Pdf/Total/Default.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Shipment.php
+++ b/app/code/core/Mage/Sales/Model/Order/Shipment.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Order/Shipment.php
+++ b/app/code/core/Mage/Sales/Model/Order/Shipment.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Shipment.php
+++ b/app/code/core/Mage/Sales/Model/Order/Shipment.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Shipment/Api.php
+++ b/app/code/core/Mage/Sales/Model/Order/Shipment/Api.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Order/Shipment/Api.php
+++ b/app/code/core/Mage/Sales/Model/Order/Shipment/Api.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Shipment/Api.php
+++ b/app/code/core/Mage/Sales/Model/Order/Shipment/Api.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Shipment/Api/V2.php
+++ b/app/code/core/Mage/Sales/Model/Order/Shipment/Api/V2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Order/Shipment/Api/V2.php
+++ b/app/code/core/Mage/Sales/Model/Order/Shipment/Api/V2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Shipment/Api/V2.php
+++ b/app/code/core/Mage/Sales/Model/Order/Shipment/Api/V2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Shipment/Comment.php
+++ b/app/code/core/Mage/Sales/Model/Order/Shipment/Comment.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Order/Shipment/Comment.php
+++ b/app/code/core/Mage/Sales/Model/Order/Shipment/Comment.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Shipment/Comment.php
+++ b/app/code/core/Mage/Sales/Model/Order/Shipment/Comment.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Shipment/Item.php
+++ b/app/code/core/Mage/Sales/Model/Order/Shipment/Item.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Order/Shipment/Item.php
+++ b/app/code/core/Mage/Sales/Model/Order/Shipment/Item.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Shipment/Item.php
+++ b/app/code/core/Mage/Sales/Model/Order/Shipment/Item.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Shipment/Track.php
+++ b/app/code/core/Mage/Sales/Model/Order/Shipment/Track.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Order/Shipment/Track.php
+++ b/app/code/core/Mage/Sales/Model/Order/Shipment/Track.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Shipment/Track.php
+++ b/app/code/core/Mage/Sales/Model/Order/Shipment/Track.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Status.php
+++ b/app/code/core/Mage/Sales/Model/Order/Status.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Order/Status.php
+++ b/app/code/core/Mage/Sales/Model/Order/Status.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Status.php
+++ b/app/code/core/Mage/Sales/Model/Order/Status.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Status/History.php
+++ b/app/code/core/Mage/Sales/Model/Order/Status/History.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Order/Status/History.php
+++ b/app/code/core/Mage/Sales/Model/Order/Status/History.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Status/History.php
+++ b/app/code/core/Mage/Sales/Model/Order/Status/History.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Tax.php
+++ b/app/code/core/Mage/Sales/Model/Order/Tax.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Order/Tax.php
+++ b/app/code/core/Mage/Sales/Model/Order/Tax.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Tax.php
+++ b/app/code/core/Mage/Sales/Model/Order/Tax.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Total.php
+++ b/app/code/core/Mage/Sales/Model/Order/Total.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Order/Total.php
+++ b/app/code/core/Mage/Sales/Model/Order/Total.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Total.php
+++ b/app/code/core/Mage/Sales/Model/Order/Total.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Total/Abstract.php
+++ b/app/code/core/Mage/Sales/Model/Order/Total/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Order/Total/Abstract.php
+++ b/app/code/core/Mage/Sales/Model/Order/Total/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Total/Abstract.php
+++ b/app/code/core/Mage/Sales/Model/Order/Total/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Total/Config/Base.php
+++ b/app/code/core/Mage/Sales/Model/Order/Total/Config/Base.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Order/Total/Config/Base.php
+++ b/app/code/core/Mage/Sales/Model/Order/Total/Config/Base.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Order/Total/Config/Base.php
+++ b/app/code/core/Mage/Sales/Model/Order/Total/Config/Base.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Payment/Method/Billing/AgreementAbstract.php
+++ b/app/code/core/Mage/Sales/Model/Payment/Method/Billing/AgreementAbstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Payment/Method/Billing/AgreementAbstract.php
+++ b/app/code/core/Mage/Sales/Model/Payment/Method/Billing/AgreementAbstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Payment/Method/Billing/AgreementAbstract.php
+++ b/app/code/core/Mage/Sales/Model/Payment/Method/Billing/AgreementAbstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Quote.php
+++ b/app/code/core/Mage/Sales/Model/Quote.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Quote.php
+++ b/app/code/core/Mage/Sales/Model/Quote.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Quote.php
+++ b/app/code/core/Mage/Sales/Model/Quote.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Quote/Address.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Address.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Quote/Address.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Address.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Quote/Address.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Address.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Quote/Address/Item.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Address/Item.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Quote/Address/Item.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Address/Item.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Quote/Address/Item.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Address/Item.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Quote/Address/Rate.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Address/Rate.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Quote/Address/Rate.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Address/Rate.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Quote/Address/Rate.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Address/Rate.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Quote/Address/Total.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Address/Total.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Quote/Address/Total.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Address/Total.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Quote/Address/Total.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Address/Total.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Quote/Address/Total/Abstract.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Address/Total/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Quote/Address/Total/Abstract.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Address/Total/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Quote/Address/Total/Abstract.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Address/Total/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Quote/Address/Total/Collector.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Address/Total/Collector.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Quote/Address/Total/Collector.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Address/Total/Collector.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Quote/Address/Total/Collector.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Address/Total/Collector.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Quote/Address/Total/Custbalance.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Address/Total/Custbalance.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Quote/Address/Total/Custbalance.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Address/Total/Custbalance.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Quote/Address/Total/Custbalance.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Address/Total/Custbalance.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Quote/Address/Total/Discount.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Address/Total/Discount.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Quote/Address/Total/Discount.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Address/Total/Discount.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Quote/Address/Total/Discount.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Address/Total/Discount.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Quote/Address/Total/Grand.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Address/Total/Grand.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Quote/Address/Total/Grand.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Address/Total/Grand.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Quote/Address/Total/Grand.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Address/Total/Grand.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Quote/Address/Total/Msrp.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Address/Total/Msrp.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Quote/Address/Total/Msrp.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Address/Total/Msrp.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Quote/Address/Total/Msrp.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Address/Total/Msrp.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Quote/Address/Total/Nominal.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Address/Total/Nominal.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Quote/Address/Total/Nominal.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Address/Total/Nominal.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Quote/Address/Total/Nominal.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Address/Total/Nominal.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Quote/Address/Total/Nominal/Collector.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Address/Total/Nominal/Collector.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Quote/Address/Total/Nominal/Collector.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Address/Total/Nominal/Collector.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Quote/Address/Total/Nominal/Collector.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Address/Total/Nominal/Collector.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Quote/Address/Total/Nominal/Recurring/Initial.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Address/Total/Nominal/Recurring/Initial.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Quote/Address/Total/Nominal/Recurring/Initial.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Address/Total/Nominal/Recurring/Initial.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Quote/Address/Total/Nominal/Recurring/Initial.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Address/Total/Nominal/Recurring/Initial.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Quote/Address/Total/Nominal/Recurring/Trial.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Address/Total/Nominal/Recurring/Trial.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Quote/Address/Total/Nominal/Recurring/Trial.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Address/Total/Nominal/Recurring/Trial.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Quote/Address/Total/Nominal/Recurring/Trial.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Address/Total/Nominal/Recurring/Trial.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Quote/Address/Total/Nominal/RecurringAbstract.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Address/Total/Nominal/RecurringAbstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Quote/Address/Total/Nominal/RecurringAbstract.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Address/Total/Nominal/RecurringAbstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Quote/Address/Total/Nominal/RecurringAbstract.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Address/Total/Nominal/RecurringAbstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Quote/Address/Total/Nominal/Shipping.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Address/Total/Nominal/Shipping.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Quote/Address/Total/Nominal/Shipping.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Address/Total/Nominal/Shipping.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Quote/Address/Total/Nominal/Shipping.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Address/Total/Nominal/Shipping.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Quote/Address/Total/Nominal/Subtotal.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Address/Total/Nominal/Subtotal.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Quote/Address/Total/Nominal/Subtotal.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Address/Total/Nominal/Subtotal.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Quote/Address/Total/Nominal/Subtotal.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Address/Total/Nominal/Subtotal.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Quote/Address/Total/Shipping.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Address/Total/Shipping.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Quote/Address/Total/Shipping.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Address/Total/Shipping.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Quote/Address/Total/Shipping.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Address/Total/Shipping.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Quote/Address/Total/Subtotal.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Address/Total/Subtotal.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Quote/Address/Total/Subtotal.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Address/Total/Subtotal.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Quote/Address/Total/Subtotal.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Address/Total/Subtotal.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Quote/Address/Total/Tax.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Address/Total/Tax.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Quote/Address/Total/Tax.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Address/Total/Tax.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Quote/Address/Total/Tax.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Address/Total/Tax.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Quote/Config.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Config.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Quote/Config.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Config.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Quote/Config.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Config.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Quote/Item.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Item.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Quote/Item.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Item.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Quote/Item.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Item.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Quote/Item/Abstract.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Item/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Quote/Item/Abstract.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Item/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Quote/Item/Abstract.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Item/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Quote/Item/Option.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Item/Option.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Quote/Item/Option.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Item/Option.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Quote/Item/Option.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Item/Option.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Quote/Payment.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Payment.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Quote/Payment.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Payment.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Quote/Payment.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Payment.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Recurring/Profile.php
+++ b/app/code/core/Mage/Sales/Model/Recurring/Profile.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Recurring/Profile.php
+++ b/app/code/core/Mage/Sales/Model/Recurring/Profile.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Recurring/Profile.php
+++ b/app/code/core/Mage/Sales/Model/Recurring/Profile.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Abstract.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Abstract.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Abstract.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Billing/Agreement.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Billing/Agreement.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Billing/Agreement.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Billing/Agreement.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Billing/Agreement.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Billing/Agreement.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Billing/Agreement/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Billing/Agreement/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Billing/Agreement/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Billing/Agreement/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Billing/Agreement/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Billing/Agreement/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Collection/Abstract.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Collection/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Collection/Abstract.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Collection/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Collection/Abstract.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Collection/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Helper/Interface.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Helper/Interface.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Helper/Interface.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Helper/Interface.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Helper/Interface.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Helper/Interface.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Helper/Mysql4.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Helper/Mysql4.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Helper/Mysql4.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Helper/Mysql4.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Helper/Mysql4.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Helper/Mysql4.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Order.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Abstract.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Abstract.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Abstract.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Address.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Address.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Address.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Address.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Address.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Address.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Address/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Address/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Address/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Address/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Address/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Address/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Attribute/Backend/Billing.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Attribute/Backend/Billing.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Attribute/Backend/Billing.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Attribute/Backend/Billing.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Attribute/Backend/Billing.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Attribute/Backend/Billing.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Attribute/Backend/Child.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Attribute/Backend/Child.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Attribute/Backend/Child.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Attribute/Backend/Child.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Attribute/Backend/Child.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Attribute/Backend/Child.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Attribute/Backend/Parent.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Attribute/Backend/Parent.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Attribute/Backend/Parent.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Attribute/Backend/Parent.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Attribute/Backend/Parent.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Attribute/Backend/Parent.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Attribute/Backend/Shipping.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Attribute/Backend/Shipping.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Attribute/Backend/Shipping.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Attribute/Backend/Shipping.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Attribute/Backend/Shipping.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Attribute/Backend/Shipping.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Collection/Abstract.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Collection/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Collection/Abstract.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Collection/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Collection/Abstract.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Collection/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Comment/Collection/Abstract.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Comment/Collection/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Comment/Collection/Abstract.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Comment/Collection/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Comment/Collection/Abstract.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Comment/Collection/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Creditmemo.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Creditmemo.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Creditmemo.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Creditmemo.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Creditmemo.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Creditmemo.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Creditmemo/Attribute/Backend/Child.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Creditmemo/Attribute/Backend/Child.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Creditmemo/Attribute/Backend/Child.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Creditmemo/Attribute/Backend/Child.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Creditmemo/Attribute/Backend/Child.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Creditmemo/Attribute/Backend/Child.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Creditmemo/Attribute/Backend/Parent.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Creditmemo/Attribute/Backend/Parent.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Creditmemo/Attribute/Backend/Parent.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Creditmemo/Attribute/Backend/Parent.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Creditmemo/Attribute/Backend/Parent.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Creditmemo/Attribute/Backend/Parent.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Creditmemo/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Creditmemo/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Creditmemo/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Creditmemo/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Creditmemo/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Creditmemo/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Creditmemo/Comment.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Creditmemo/Comment.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Creditmemo/Comment.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Creditmemo/Comment.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Creditmemo/Comment.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Creditmemo/Comment.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Creditmemo/Comment/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Creditmemo/Comment/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Creditmemo/Comment/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Creditmemo/Comment/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Creditmemo/Comment/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Creditmemo/Comment/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Creditmemo/Grid/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Creditmemo/Grid/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Creditmemo/Grid/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Creditmemo/Grid/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Creditmemo/Grid/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Creditmemo/Grid/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Creditmemo/Item.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Creditmemo/Item.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Creditmemo/Item.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Creditmemo/Item.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Creditmemo/Item.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Creditmemo/Item.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Creditmemo/Item/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Creditmemo/Item/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Creditmemo/Item/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Creditmemo/Item/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Creditmemo/Item/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Creditmemo/Item/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Grid/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Grid/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Grid/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Grid/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Grid/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Grid/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Invoice.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Invoice.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Invoice.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Invoice.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Invoice.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Invoice.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Invoice/Attribute/Backend/Child.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Invoice/Attribute/Backend/Child.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Invoice/Attribute/Backend/Child.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Invoice/Attribute/Backend/Child.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Invoice/Attribute/Backend/Child.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Invoice/Attribute/Backend/Child.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Invoice/Attribute/Backend/Item.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Invoice/Attribute/Backend/Item.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Invoice/Attribute/Backend/Item.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Invoice/Attribute/Backend/Item.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Invoice/Attribute/Backend/Item.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Invoice/Attribute/Backend/Item.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Invoice/Attribute/Backend/Order.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Invoice/Attribute/Backend/Order.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Invoice/Attribute/Backend/Order.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Invoice/Attribute/Backend/Order.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Invoice/Attribute/Backend/Order.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Invoice/Attribute/Backend/Order.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Invoice/Attribute/Backend/Parent.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Invoice/Attribute/Backend/Parent.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Invoice/Attribute/Backend/Parent.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Invoice/Attribute/Backend/Parent.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Invoice/Attribute/Backend/Parent.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Invoice/Attribute/Backend/Parent.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Invoice/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Invoice/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Invoice/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Invoice/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Invoice/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Invoice/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Invoice/Comment.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Invoice/Comment.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Invoice/Comment.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Invoice/Comment.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Invoice/Comment.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Invoice/Comment.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Invoice/Comment/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Invoice/Comment/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Invoice/Comment/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Invoice/Comment/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Invoice/Comment/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Invoice/Comment/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Invoice/Grid/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Invoice/Grid/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Invoice/Grid/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Invoice/Grid/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Invoice/Grid/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Invoice/Grid/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Invoice/Item.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Invoice/Item.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Invoice/Item.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Invoice/Item.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Invoice/Item.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Invoice/Item.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Invoice/Item/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Invoice/Item/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Invoice/Item/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Invoice/Item/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Invoice/Item/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Invoice/Item/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Item.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Item.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Item.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Item.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Item.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Item.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Item/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Item/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Item/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Item/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Item/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Item/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Payment.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Payment.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Payment.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Payment.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Payment.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Payment.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Payment/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Payment/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Payment/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Payment/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Payment/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Payment/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Payment/Transaction.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Payment/Transaction.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Payment/Transaction.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Payment/Transaction.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Payment/Transaction.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Payment/Transaction.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Payment/Transaction/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Payment/Transaction/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Payment/Transaction/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Payment/Transaction/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Payment/Transaction/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Payment/Transaction/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Shipment.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Shipment.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Shipment.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Shipment.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Shipment.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Shipment.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Shipment/Attribute/Backend/Child.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Shipment/Attribute/Backend/Child.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Shipment/Attribute/Backend/Child.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Shipment/Attribute/Backend/Child.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Shipment/Attribute/Backend/Child.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Shipment/Attribute/Backend/Child.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Shipment/Attribute/Backend/Parent.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Shipment/Attribute/Backend/Parent.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Shipment/Attribute/Backend/Parent.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Shipment/Attribute/Backend/Parent.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Shipment/Attribute/Backend/Parent.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Shipment/Attribute/Backend/Parent.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Shipment/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Shipment/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Shipment/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Shipment/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Shipment/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Shipment/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Shipment/Comment.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Shipment/Comment.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Shipment/Comment.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Shipment/Comment.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Shipment/Comment.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Shipment/Comment.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Shipment/Comment/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Shipment/Comment/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Shipment/Comment/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Shipment/Comment/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Shipment/Comment/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Shipment/Comment/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Shipment/Grid/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Shipment/Grid/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Shipment/Grid/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Shipment/Grid/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Shipment/Grid/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Shipment/Grid/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Shipment/Item.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Shipment/Item.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Shipment/Item.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Shipment/Item.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Shipment/Item.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Shipment/Item.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Shipment/Item/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Shipment/Item/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Shipment/Item/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Shipment/Item/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Shipment/Item/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Shipment/Item/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Shipment/Track.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Shipment/Track.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Shipment/Track.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Shipment/Track.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Shipment/Track.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Shipment/Track.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Shipment/Track/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Shipment/Track/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Shipment/Track/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Shipment/Track/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Shipment/Track/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Shipment/Track/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Status.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Status.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Status.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Status.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Status.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Status.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Status/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Status/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Status/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Status/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Status/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Status/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Status/History.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Status/History.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Status/History.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Status/History.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Status/History.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Status/History.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Status/History/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Status/History/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Status/History/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Status/History/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Status/History/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Status/History/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Tax.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Tax.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Tax.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Tax.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Tax.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Tax.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Tax/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Tax/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Tax/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Tax/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Tax/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Tax/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Quote.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Quote.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Quote.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Quote.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Quote.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Quote.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Quote/Address.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Quote/Address.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Quote/Address.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Quote/Address.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Quote/Address.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Quote/Address.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Attribute/Backend.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Attribute/Backend.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Attribute/Backend.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Attribute/Backend.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Attribute/Backend.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Attribute/Backend.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Attribute/Backend/Child.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Attribute/Backend/Child.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Attribute/Backend/Child.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Attribute/Backend/Child.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Attribute/Backend/Child.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Attribute/Backend/Child.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Attribute/Backend/Parent.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Attribute/Backend/Parent.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Attribute/Backend/Parent.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Attribute/Backend/Parent.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Attribute/Backend/Parent.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Attribute/Backend/Parent.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Attribute/Backend/Region.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Attribute/Backend/Region.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Attribute/Backend/Region.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Attribute/Backend/Region.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Attribute/Backend/Region.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Attribute/Backend/Region.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Attribute/Frontend.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Attribute/Frontend.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Attribute/Frontend.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Attribute/Frontend.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Attribute/Frontend.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Attribute/Frontend.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Attribute/Frontend/Custbalance.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Attribute/Frontend/Custbalance.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Attribute/Frontend/Custbalance.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Attribute/Frontend/Custbalance.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Attribute/Frontend/Custbalance.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Attribute/Frontend/Custbalance.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Attribute/Frontend/Discount.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Attribute/Frontend/Discount.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Attribute/Frontend/Discount.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Attribute/Frontend/Discount.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Attribute/Frontend/Discount.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Attribute/Frontend/Discount.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Attribute/Frontend/Grand.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Attribute/Frontend/Grand.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Attribute/Frontend/Grand.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Attribute/Frontend/Grand.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Attribute/Frontend/Grand.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Attribute/Frontend/Grand.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Attribute/Frontend/Shipping.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Attribute/Frontend/Shipping.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Attribute/Frontend/Shipping.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Attribute/Frontend/Shipping.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Attribute/Frontend/Shipping.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Attribute/Frontend/Shipping.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Attribute/Frontend/Subtotal.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Attribute/Frontend/Subtotal.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Attribute/Frontend/Subtotal.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Attribute/Frontend/Subtotal.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Attribute/Frontend/Subtotal.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Attribute/Frontend/Subtotal.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Attribute/Frontend/Tax.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Attribute/Frontend/Tax.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Attribute/Frontend/Tax.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Attribute/Frontend/Tax.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Attribute/Frontend/Tax.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Attribute/Frontend/Tax.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Item.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Item.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Item.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Item.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Item.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Item.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Item/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Item/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Item/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Item/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Item/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Item/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Rate.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Rate.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Rate.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Rate.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Rate.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Rate.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Rate/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Rate/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Rate/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Rate/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Rate/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Quote/Address/Rate/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Quote/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Quote/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Quote/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Quote/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Quote/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Quote/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Quote/Item.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Quote/Item.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Quote/Item.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Quote/Item.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Quote/Item.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Quote/Item.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Quote/Item/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Quote/Item/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Quote/Item/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Quote/Item/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Quote/Item/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Quote/Item/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Quote/Item/Option.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Quote/Item/Option.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Quote/Item/Option.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Quote/Item/Option.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Quote/Item/Option.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Quote/Item/Option.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Quote/Item/Option/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Quote/Item/Option/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Quote/Item/Option/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Quote/Item/Option/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Quote/Item/Option/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Quote/Item/Option/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Quote/Payment.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Quote/Payment.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Quote/Payment.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Quote/Payment.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Quote/Payment.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Quote/Payment.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Quote/Payment/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Quote/Payment/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Quote/Payment/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Quote/Payment/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Quote/Payment/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Quote/Payment/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Recurring/Profile.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Recurring/Profile.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Recurring/Profile.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Recurring/Profile.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Recurring/Profile.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Recurring/Profile.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Recurring/Profile/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Recurring/Profile/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Recurring/Profile/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Recurring/Profile/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Recurring/Profile/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Recurring/Profile/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Report.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Report.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Report.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Report.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Report.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Report.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Report/Abstract.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Report/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Report/Abstract.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Report/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Report/Abstract.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Report/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Report/Bestsellers.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Report/Bestsellers.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Report/Bestsellers.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Report/Bestsellers.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Report/Bestsellers.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Report/Bestsellers.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Report/Bestsellers/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Report/Bestsellers/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Report/Bestsellers/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Report/Bestsellers/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Report/Bestsellers/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Report/Bestsellers/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Report/Collection/Abstract.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Report/Collection/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Report/Collection/Abstract.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Report/Collection/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Report/Collection/Abstract.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Report/Collection/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Report/Invoiced.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Report/Invoiced.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Report/Invoiced.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Report/Invoiced.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Report/Invoiced.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Report/Invoiced.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Report/Invoiced/Collection/Invoiced.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Report/Invoiced/Collection/Invoiced.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Report/Invoiced/Collection/Invoiced.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Report/Invoiced/Collection/Invoiced.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Report/Invoiced/Collection/Invoiced.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Report/Invoiced/Collection/Invoiced.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Report/Invoiced/Collection/Order.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Report/Invoiced/Collection/Order.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Report/Invoiced/Collection/Order.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Report/Invoiced/Collection/Order.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Report/Invoiced/Collection/Order.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Report/Invoiced/Collection/Order.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Report/Order.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Report/Order.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Report/Order.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Report/Order.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Report/Order.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Report/Order.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Report/Order/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Report/Order/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Report/Order/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Report/Order/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Report/Order/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Report/Order/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Report/Order/Createdat.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Report/Order/Createdat.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Report/Order/Createdat.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Report/Order/Createdat.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Report/Order/Createdat.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Report/Order/Createdat.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Report/Order/Updatedat.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Report/Order/Updatedat.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Report/Order/Updatedat.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Report/Order/Updatedat.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Report/Order/Updatedat.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Report/Order/Updatedat.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Report/Order/Updatedat/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Report/Order/Updatedat/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Report/Order/Updatedat/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Report/Order/Updatedat/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Report/Order/Updatedat/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Report/Order/Updatedat/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Report/Refunded.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Report/Refunded.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Report/Refunded.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Report/Refunded.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Report/Refunded.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Report/Refunded.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Report/Refunded/Collection/Order.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Report/Refunded/Collection/Order.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Report/Refunded/Collection/Order.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Report/Refunded/Collection/Order.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Report/Refunded/Collection/Order.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Report/Refunded/Collection/Order.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Report/Refunded/Collection/Refunded.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Report/Refunded/Collection/Refunded.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Report/Refunded/Collection/Refunded.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Report/Refunded/Collection/Refunded.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Report/Refunded/Collection/Refunded.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Report/Refunded/Collection/Refunded.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Report/Shipping.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Report/Shipping.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Report/Shipping.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Report/Shipping.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Report/Shipping.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Report/Shipping.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Report/Shipping/Collection/Order.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Report/Shipping/Collection/Order.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Report/Shipping/Collection/Order.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Report/Shipping/Collection/Order.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Report/Shipping/Collection/Order.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Report/Shipping/Collection/Order.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Report/Shipping/Collection/Shipment.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Report/Shipping/Collection/Shipment.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Report/Shipping/Collection/Shipment.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Report/Shipping/Collection/Shipment.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Report/Shipping/Collection/Shipment.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Report/Shipping/Collection/Shipment.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Sale/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Sale/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Sale/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Sale/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Sale/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Sale/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Setup.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Setup.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Resource/Setup.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Setup.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Resource/Setup.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Setup.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Service/Order.php
+++ b/app/code/core/Mage/Sales/Model/Service/Order.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Service/Order.php
+++ b/app/code/core/Mage/Sales/Model/Service/Order.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Service/Order.php
+++ b/app/code/core/Mage/Sales/Model/Service/Order.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Service/Quote.php
+++ b/app/code/core/Mage/Sales/Model/Service/Quote.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Service/Quote.php
+++ b/app/code/core/Mage/Sales/Model/Service/Quote.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Service/Quote.php
+++ b/app/code/core/Mage/Sales/Model/Service/Quote.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Status/List.php
+++ b/app/code/core/Mage/Sales/Model/Status/List.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/Model/Status/List.php
+++ b/app/code/core/Mage/Sales/Model/Status/List.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/Model/Status/List.php
+++ b/app/code/core/Mage/Sales/Model/Status/List.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/controllers/Billing/AgreementController.php
+++ b/app/code/core/Mage/Sales/controllers/Billing/AgreementController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/controllers/Billing/AgreementController.php
+++ b/app/code/core/Mage/Sales/controllers/Billing/AgreementController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/controllers/Billing/AgreementController.php
+++ b/app/code/core/Mage/Sales/controllers/Billing/AgreementController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/controllers/DownloadController.php
+++ b/app/code/core/Mage/Sales/controllers/DownloadController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/controllers/DownloadController.php
+++ b/app/code/core/Mage/Sales/controllers/DownloadController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/controllers/DownloadController.php
+++ b/app/code/core/Mage/Sales/controllers/DownloadController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/controllers/GuestController.php
+++ b/app/code/core/Mage/Sales/controllers/GuestController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/controllers/GuestController.php
+++ b/app/code/core/Mage/Sales/controllers/GuestController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/controllers/GuestController.php
+++ b/app/code/core/Mage/Sales/controllers/GuestController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/controllers/OrderController.php
+++ b/app/code/core/Mage/Sales/controllers/OrderController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/controllers/OrderController.php
+++ b/app/code/core/Mage/Sales/controllers/OrderController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/controllers/OrderController.php
+++ b/app/code/core/Mage/Sales/controllers/OrderController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/controllers/Recurring/ProfileController.php
+++ b/app/code/core/Mage/Sales/controllers/Recurring/ProfileController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/controllers/Recurring/ProfileController.php
+++ b/app/code/core/Mage/Sales/controllers/Recurring/ProfileController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/controllers/Recurring/ProfileController.php
+++ b/app/code/core/Mage/Sales/controllers/Recurring/ProfileController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/data/sales_setup/data-install-1.6.0.0.php
+++ b/app/code/core/Mage/Sales/data/sales_setup/data-install-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/data/sales_setup/data-install-1.6.0.0.php
+++ b/app/code/core/Mage/Sales/data/sales_setup/data-install-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/data/sales_setup/data-install-1.6.0.0.php
+++ b/app/code/core/Mage/Sales/data/sales_setup/data-install-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/data/sales_setup/data-upgrade-1.6.0.4-1.6.0.5.php
+++ b/app/code/core/Mage/Sales/data/sales_setup/data-upgrade-1.6.0.4-1.6.0.5.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/data/sales_setup/data-upgrade-1.6.0.4-1.6.0.5.php
+++ b/app/code/core/Mage/Sales/data/sales_setup/data-upgrade-1.6.0.4-1.6.0.5.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/data/sales_setup/data-upgrade-1.6.0.4-1.6.0.5.php
+++ b/app/code/core/Mage/Sales/data/sales_setup/data-upgrade-1.6.0.4-1.6.0.5.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/etc/adminhtml.xml
+++ b/app/code/core/Mage/Sales/etc/adminhtml.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/etc/adminhtml.xml
+++ b/app/code/core/Mage/Sales/etc/adminhtml.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/etc/adminhtml.xml
+++ b/app/code/core/Mage/Sales/etc/adminhtml.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/etc/api.xml
+++ b/app/code/core/Mage/Sales/etc/api.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/etc/api.xml
+++ b/app/code/core/Mage/Sales/etc/api.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/etc/api.xml
+++ b/app/code/core/Mage/Sales/etc/api.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/etc/api2.xml
+++ b/app/code/core/Mage/Sales/etc/api2.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/etc/api2.xml
+++ b/app/code/core/Mage/Sales/etc/api2.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/etc/api2.xml
+++ b/app/code/core/Mage/Sales/etc/api2.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/etc/config.xml
+++ b/app/code/core/Mage/Sales/etc/config.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/etc/config.xml
+++ b/app/code/core/Mage/Sales/etc/config.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/etc/config.xml
+++ b/app/code/core/Mage/Sales/etc/config.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/etc/system.xml
+++ b/app/code/core/Mage/Sales/etc/system.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/etc/system.xml
+++ b/app/code/core/Mage/Sales/etc/system.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/etc/system.xml
+++ b/app/code/core/Mage/Sales/etc/system.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/etc/widget.xml
+++ b/app/code/core/Mage/Sales/etc/widget.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/etc/widget.xml
+++ b/app/code/core/Mage/Sales/etc/widget.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/etc/widget.xml
+++ b/app/code/core/Mage/Sales/etc/widget.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/install-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/install-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/install-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-install-0.7.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-install-0.7.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-install-0.7.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-install-0.8.11.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-install-0.8.11.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-install-0.8.11.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-install-0.8.11.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-install-0.8.11.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-install-0.8.11.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-install-0.9.0.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-install-0.9.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-install-0.9.0.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-install-0.9.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-install-0.9.0.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-install-0.9.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-install-1.4.0.0.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-install-1.4.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-install-1.4.0.0.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-install-1.4.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-install-1.4.0.0.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-install-1.4.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.6.2-0.7.0.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.6.2-0.7.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.6.2-0.7.0.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.6.2-0.7.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.6.2-0.7.0.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.6.2-0.7.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.7.0-0.7.1.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.7.0-0.7.1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.7.0-0.7.1.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.7.0-0.7.1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.7.0-0.7.1.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.7.0-0.7.1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.7.1-0.7.2.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.7.1-0.7.2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.7.1-0.7.2.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.7.1-0.7.2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.7.1-0.7.2.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.7.1-0.7.2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.7.2-0.7.3.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.7.2-0.7.3.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.7.2-0.7.3.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.7.2-0.7.3.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.7.2-0.7.3.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.7.2-0.7.3.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.7.9-0.7.10.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.7.9-0.7.10.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.7.9-0.7.10.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.7.9-0.7.10.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.7.9-0.7.10.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.7.9-0.7.10.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.0-0.8.1.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.0-0.8.1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.0-0.8.1.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.0-0.8.1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.0-0.8.1.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.0-0.8.1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.1-0.8.2.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.1-0.8.2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.1-0.8.2.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.1-0.8.2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.1-0.8.2.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.1-0.8.2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.11-0.8.12.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.11-0.8.12.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.11-0.8.12.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.11-0.8.12.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.11-0.8.12.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.11-0.8.12.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.12-0.8.13.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.12-0.8.13.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.12-0.8.13.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.12-0.8.13.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.12-0.8.13.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.12-0.8.13.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.13-0.8.14.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.13-0.8.14.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.13-0.8.14.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.13-0.8.14.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.13-0.8.14.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.13-0.8.14.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.14-0.8.15.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.14-0.8.15.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.14-0.8.15.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.14-0.8.15.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.14-0.8.15.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.14-0.8.15.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.15-0.8.16.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.15-0.8.16.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.15-0.8.16.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.15-0.8.16.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.15-0.8.16.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.15-0.8.16.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.16-0.8.17.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.16-0.8.17.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.16-0.8.17.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.16-0.8.17.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.16-0.8.17.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.16-0.8.17.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.17-0.8.18.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.17-0.8.18.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.17-0.8.18.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.17-0.8.18.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.17-0.8.18.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.17-0.8.18.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.18-0.8.19.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.18-0.8.19.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.18-0.8.19.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.18-0.8.19.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.18-0.8.19.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.18-0.8.19.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.19-0.8.20.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.19-0.8.20.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.19-0.8.20.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.19-0.8.20.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.19-0.8.20.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.19-0.8.20.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.2-0.8.3.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.2-0.8.3.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.2-0.8.3.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.2-0.8.3.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.2-0.8.3.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.2-0.8.3.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.20-0.8.21.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.20-0.8.21.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.20-0.8.21.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.20-0.8.21.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.20-0.8.21.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.20-0.8.21.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.21-0.8.22.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.21-0.8.22.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.21-0.8.22.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.21-0.8.22.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.21-0.8.22.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.21-0.8.22.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.22-0.8.23.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.22-0.8.23.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.22-0.8.23.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.22-0.8.23.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.22-0.8.23.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.22-0.8.23.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.23-0.8.24.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.23-0.8.24.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.23-0.8.24.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.23-0.8.24.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.23-0.8.24.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.23-0.8.24.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.24-0.8.25.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.24-0.8.25.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.24-0.8.25.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.24-0.8.25.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.24-0.8.25.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.24-0.8.25.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.25-0.8.26.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.25-0.8.26.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.25-0.8.26.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.25-0.8.26.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.25-0.8.26.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.25-0.8.26.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.26-0.8.27.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.26-0.8.27.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.26-0.8.27.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.26-0.8.27.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.26-0.8.27.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.26-0.8.27.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.27-0.8.28.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.27-0.8.28.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.27-0.8.28.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.27-0.8.28.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.27-0.8.28.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.27-0.8.28.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.28-0.8.29.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.28-0.8.29.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.28-0.8.29.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.28-0.8.29.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.28-0.8.29.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.28-0.8.29.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.29-0.9.0.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.29-0.9.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.29-0.9.0.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.29-0.9.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.29-0.9.0.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.29-0.9.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.3-0.8.4.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.3-0.8.4.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.3-0.8.4.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.3-0.8.4.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.3-0.8.4.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.3-0.8.4.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.6-0.8.7.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.6-0.8.7.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.6-0.8.7.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.6-0.8.7.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.6-0.8.7.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.6-0.8.7.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.7-0.8.8.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.7-0.8.8.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.7-0.8.8.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.7-0.8.8.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.7-0.8.8.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.7-0.8.8.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.8-0.8.9.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.8-0.8.9.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.8-0.8.9.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.8-0.8.9.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.8-0.8.9.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.8.8-0.8.9.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.0-0.9.1.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.0-0.9.1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.0-0.9.1.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.0-0.9.1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.0-0.9.1.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.0-0.9.1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.1-0.9.2.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.1-0.9.2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.1-0.9.2.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.1-0.9.2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.1-0.9.2.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.1-0.9.2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.10-0.9.11.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.10-0.9.11.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.10-0.9.11.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.10-0.9.11.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.10-0.9.11.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.10-0.9.11.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.11-0.9.12.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.11-0.9.12.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.11-0.9.12.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.11-0.9.12.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.11-0.9.12.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.11-0.9.12.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.12-0.9.13.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.12-0.9.13.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.12-0.9.13.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.12-0.9.13.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.12-0.9.13.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.12-0.9.13.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.13-0.9.14.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.13-0.9.14.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.13-0.9.14.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.13-0.9.14.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.13-0.9.14.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.13-0.9.14.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.14-0.9.15.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.14-0.9.15.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.14-0.9.15.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.14-0.9.15.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.14-0.9.15.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.14-0.9.15.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.15-0.9.16.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.15-0.9.16.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.15-0.9.16.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.15-0.9.16.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.15-0.9.16.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.15-0.9.16.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.16-0.9.17.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.16-0.9.17.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.16-0.9.17.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.16-0.9.17.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.16-0.9.17.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.16-0.9.17.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.17-0.9.18.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.17-0.9.18.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.17-0.9.18.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.17-0.9.18.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.17-0.9.18.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.17-0.9.18.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.18-0.9.19.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.18-0.9.19.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.18-0.9.19.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.18-0.9.19.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.18-0.9.19.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.18-0.9.19.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.19-0.9.20.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.19-0.9.20.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.19-0.9.20.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.19-0.9.20.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.19-0.9.20.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.19-0.9.20.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.2-0.9.3.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.2-0.9.3.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.2-0.9.3.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.2-0.9.3.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.2-0.9.3.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.2-0.9.3.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.20-0.9.21.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.20-0.9.21.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.20-0.9.21.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.20-0.9.21.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.20-0.9.21.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.20-0.9.21.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.21-0.9.22.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.21-0.9.22.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.21-0.9.22.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.21-0.9.22.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.21-0.9.22.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.21-0.9.22.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.22-0.9.23.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.22-0.9.23.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.22-0.9.23.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.22-0.9.23.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.22-0.9.23.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.22-0.9.23.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.23-0.9.24.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.23-0.9.24.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.23-0.9.24.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.23-0.9.24.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.23-0.9.24.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.23-0.9.24.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.24-0.9.25.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.24-0.9.25.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.24-0.9.25.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.24-0.9.25.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.24-0.9.25.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.24-0.9.25.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.25-0.9.26.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.25-0.9.26.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.25-0.9.26.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.25-0.9.26.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.25-0.9.26.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.25-0.9.26.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.26-0.9.27.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.26-0.9.27.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.26-0.9.27.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.26-0.9.27.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.26-0.9.27.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.26-0.9.27.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.27-0.9.28.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.27-0.9.28.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.27-0.9.28.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.27-0.9.28.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.27-0.9.28.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.27-0.9.28.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.28-0.9.29.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.28-0.9.29.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.28-0.9.29.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.28-0.9.29.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.28-0.9.29.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.28-0.9.29.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.29-0.9.30.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.29-0.9.30.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.29-0.9.30.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.29-0.9.30.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.29-0.9.30.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.29-0.9.30.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.3-0.9.4.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.3-0.9.4.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.3-0.9.4.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.3-0.9.4.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.3-0.9.4.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.3-0.9.4.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.30-0.9.31.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.30-0.9.31.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.30-0.9.31.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.30-0.9.31.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.30-0.9.31.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.30-0.9.31.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.31-0.9.32.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.31-0.9.32.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.31-0.9.32.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.31-0.9.32.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.31-0.9.32.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.31-0.9.32.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.32-0.9.33.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.32-0.9.33.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.32-0.9.33.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.32-0.9.33.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.32-0.9.33.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.32-0.9.33.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.33-0.9.34.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.33-0.9.34.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.33-0.9.34.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.33-0.9.34.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.33-0.9.34.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.33-0.9.34.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.34-0.9.35.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.34-0.9.35.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.34-0.9.35.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.34-0.9.35.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.34-0.9.35.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.34-0.9.35.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.35-0.9.36.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.35-0.9.36.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.35-0.9.36.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.35-0.9.36.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.35-0.9.36.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.35-0.9.36.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.36-0.9.37.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.36-0.9.37.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.36-0.9.37.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.36-0.9.37.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.36-0.9.37.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.36-0.9.37.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.37-0.9.38.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.37-0.9.38.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.37-0.9.38.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.37-0.9.38.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.37-0.9.38.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.37-0.9.38.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.38-0.9.39.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.38-0.9.39.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.38-0.9.39.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.38-0.9.39.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.38-0.9.39.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.38-0.9.39.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.39-0.9.40.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.39-0.9.40.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.39-0.9.40.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.39-0.9.40.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.39-0.9.40.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.39-0.9.40.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.4-0.9.5.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.4-0.9.5.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.4-0.9.5.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.4-0.9.5.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.4-0.9.5.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.4-0.9.5.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.40-0.9.41.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.40-0.9.41.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.40-0.9.41.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.40-0.9.41.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.40-0.9.41.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.40-0.9.41.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.41-0.9.42.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.41-0.9.42.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.41-0.9.42.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.41-0.9.42.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.41-0.9.42.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.41-0.9.42.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.42-0.9.43.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.42-0.9.43.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.42-0.9.43.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.42-0.9.43.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.42-0.9.43.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.42-0.9.43.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.43-0.9.44.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.43-0.9.44.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.43-0.9.44.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.43-0.9.44.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.43-0.9.44.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.43-0.9.44.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.44-0.9.45.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.44-0.9.45.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.44-0.9.45.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.44-0.9.45.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.44-0.9.45.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.44-0.9.45.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.45-0.9.46.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.45-0.9.46.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.45-0.9.46.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.45-0.9.46.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.45-0.9.46.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.45-0.9.46.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.46-0.9.47.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.46-0.9.47.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.46-0.9.47.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.46-0.9.47.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.46-0.9.47.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.46-0.9.47.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.47-0.9.48.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.47-0.9.48.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.47-0.9.48.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.47-0.9.48.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.47-0.9.48.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.47-0.9.48.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.48-0.9.49.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.48-0.9.49.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.48-0.9.49.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.48-0.9.49.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.48-0.9.49.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.48-0.9.49.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.49-0.9.50.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.49-0.9.50.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.49-0.9.50.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.49-0.9.50.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.49-0.9.50.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.49-0.9.50.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.5-0.9.6.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.5-0.9.6.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.5-0.9.6.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.5-0.9.6.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.5-0.9.6.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.5-0.9.6.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.50-0.9.51.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.50-0.9.51.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.50-0.9.51.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.50-0.9.51.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.50-0.9.51.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.50-0.9.51.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.51-0.9.52.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.51-0.9.52.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.51-0.9.52.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.51-0.9.52.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.51-0.9.52.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.51-0.9.52.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.52-0.9.53.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.52-0.9.53.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.52-0.9.53.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.52-0.9.53.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.52-0.9.53.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.52-0.9.53.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.53-0.9.54.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.53-0.9.54.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.53-0.9.54.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.53-0.9.54.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.53-0.9.54.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.53-0.9.54.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.54-0.9.55.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.54-0.9.55.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.54-0.9.55.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.54-0.9.55.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.54-0.9.55.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.54-0.9.55.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.55-0.9.56.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.55-0.9.56.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.55-0.9.56.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.55-0.9.56.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.55-0.9.56.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.55-0.9.56.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.6-0.9.7.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.6-0.9.7.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.6-0.9.7.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.6-0.9.7.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.6-0.9.7.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.6-0.9.7.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.7-0.9.8.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.7-0.9.8.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.7-0.9.8.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.7-0.9.8.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.7-0.9.8.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.7-0.9.8.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.8-0.9.9.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.8-0.9.9.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.8-0.9.9.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.8-0.9.9.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.8-0.9.9.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.8-0.9.9.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.9-0.9.10.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.9-0.9.10.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.9-0.9.10.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.9-0.9.10.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.9-0.9.10.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-0.9.9-0.9.10.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.3.99-1.4.0.0.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.3.99-1.4.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.3.99-1.4.0.0.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.3.99-1.4.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.3.99-1.4.0.0.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.3.99-1.4.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.0-1.4.0.1.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.0-1.4.0.1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.0-1.4.0.1.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.0-1.4.0.1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.0-1.4.0.1.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.0-1.4.0.1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.1-1.4.0.2.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.1-1.4.0.2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.1-1.4.0.2.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.1-1.4.0.2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.1-1.4.0.2.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.1-1.4.0.2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.15-1.4.0.16.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.15-1.4.0.16.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.15-1.4.0.16.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.15-1.4.0.16.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.15-1.4.0.16.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.15-1.4.0.16.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.16-1.4.0.17.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.16-1.4.0.17.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.16-1.4.0.17.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.16-1.4.0.17.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.16-1.4.0.17.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.16-1.4.0.17.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.17-1.4.0.18.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.17-1.4.0.18.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.17-1.4.0.18.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.17-1.4.0.18.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.17-1.4.0.18.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.17-1.4.0.18.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.18-1.4.0.19.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.18-1.4.0.19.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.18-1.4.0.19.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.18-1.4.0.19.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.18-1.4.0.19.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.18-1.4.0.19.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.19-1.4.0.20.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.19-1.4.0.20.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.19-1.4.0.20.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.19-1.4.0.20.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.19-1.4.0.20.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.19-1.4.0.20.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.2-1.4.0.3.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.2-1.4.0.3.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.2-1.4.0.3.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.2-1.4.0.3.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.2-1.4.0.3.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.2-1.4.0.3.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.20-1.4.0.21.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.20-1.4.0.21.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.20-1.4.0.21.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.20-1.4.0.21.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.20-1.4.0.21.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.20-1.4.0.21.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.21-1.4.0.22.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.21-1.4.0.22.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.21-1.4.0.22.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.21-1.4.0.22.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.21-1.4.0.22.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.21-1.4.0.22.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.22-1.4.0.23.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.22-1.4.0.23.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.22-1.4.0.23.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.22-1.4.0.23.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.22-1.4.0.23.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.22-1.4.0.23.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.23-1.4.0.24.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.23-1.4.0.24.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.23-1.4.0.24.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.23-1.4.0.24.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.23-1.4.0.24.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.23-1.4.0.24.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.24-1.4.0.25.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.24-1.4.0.25.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.24-1.4.0.25.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.24-1.4.0.25.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.24-1.4.0.25.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.24-1.4.0.25.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.3-1.4.0.4.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.3-1.4.0.4.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.3-1.4.0.4.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.3-1.4.0.4.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.3-1.4.0.4.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.3-1.4.0.4.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.4-1.4.0.5.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.4-1.4.0.5.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.4-1.4.0.5.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.4-1.4.0.5.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.4-1.4.0.5.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.4-1.4.0.5.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.5-1.4.0.6.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.5-1.4.0.6.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.5-1.4.0.6.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.5-1.4.0.6.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.5-1.4.0.6.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.5-1.4.0.6.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.6-1.4.0.7.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.6-1.4.0.7.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.6-1.4.0.7.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.6-1.4.0.7.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.6-1.4.0.7.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.6-1.4.0.7.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.7-1.4.0.8.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.7-1.4.0.8.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.7-1.4.0.8.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.7-1.4.0.8.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.7-1.4.0.8.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.7-1.4.0.8.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.8-1.4.0.15.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.8-1.4.0.15.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.8-1.4.0.15.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.8-1.4.0.15.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.8-1.4.0.15.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.4.0.8-1.4.0.15.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/upgrade-1.6.0.0-1.6.0.1.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/upgrade-1.6.0.0-1.6.0.1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/upgrade-1.6.0.0-1.6.0.1.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/upgrade-1.6.0.0-1.6.0.1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/upgrade-1.6.0.0-1.6.0.1.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/upgrade-1.6.0.0-1.6.0.1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/upgrade-1.6.0.1-1.6.0.2.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/upgrade-1.6.0.1-1.6.0.2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/upgrade-1.6.0.1-1.6.0.2.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/upgrade-1.6.0.1-1.6.0.2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/upgrade-1.6.0.1-1.6.0.2.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/upgrade-1.6.0.1-1.6.0.2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/upgrade-1.6.0.10-1.6.0.11.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/upgrade-1.6.0.10-1.6.0.11.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/upgrade-1.6.0.10-1.6.0.11.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/upgrade-1.6.0.10-1.6.0.11.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/upgrade-1.6.0.10-1.6.0.11.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/upgrade-1.6.0.10-1.6.0.11.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/upgrade-1.6.0.2-1.6.0.3.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/upgrade-1.6.0.2-1.6.0.3.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/upgrade-1.6.0.2-1.6.0.3.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/upgrade-1.6.0.2-1.6.0.3.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/upgrade-1.6.0.2-1.6.0.3.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/upgrade-1.6.0.2-1.6.0.3.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/upgrade-1.6.0.3-1.6.0.4.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/upgrade-1.6.0.3-1.6.0.4.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/upgrade-1.6.0.3-1.6.0.4.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/upgrade-1.6.0.3-1.6.0.4.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/upgrade-1.6.0.3-1.6.0.4.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/upgrade-1.6.0.3-1.6.0.4.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/upgrade-1.6.0.4-1.6.0.5.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/upgrade-1.6.0.4-1.6.0.5.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/upgrade-1.6.0.4-1.6.0.5.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/upgrade-1.6.0.4-1.6.0.5.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/upgrade-1.6.0.4-1.6.0.5.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/upgrade-1.6.0.4-1.6.0.5.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/upgrade-1.6.0.5-1.6.0.6.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/upgrade-1.6.0.5-1.6.0.6.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/upgrade-1.6.0.5-1.6.0.6.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/upgrade-1.6.0.5-1.6.0.6.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/upgrade-1.6.0.5-1.6.0.6.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/upgrade-1.6.0.5-1.6.0.6.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/upgrade-1.6.0.6-1.6.0.7.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/upgrade-1.6.0.6-1.6.0.7.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/upgrade-1.6.0.6-1.6.0.7.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/upgrade-1.6.0.6-1.6.0.7.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/upgrade-1.6.0.6-1.6.0.7.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/upgrade-1.6.0.6-1.6.0.7.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/upgrade-1.6.0.7-1.6.0.8.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/upgrade-1.6.0.7-1.6.0.8.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/upgrade-1.6.0.7-1.6.0.8.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/upgrade-1.6.0.7-1.6.0.8.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/upgrade-1.6.0.7-1.6.0.8.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/upgrade-1.6.0.7-1.6.0.8.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/upgrade-1.6.0.8-1.6.0.9.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/upgrade-1.6.0.8-1.6.0.9.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/upgrade-1.6.0.8-1.6.0.9.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/upgrade-1.6.0.8-1.6.0.9.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/upgrade-1.6.0.8-1.6.0.9.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/upgrade-1.6.0.8-1.6.0.9.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/upgrade-1.6.0.9-1.6.0.10.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/upgrade-1.6.0.9-1.6.0.10.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sales/sql/sales_setup/upgrade-1.6.0.9-1.6.0.10.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/upgrade-1.6.0.9-1.6.0.10.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/Sales/sql/sales_setup/upgrade-1.6.0.9-1.6.0.10.php
+++ b/app/code/core/Mage/Sales/sql/sales_setup/upgrade-1.6.0.9-1.6.0.10.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/code/core/Mage/SalesRule/Exception.php
+++ b/app/code/core/Mage/SalesRule/Exception.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/SalesRule/Exception.php
+++ b/app/code/core/Mage/SalesRule/Exception.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Exception.php
+++ b/app/code/core/Mage/SalesRule/Exception.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Helper/Coupon.php
+++ b/app/code/core/Mage/SalesRule/Helper/Coupon.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/SalesRule/Helper/Coupon.php
+++ b/app/code/core/Mage/SalesRule/Helper/Coupon.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Helper/Coupon.php
+++ b/app/code/core/Mage/SalesRule/Helper/Coupon.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Helper/Data.php
+++ b/app/code/core/Mage/SalesRule/Helper/Data.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/SalesRule/Helper/Data.php
+++ b/app/code/core/Mage/SalesRule/Helper/Data.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Helper/Data.php
+++ b/app/code/core/Mage/SalesRule/Helper/Data.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/Coupon.php
+++ b/app/code/core/Mage/SalesRule/Model/Coupon.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/SalesRule/Model/Coupon.php
+++ b/app/code/core/Mage/SalesRule/Model/Coupon.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/Coupon.php
+++ b/app/code/core/Mage/SalesRule/Model/Coupon.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/Coupon/Codegenerator.php
+++ b/app/code/core/Mage/SalesRule/Model/Coupon/Codegenerator.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/SalesRule/Model/Coupon/Codegenerator.php
+++ b/app/code/core/Mage/SalesRule/Model/Coupon/Codegenerator.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/Coupon/Codegenerator.php
+++ b/app/code/core/Mage/SalesRule/Model/Coupon/Codegenerator.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/Coupon/CodegeneratorInterface.php
+++ b/app/code/core/Mage/SalesRule/Model/Coupon/CodegeneratorInterface.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/SalesRule/Model/Coupon/CodegeneratorInterface.php
+++ b/app/code/core/Mage/SalesRule/Model/Coupon/CodegeneratorInterface.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/Coupon/CodegeneratorInterface.php
+++ b/app/code/core/Mage/SalesRule/Model/Coupon/CodegeneratorInterface.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/Coupon/Massgenerator.php
+++ b/app/code/core/Mage/SalesRule/Model/Coupon/Massgenerator.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/SalesRule/Model/Coupon/Massgenerator.php
+++ b/app/code/core/Mage/SalesRule/Model/Coupon/Massgenerator.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/Coupon/Massgenerator.php
+++ b/app/code/core/Mage/SalesRule/Model/Coupon/Massgenerator.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/Mysql4/Coupon.php
+++ b/app/code/core/Mage/SalesRule/Model/Mysql4/Coupon.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/SalesRule/Model/Mysql4/Coupon.php
+++ b/app/code/core/Mage/SalesRule/Model/Mysql4/Coupon.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/Mysql4/Coupon.php
+++ b/app/code/core/Mage/SalesRule/Model/Mysql4/Coupon.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/Mysql4/Coupon/Collection.php
+++ b/app/code/core/Mage/SalesRule/Model/Mysql4/Coupon/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/SalesRule/Model/Mysql4/Coupon/Collection.php
+++ b/app/code/core/Mage/SalesRule/Model/Mysql4/Coupon/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/Mysql4/Coupon/Collection.php
+++ b/app/code/core/Mage/SalesRule/Model/Mysql4/Coupon/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/Mysql4/Coupon/Usage.php
+++ b/app/code/core/Mage/SalesRule/Model/Mysql4/Coupon/Usage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/SalesRule/Model/Mysql4/Coupon/Usage.php
+++ b/app/code/core/Mage/SalesRule/Model/Mysql4/Coupon/Usage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/Mysql4/Coupon/Usage.php
+++ b/app/code/core/Mage/SalesRule/Model/Mysql4/Coupon/Usage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/Mysql4/Report/Collection.php
+++ b/app/code/core/Mage/SalesRule/Model/Mysql4/Report/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/SalesRule/Model/Mysql4/Report/Collection.php
+++ b/app/code/core/Mage/SalesRule/Model/Mysql4/Report/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/Mysql4/Report/Collection.php
+++ b/app/code/core/Mage/SalesRule/Model/Mysql4/Report/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/Mysql4/Report/Rule.php
+++ b/app/code/core/Mage/SalesRule/Model/Mysql4/Report/Rule.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/SalesRule/Model/Mysql4/Report/Rule.php
+++ b/app/code/core/Mage/SalesRule/Model/Mysql4/Report/Rule.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/Mysql4/Report/Rule.php
+++ b/app/code/core/Mage/SalesRule/Model/Mysql4/Report/Rule.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/Mysql4/Report/Updatedat/Collection.php
+++ b/app/code/core/Mage/SalesRule/Model/Mysql4/Report/Updatedat/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/SalesRule/Model/Mysql4/Report/Updatedat/Collection.php
+++ b/app/code/core/Mage/SalesRule/Model/Mysql4/Report/Updatedat/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/Mysql4/Report/Updatedat/Collection.php
+++ b/app/code/core/Mage/SalesRule/Model/Mysql4/Report/Updatedat/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/Mysql4/Rule.php
+++ b/app/code/core/Mage/SalesRule/Model/Mysql4/Rule.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/SalesRule/Model/Mysql4/Rule.php
+++ b/app/code/core/Mage/SalesRule/Model/Mysql4/Rule.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/Mysql4/Rule.php
+++ b/app/code/core/Mage/SalesRule/Model/Mysql4/Rule.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/Mysql4/Rule/Collection.php
+++ b/app/code/core/Mage/SalesRule/Model/Mysql4/Rule/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/SalesRule/Model/Mysql4/Rule/Collection.php
+++ b/app/code/core/Mage/SalesRule/Model/Mysql4/Rule/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/Mysql4/Rule/Collection.php
+++ b/app/code/core/Mage/SalesRule/Model/Mysql4/Rule/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/Mysql4/Rule/Customer.php
+++ b/app/code/core/Mage/SalesRule/Model/Mysql4/Rule/Customer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/SalesRule/Model/Mysql4/Rule/Customer.php
+++ b/app/code/core/Mage/SalesRule/Model/Mysql4/Rule/Customer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/Mysql4/Rule/Customer.php
+++ b/app/code/core/Mage/SalesRule/Model/Mysql4/Rule/Customer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/Mysql4/Rule/Customer/Collection.php
+++ b/app/code/core/Mage/SalesRule/Model/Mysql4/Rule/Customer/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/SalesRule/Model/Mysql4/Rule/Customer/Collection.php
+++ b/app/code/core/Mage/SalesRule/Model/Mysql4/Rule/Customer/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/Mysql4/Rule/Customer/Collection.php
+++ b/app/code/core/Mage/SalesRule/Model/Mysql4/Rule/Customer/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/Mysql4/Rule/Product.php
+++ b/app/code/core/Mage/SalesRule/Model/Mysql4/Rule/Product.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/SalesRule/Model/Mysql4/Rule/Product.php
+++ b/app/code/core/Mage/SalesRule/Model/Mysql4/Rule/Product.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/Mysql4/Rule/Product.php
+++ b/app/code/core/Mage/SalesRule/Model/Mysql4/Rule/Product.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/Mysql4/Rule/Product/Collection.php
+++ b/app/code/core/Mage/SalesRule/Model/Mysql4/Rule/Product/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/SalesRule/Model/Mysql4/Rule/Product/Collection.php
+++ b/app/code/core/Mage/SalesRule/Model/Mysql4/Rule/Product/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/Mysql4/Rule/Product/Collection.php
+++ b/app/code/core/Mage/SalesRule/Model/Mysql4/Rule/Product/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/Observer.php
+++ b/app/code/core/Mage/SalesRule/Model/Observer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/SalesRule/Model/Observer.php
+++ b/app/code/core/Mage/SalesRule/Model/Observer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/Observer.php
+++ b/app/code/core/Mage/SalesRule/Model/Observer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/Quote/Discount.php
+++ b/app/code/core/Mage/SalesRule/Model/Quote/Discount.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/SalesRule/Model/Quote/Discount.php
+++ b/app/code/core/Mage/SalesRule/Model/Quote/Discount.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/Quote/Discount.php
+++ b/app/code/core/Mage/SalesRule/Model/Quote/Discount.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/Quote/Freeshipping.php
+++ b/app/code/core/Mage/SalesRule/Model/Quote/Freeshipping.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/SalesRule/Model/Quote/Freeshipping.php
+++ b/app/code/core/Mage/SalesRule/Model/Quote/Freeshipping.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/Quote/Freeshipping.php
+++ b/app/code/core/Mage/SalesRule/Model/Quote/Freeshipping.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/Quote/Nominal/Discount.php
+++ b/app/code/core/Mage/SalesRule/Model/Quote/Nominal/Discount.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/SalesRule/Model/Quote/Nominal/Discount.php
+++ b/app/code/core/Mage/SalesRule/Model/Quote/Nominal/Discount.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/Quote/Nominal/Discount.php
+++ b/app/code/core/Mage/SalesRule/Model/Quote/Nominal/Discount.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/Resource/Coupon.php
+++ b/app/code/core/Mage/SalesRule/Model/Resource/Coupon.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/SalesRule/Model/Resource/Coupon.php
+++ b/app/code/core/Mage/SalesRule/Model/Resource/Coupon.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/Resource/Coupon.php
+++ b/app/code/core/Mage/SalesRule/Model/Resource/Coupon.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/Resource/Coupon/Collection.php
+++ b/app/code/core/Mage/SalesRule/Model/Resource/Coupon/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/SalesRule/Model/Resource/Coupon/Collection.php
+++ b/app/code/core/Mage/SalesRule/Model/Resource/Coupon/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/Resource/Coupon/Collection.php
+++ b/app/code/core/Mage/SalesRule/Model/Resource/Coupon/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/Resource/Coupon/Usage.php
+++ b/app/code/core/Mage/SalesRule/Model/Resource/Coupon/Usage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/SalesRule/Model/Resource/Coupon/Usage.php
+++ b/app/code/core/Mage/SalesRule/Model/Resource/Coupon/Usage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/Resource/Coupon/Usage.php
+++ b/app/code/core/Mage/SalesRule/Model/Resource/Coupon/Usage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/Resource/Report/Collection.php
+++ b/app/code/core/Mage/SalesRule/Model/Resource/Report/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/SalesRule/Model/Resource/Report/Collection.php
+++ b/app/code/core/Mage/SalesRule/Model/Resource/Report/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/Resource/Report/Collection.php
+++ b/app/code/core/Mage/SalesRule/Model/Resource/Report/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/Resource/Report/Rule.php
+++ b/app/code/core/Mage/SalesRule/Model/Resource/Report/Rule.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/SalesRule/Model/Resource/Report/Rule.php
+++ b/app/code/core/Mage/SalesRule/Model/Resource/Report/Rule.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/Resource/Report/Rule.php
+++ b/app/code/core/Mage/SalesRule/Model/Resource/Report/Rule.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/Resource/Report/Rule/Createdat.php
+++ b/app/code/core/Mage/SalesRule/Model/Resource/Report/Rule/Createdat.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/SalesRule/Model/Resource/Report/Rule/Createdat.php
+++ b/app/code/core/Mage/SalesRule/Model/Resource/Report/Rule/Createdat.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/Resource/Report/Rule/Createdat.php
+++ b/app/code/core/Mage/SalesRule/Model/Resource/Report/Rule/Createdat.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/Resource/Report/Rule/Updatedat.php
+++ b/app/code/core/Mage/SalesRule/Model/Resource/Report/Rule/Updatedat.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/SalesRule/Model/Resource/Report/Rule/Updatedat.php
+++ b/app/code/core/Mage/SalesRule/Model/Resource/Report/Rule/Updatedat.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/Resource/Report/Rule/Updatedat.php
+++ b/app/code/core/Mage/SalesRule/Model/Resource/Report/Rule/Updatedat.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/Resource/Report/Updatedat/Collection.php
+++ b/app/code/core/Mage/SalesRule/Model/Resource/Report/Updatedat/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/SalesRule/Model/Resource/Report/Updatedat/Collection.php
+++ b/app/code/core/Mage/SalesRule/Model/Resource/Report/Updatedat/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/Resource/Report/Updatedat/Collection.php
+++ b/app/code/core/Mage/SalesRule/Model/Resource/Report/Updatedat/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/Resource/Rule.php
+++ b/app/code/core/Mage/SalesRule/Model/Resource/Rule.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/SalesRule/Model/Resource/Rule.php
+++ b/app/code/core/Mage/SalesRule/Model/Resource/Rule.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/Resource/Rule.php
+++ b/app/code/core/Mage/SalesRule/Model/Resource/Rule.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/Resource/Rule/Collection.php
+++ b/app/code/core/Mage/SalesRule/Model/Resource/Rule/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/SalesRule/Model/Resource/Rule/Collection.php
+++ b/app/code/core/Mage/SalesRule/Model/Resource/Rule/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/Resource/Rule/Collection.php
+++ b/app/code/core/Mage/SalesRule/Model/Resource/Rule/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/Resource/Rule/Customer.php
+++ b/app/code/core/Mage/SalesRule/Model/Resource/Rule/Customer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/SalesRule/Model/Resource/Rule/Customer.php
+++ b/app/code/core/Mage/SalesRule/Model/Resource/Rule/Customer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/Resource/Rule/Customer.php
+++ b/app/code/core/Mage/SalesRule/Model/Resource/Rule/Customer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/Resource/Rule/Customer/Collection.php
+++ b/app/code/core/Mage/SalesRule/Model/Resource/Rule/Customer/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/SalesRule/Model/Resource/Rule/Customer/Collection.php
+++ b/app/code/core/Mage/SalesRule/Model/Resource/Rule/Customer/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/Resource/Rule/Customer/Collection.php
+++ b/app/code/core/Mage/SalesRule/Model/Resource/Rule/Customer/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/Resource/Rule/Product.php
+++ b/app/code/core/Mage/SalesRule/Model/Resource/Rule/Product.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/SalesRule/Model/Resource/Rule/Product.php
+++ b/app/code/core/Mage/SalesRule/Model/Resource/Rule/Product.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/Resource/Rule/Product.php
+++ b/app/code/core/Mage/SalesRule/Model/Resource/Rule/Product.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/Resource/Rule/Product/Collection.php
+++ b/app/code/core/Mage/SalesRule/Model/Resource/Rule/Product/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/SalesRule/Model/Resource/Rule/Product/Collection.php
+++ b/app/code/core/Mage/SalesRule/Model/Resource/Rule/Product/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/Resource/Rule/Product/Collection.php
+++ b/app/code/core/Mage/SalesRule/Model/Resource/Rule/Product/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/Rule.php
+++ b/app/code/core/Mage/SalesRule/Model/Rule.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/SalesRule/Model/Rule.php
+++ b/app/code/core/Mage/SalesRule/Model/Rule.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/Rule.php
+++ b/app/code/core/Mage/SalesRule/Model/Rule.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/Rule/Action/Collection.php
+++ b/app/code/core/Mage/SalesRule/Model/Rule/Action/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/SalesRule/Model/Rule/Action/Collection.php
+++ b/app/code/core/Mage/SalesRule/Model/Rule/Action/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/Rule/Action/Collection.php
+++ b/app/code/core/Mage/SalesRule/Model/Rule/Action/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/Rule/Action/Product.php
+++ b/app/code/core/Mage/SalesRule/Model/Rule/Action/Product.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/SalesRule/Model/Rule/Action/Product.php
+++ b/app/code/core/Mage/SalesRule/Model/Rule/Action/Product.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/Rule/Action/Product.php
+++ b/app/code/core/Mage/SalesRule/Model/Rule/Action/Product.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/Rule/Condition/Address.php
+++ b/app/code/core/Mage/SalesRule/Model/Rule/Condition/Address.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/SalesRule/Model/Rule/Condition/Address.php
+++ b/app/code/core/Mage/SalesRule/Model/Rule/Condition/Address.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/Rule/Condition/Address.php
+++ b/app/code/core/Mage/SalesRule/Model/Rule/Condition/Address.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/Rule/Condition/Combine.php
+++ b/app/code/core/Mage/SalesRule/Model/Rule/Condition/Combine.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/SalesRule/Model/Rule/Condition/Combine.php
+++ b/app/code/core/Mage/SalesRule/Model/Rule/Condition/Combine.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/Rule/Condition/Combine.php
+++ b/app/code/core/Mage/SalesRule/Model/Rule/Condition/Combine.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/Rule/Condition/Product.php
+++ b/app/code/core/Mage/SalesRule/Model/Rule/Condition/Product.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/SalesRule/Model/Rule/Condition/Product.php
+++ b/app/code/core/Mage/SalesRule/Model/Rule/Condition/Product.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/Rule/Condition/Product.php
+++ b/app/code/core/Mage/SalesRule/Model/Rule/Condition/Product.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/Rule/Condition/Product/Attribute/Assigned.php
+++ b/app/code/core/Mage/SalesRule/Model/Rule/Condition/Product/Attribute/Assigned.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/SalesRule/Model/Rule/Condition/Product/Attribute/Assigned.php
+++ b/app/code/core/Mage/SalesRule/Model/Rule/Condition/Product/Attribute/Assigned.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/Rule/Condition/Product/Attribute/Assigned.php
+++ b/app/code/core/Mage/SalesRule/Model/Rule/Condition/Product/Attribute/Assigned.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/Rule/Condition/Product/Combine.php
+++ b/app/code/core/Mage/SalesRule/Model/Rule/Condition/Product/Combine.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/SalesRule/Model/Rule/Condition/Product/Combine.php
+++ b/app/code/core/Mage/SalesRule/Model/Rule/Condition/Product/Combine.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/Rule/Condition/Product/Combine.php
+++ b/app/code/core/Mage/SalesRule/Model/Rule/Condition/Product/Combine.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/Rule/Condition/Product/Found.php
+++ b/app/code/core/Mage/SalesRule/Model/Rule/Condition/Product/Found.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/SalesRule/Model/Rule/Condition/Product/Found.php
+++ b/app/code/core/Mage/SalesRule/Model/Rule/Condition/Product/Found.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/Rule/Condition/Product/Found.php
+++ b/app/code/core/Mage/SalesRule/Model/Rule/Condition/Product/Found.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/Rule/Condition/Product/Subselect.php
+++ b/app/code/core/Mage/SalesRule/Model/Rule/Condition/Product/Subselect.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/SalesRule/Model/Rule/Condition/Product/Subselect.php
+++ b/app/code/core/Mage/SalesRule/Model/Rule/Condition/Product/Subselect.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/Rule/Condition/Product/Subselect.php
+++ b/app/code/core/Mage/SalesRule/Model/Rule/Condition/Product/Subselect.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/Rule/Customer.php
+++ b/app/code/core/Mage/SalesRule/Model/Rule/Customer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/SalesRule/Model/Rule/Customer.php
+++ b/app/code/core/Mage/SalesRule/Model/Rule/Customer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/Rule/Customer.php
+++ b/app/code/core/Mage/SalesRule/Model/Rule/Customer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/Rule/Product.php
+++ b/app/code/core/Mage/SalesRule/Model/Rule/Product.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/SalesRule/Model/Rule/Product.php
+++ b/app/code/core/Mage/SalesRule/Model/Rule/Product.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/Rule/Product.php
+++ b/app/code/core/Mage/SalesRule/Model/Rule/Product.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/System/Config/Source/Coupon/Format.php
+++ b/app/code/core/Mage/SalesRule/Model/System/Config/Source/Coupon/Format.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/SalesRule/Model/System/Config/Source/Coupon/Format.php
+++ b/app/code/core/Mage/SalesRule/Model/System/Config/Source/Coupon/Format.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/System/Config/Source/Coupon/Format.php
+++ b/app/code/core/Mage/SalesRule/Model/System/Config/Source/Coupon/Format.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/Validator.php
+++ b/app/code/core/Mage/SalesRule/Model/Validator.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/SalesRule/Model/Validator.php
+++ b/app/code/core/Mage/SalesRule/Model/Validator.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/Model/Validator.php
+++ b/app/code/core/Mage/SalesRule/Model/Validator.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/etc/adminhtml.xml
+++ b/app/code/core/Mage/SalesRule/etc/adminhtml.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/etc/adminhtml.xml
+++ b/app/code/core/Mage/SalesRule/etc/adminhtml.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/etc/adminhtml.xml
+++ b/app/code/core/Mage/SalesRule/etc/adminhtml.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/SalesRule/etc/config.xml
+++ b/app/code/core/Mage/SalesRule/etc/config.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/etc/config.xml
+++ b/app/code/core/Mage/SalesRule/etc/config.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/etc/config.xml
+++ b/app/code/core/Mage/SalesRule/etc/config.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/SalesRule/etc/system.xml
+++ b/app/code/core/Mage/SalesRule/etc/system.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/etc/system.xml
+++ b/app/code/core/Mage/SalesRule/etc/system.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/etc/system.xml
+++ b/app/code/core/Mage/SalesRule/etc/system.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/SalesRule/sql/salesrule_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/SalesRule/sql/salesrule_setup/install-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/SalesRule/sql/salesrule_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/SalesRule/sql/salesrule_setup/install-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/sql/salesrule_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/SalesRule/sql/salesrule_setup/install-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-install-0.7.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-install-0.7.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-install-0.7.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-install-1.4.0.0.0.php
+++ b/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-install-1.4.0.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-install-1.4.0.0.0.php
+++ b/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-install-1.4.0.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-install-1.4.0.0.0.php
+++ b/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-install-1.4.0.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-0.7.0-0.7.1.php
+++ b/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-0.7.0-0.7.1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-0.7.0-0.7.1.php
+++ b/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-0.7.0-0.7.1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-0.7.0-0.7.1.php
+++ b/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-0.7.0-0.7.1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-0.7.1-0.7.2.php
+++ b/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-0.7.1-0.7.2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-0.7.1-0.7.2.php
+++ b/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-0.7.1-0.7.2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-0.7.1-0.7.2.php
+++ b/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-0.7.1-0.7.2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-0.7.10-0.7.11.php
+++ b/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-0.7.10-0.7.11.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-0.7.10-0.7.11.php
+++ b/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-0.7.10-0.7.11.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-0.7.10-0.7.11.php
+++ b/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-0.7.10-0.7.11.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-0.7.11-0.7.12.php
+++ b/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-0.7.11-0.7.12.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-0.7.11-0.7.12.php
+++ b/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-0.7.11-0.7.12.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-0.7.11-0.7.12.php
+++ b/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-0.7.11-0.7.12.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-0.7.2-0.7.3.php
+++ b/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-0.7.2-0.7.3.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-0.7.2-0.7.3.php
+++ b/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-0.7.2-0.7.3.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-0.7.2-0.7.3.php
+++ b/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-0.7.2-0.7.3.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-0.7.3-0.7.4.php
+++ b/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-0.7.3-0.7.4.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-0.7.3-0.7.4.php
+++ b/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-0.7.3-0.7.4.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-0.7.3-0.7.4.php
+++ b/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-0.7.3-0.7.4.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-0.7.4-0.7.5.php
+++ b/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-0.7.4-0.7.5.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-0.7.4-0.7.5.php
+++ b/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-0.7.4-0.7.5.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-0.7.4-0.7.5.php
+++ b/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-0.7.4-0.7.5.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-0.7.5-0.7.6.php
+++ b/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-0.7.5-0.7.6.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-0.7.5-0.7.6.php
+++ b/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-0.7.5-0.7.6.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-0.7.5-0.7.6.php
+++ b/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-0.7.5-0.7.6.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-0.7.6-0.7.7.php
+++ b/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-0.7.6-0.7.7.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-0.7.6-0.7.7.php
+++ b/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-0.7.6-0.7.7.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-0.7.6-0.7.7.php
+++ b/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-0.7.6-0.7.7.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-0.7.7-0.7.8.php
+++ b/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-0.7.7-0.7.8.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-0.7.7-0.7.8.php
+++ b/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-0.7.7-0.7.8.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-0.7.7-0.7.8.php
+++ b/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-0.7.7-0.7.8.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-0.7.8-0.7.9.php
+++ b/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-0.7.8-0.7.9.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-0.7.8-0.7.9.php
+++ b/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-0.7.8-0.7.9.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-0.7.8-0.7.9.php
+++ b/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-0.7.8-0.7.9.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-0.7.9-0.7.10.php
+++ b/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-0.7.9-0.7.10.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-0.7.9-0.7.10.php
+++ b/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-0.7.9-0.7.10.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-0.7.9-0.7.10.php
+++ b/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-0.7.9-0.7.10.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-1.4.0.0.0-1.4.0.0.1.php
+++ b/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-1.4.0.0.0-1.4.0.0.1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-1.4.0.0.0-1.4.0.0.1.php
+++ b/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-1.4.0.0.0-1.4.0.0.1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-1.4.0.0.0-1.4.0.0.1.php
+++ b/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-1.4.0.0.0-1.4.0.0.1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-1.4.0.0.1-1.4.0.0.2.php
+++ b/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-1.4.0.0.1-1.4.0.0.2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-1.4.0.0.1-1.4.0.0.2.php
+++ b/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-1.4.0.0.1-1.4.0.0.2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-1.4.0.0.1-1.4.0.0.2.php
+++ b/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-1.4.0.0.1-1.4.0.0.2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-1.4.0.0.2-1.4.0.0.3.php
+++ b/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-1.4.0.0.2-1.4.0.0.3.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-1.4.0.0.2-1.4.0.0.3.php
+++ b/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-1.4.0.0.2-1.4.0.0.3.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-1.4.0.0.2-1.4.0.0.3.php
+++ b/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-1.4.0.0.2-1.4.0.0.3.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-1.4.0.0.3-1.4.0.0.4.php
+++ b/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-1.4.0.0.3-1.4.0.0.4.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-1.4.0.0.3-1.4.0.0.4.php
+++ b/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-1.4.0.0.3-1.4.0.0.4.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-1.4.0.0.3-1.4.0.0.4.php
+++ b/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-1.4.0.0.3-1.4.0.0.4.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-1.4.0.0.4-1.4.0.0.5.php
+++ b/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-1.4.0.0.4-1.4.0.0.5.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-1.4.0.0.4-1.4.0.0.5.php
+++ b/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-1.4.0.0.4-1.4.0.0.5.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-1.4.0.0.4-1.4.0.0.5.php
+++ b/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-1.4.0.0.4-1.4.0.0.5.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-1.4.0.0.5-1.4.0.0.6.php
+++ b/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-1.4.0.0.5-1.4.0.0.6.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-1.4.0.0.5-1.4.0.0.6.php
+++ b/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-1.4.0.0.5-1.4.0.0.6.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-1.4.0.0.5-1.4.0.0.6.php
+++ b/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-1.4.0.0.5-1.4.0.0.6.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/SalesRule/sql/salesrule_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/sql/salesrule_setup/upgrade-1.6.0.0-1.6.0.1.php
+++ b/app/code/core/Mage/SalesRule/sql/salesrule_setup/upgrade-1.6.0.0-1.6.0.1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/SalesRule/sql/salesrule_setup/upgrade-1.6.0.0-1.6.0.1.php
+++ b/app/code/core/Mage/SalesRule/sql/salesrule_setup/upgrade-1.6.0.0-1.6.0.1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/sql/salesrule_setup/upgrade-1.6.0.0-1.6.0.1.php
+++ b/app/code/core/Mage/SalesRule/sql/salesrule_setup/upgrade-1.6.0.0-1.6.0.1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/sql/salesrule_setup/upgrade-1.6.0.1-1.6.0.2.php
+++ b/app/code/core/Mage/SalesRule/sql/salesrule_setup/upgrade-1.6.0.1-1.6.0.2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/SalesRule/sql/salesrule_setup/upgrade-1.6.0.1-1.6.0.2.php
+++ b/app/code/core/Mage/SalesRule/sql/salesrule_setup/upgrade-1.6.0.1-1.6.0.2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/sql/salesrule_setup/upgrade-1.6.0.1-1.6.0.2.php
+++ b/app/code/core/Mage/SalesRule/sql/salesrule_setup/upgrade-1.6.0.1-1.6.0.2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/sql/salesrule_setup/upgrade-1.6.0.2-1.6.0.3.php
+++ b/app/code/core/Mage/SalesRule/sql/salesrule_setup/upgrade-1.6.0.2-1.6.0.3.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/SalesRule/sql/salesrule_setup/upgrade-1.6.0.2-1.6.0.3.php
+++ b/app/code/core/Mage/SalesRule/sql/salesrule_setup/upgrade-1.6.0.2-1.6.0.3.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/SalesRule/sql/salesrule_setup/upgrade-1.6.0.2-1.6.0.3.php
+++ b/app/code/core/Mage/SalesRule/sql/salesrule_setup/upgrade-1.6.0.2-1.6.0.3.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/code/core/Mage/Sendfriend/Block/Send.php
+++ b/app/code/core/Mage/Sendfriend/Block/Send.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sendfriend

--- a/app/code/core/Mage/Sendfriend/Block/Send.php
+++ b/app/code/core/Mage/Sendfriend/Block/Send.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sendfriend/Block/Send.php
+++ b/app/code/core/Mage/Sendfriend/Block/Send.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sendfriend

--- a/app/code/core/Mage/Sendfriend/Helper/Data.php
+++ b/app/code/core/Mage/Sendfriend/Helper/Data.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sendfriend

--- a/app/code/core/Mage/Sendfriend/Helper/Data.php
+++ b/app/code/core/Mage/Sendfriend/Helper/Data.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sendfriend/Helper/Data.php
+++ b/app/code/core/Mage/Sendfriend/Helper/Data.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sendfriend

--- a/app/code/core/Mage/Sendfriend/Model/Mysql4/Sendfriend.php
+++ b/app/code/core/Mage/Sendfriend/Model/Mysql4/Sendfriend.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sendfriend

--- a/app/code/core/Mage/Sendfriend/Model/Mysql4/Sendfriend.php
+++ b/app/code/core/Mage/Sendfriend/Model/Mysql4/Sendfriend.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sendfriend/Model/Mysql4/Sendfriend.php
+++ b/app/code/core/Mage/Sendfriend/Model/Mysql4/Sendfriend.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sendfriend

--- a/app/code/core/Mage/Sendfriend/Model/Mysql4/Sendfriend/Collection.php
+++ b/app/code/core/Mage/Sendfriend/Model/Mysql4/Sendfriend/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sendfriend

--- a/app/code/core/Mage/Sendfriend/Model/Mysql4/Sendfriend/Collection.php
+++ b/app/code/core/Mage/Sendfriend/Model/Mysql4/Sendfriend/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sendfriend/Model/Mysql4/Sendfriend/Collection.php
+++ b/app/code/core/Mage/Sendfriend/Model/Mysql4/Sendfriend/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sendfriend

--- a/app/code/core/Mage/Sendfriend/Model/Mysql4/Setup.php
+++ b/app/code/core/Mage/Sendfriend/Model/Mysql4/Setup.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sendfriend

--- a/app/code/core/Mage/Sendfriend/Model/Mysql4/Setup.php
+++ b/app/code/core/Mage/Sendfriend/Model/Mysql4/Setup.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sendfriend/Model/Mysql4/Setup.php
+++ b/app/code/core/Mage/Sendfriend/Model/Mysql4/Setup.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sendfriend

--- a/app/code/core/Mage/Sendfriend/Model/Observer.php
+++ b/app/code/core/Mage/Sendfriend/Model/Observer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sendfriend

--- a/app/code/core/Mage/Sendfriend/Model/Observer.php
+++ b/app/code/core/Mage/Sendfriend/Model/Observer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sendfriend/Model/Observer.php
+++ b/app/code/core/Mage/Sendfriend/Model/Observer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sendfriend

--- a/app/code/core/Mage/Sendfriend/Model/Resource/Sendfriend.php
+++ b/app/code/core/Mage/Sendfriend/Model/Resource/Sendfriend.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sendfriend

--- a/app/code/core/Mage/Sendfriend/Model/Resource/Sendfriend.php
+++ b/app/code/core/Mage/Sendfriend/Model/Resource/Sendfriend.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sendfriend/Model/Resource/Sendfriend.php
+++ b/app/code/core/Mage/Sendfriend/Model/Resource/Sendfriend.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sendfriend

--- a/app/code/core/Mage/Sendfriend/Model/Resource/Sendfriend/Collection.php
+++ b/app/code/core/Mage/Sendfriend/Model/Resource/Sendfriend/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sendfriend

--- a/app/code/core/Mage/Sendfriend/Model/Resource/Sendfriend/Collection.php
+++ b/app/code/core/Mage/Sendfriend/Model/Resource/Sendfriend/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sendfriend/Model/Resource/Sendfriend/Collection.php
+++ b/app/code/core/Mage/Sendfriend/Model/Resource/Sendfriend/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sendfriend

--- a/app/code/core/Mage/Sendfriend/Model/Resource/Setup.php
+++ b/app/code/core/Mage/Sendfriend/Model/Resource/Setup.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sendfriend

--- a/app/code/core/Mage/Sendfriend/Model/Resource/Setup.php
+++ b/app/code/core/Mage/Sendfriend/Model/Resource/Setup.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sendfriend/Model/Resource/Setup.php
+++ b/app/code/core/Mage/Sendfriend/Model/Resource/Setup.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sendfriend

--- a/app/code/core/Mage/Sendfriend/Model/Sendfriend.php
+++ b/app/code/core/Mage/Sendfriend/Model/Sendfriend.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sendfriend

--- a/app/code/core/Mage/Sendfriend/Model/Sendfriend.php
+++ b/app/code/core/Mage/Sendfriend/Model/Sendfriend.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sendfriend/Model/Sendfriend.php
+++ b/app/code/core/Mage/Sendfriend/Model/Sendfriend.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sendfriend

--- a/app/code/core/Mage/Sendfriend/controllers/ProductController.php
+++ b/app/code/core/Mage/Sendfriend/controllers/ProductController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sendfriend

--- a/app/code/core/Mage/Sendfriend/controllers/ProductController.php
+++ b/app/code/core/Mage/Sendfriend/controllers/ProductController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sendfriend/controllers/ProductController.php
+++ b/app/code/core/Mage/Sendfriend/controllers/ProductController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sendfriend

--- a/app/code/core/Mage/Sendfriend/etc/config.xml
+++ b/app/code/core/Mage/Sendfriend/etc/config.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sendfriend

--- a/app/code/core/Mage/Sendfriend/etc/config.xml
+++ b/app/code/core/Mage/Sendfriend/etc/config.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sendfriend

--- a/app/code/core/Mage/Sendfriend/etc/config.xml
+++ b/app/code/core/Mage/Sendfriend/etc/config.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sendfriend/etc/system.xml
+++ b/app/code/core/Mage/Sendfriend/etc/system.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sendfriend

--- a/app/code/core/Mage/Sendfriend/etc/system.xml
+++ b/app/code/core/Mage/Sendfriend/etc/system.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sendfriend

--- a/app/code/core/Mage/Sendfriend/etc/system.xml
+++ b/app/code/core/Mage/Sendfriend/etc/system.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sendfriend/sql/sendfriend_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Sendfriend/sql/sendfriend_setup/install-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sendfriend

--- a/app/code/core/Mage/Sendfriend/sql/sendfriend_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Sendfriend/sql/sendfriend_setup/install-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sendfriend/sql/sendfriend_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Sendfriend/sql/sendfriend_setup/install-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sendfriend

--- a/app/code/core/Mage/Sendfriend/sql/sendfriend_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/Sendfriend/sql/sendfriend_setup/mysql4-install-0.7.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sendfriend

--- a/app/code/core/Mage/Sendfriend/sql/sendfriend_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/Sendfriend/sql/sendfriend_setup/mysql4-install-0.7.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sendfriend/sql/sendfriend_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/Sendfriend/sql/sendfriend_setup/mysql4-install-0.7.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sendfriend

--- a/app/code/core/Mage/Sendfriend/sql/sendfriend_setup/mysql4-upgrade-0.7.1-0.7.2.php
+++ b/app/code/core/Mage/Sendfriend/sql/sendfriend_setup/mysql4-upgrade-0.7.1-0.7.2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sendfriend

--- a/app/code/core/Mage/Sendfriend/sql/sendfriend_setup/mysql4-upgrade-0.7.1-0.7.2.php
+++ b/app/code/core/Mage/Sendfriend/sql/sendfriend_setup/mysql4-upgrade-0.7.1-0.7.2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sendfriend/sql/sendfriend_setup/mysql4-upgrade-0.7.1-0.7.2.php
+++ b/app/code/core/Mage/Sendfriend/sql/sendfriend_setup/mysql4-upgrade-0.7.1-0.7.2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sendfriend

--- a/app/code/core/Mage/Sendfriend/sql/sendfriend_setup/mysql4-upgrade-0.7.2-0.7.3.php
+++ b/app/code/core/Mage/Sendfriend/sql/sendfriend_setup/mysql4-upgrade-0.7.2-0.7.3.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sendfriend

--- a/app/code/core/Mage/Sendfriend/sql/sendfriend_setup/mysql4-upgrade-0.7.2-0.7.3.php
+++ b/app/code/core/Mage/Sendfriend/sql/sendfriend_setup/mysql4-upgrade-0.7.2-0.7.3.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sendfriend/sql/sendfriend_setup/mysql4-upgrade-0.7.2-0.7.3.php
+++ b/app/code/core/Mage/Sendfriend/sql/sendfriend_setup/mysql4-upgrade-0.7.2-0.7.3.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sendfriend

--- a/app/code/core/Mage/Sendfriend/sql/sendfriend_setup/mysql4-upgrade-0.7.3-0.7.4.php
+++ b/app/code/core/Mage/Sendfriend/sql/sendfriend_setup/mysql4-upgrade-0.7.3-0.7.4.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sendfriend

--- a/app/code/core/Mage/Sendfriend/sql/sendfriend_setup/mysql4-upgrade-0.7.3-0.7.4.php
+++ b/app/code/core/Mage/Sendfriend/sql/sendfriend_setup/mysql4-upgrade-0.7.3-0.7.4.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sendfriend/sql/sendfriend_setup/mysql4-upgrade-0.7.3-0.7.4.php
+++ b/app/code/core/Mage/Sendfriend/sql/sendfriend_setup/mysql4-upgrade-0.7.3-0.7.4.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sendfriend

--- a/app/code/core/Mage/Sendfriend/sql/sendfriend_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/Sendfriend/sql/sendfriend_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sendfriend

--- a/app/code/core/Mage/Sendfriend/sql/sendfriend_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/Sendfriend/sql/sendfriend_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sendfriend/sql/sendfriend_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/Sendfriend/sql/sendfriend_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sendfriend

--- a/app/code/core/Mage/Sendfriend/sql/sendfriend_setup/mysql4-upgrade-1.6.0.0-1.6.0.1.php
+++ b/app/code/core/Mage/Sendfriend/sql/sendfriend_setup/mysql4-upgrade-1.6.0.0-1.6.0.1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sendfriend

--- a/app/code/core/Mage/Sendfriend/sql/sendfriend_setup/mysql4-upgrade-1.6.0.0-1.6.0.1.php
+++ b/app/code/core/Mage/Sendfriend/sql/sendfriend_setup/mysql4-upgrade-1.6.0.0-1.6.0.1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sendfriend/sql/sendfriend_setup/mysql4-upgrade-1.6.0.0-1.6.0.1.php
+++ b/app/code/core/Mage/Sendfriend/sql/sendfriend_setup/mysql4-upgrade-1.6.0.0-1.6.0.1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sendfriend

--- a/app/code/core/Mage/Shipping/Block/Tracking/Ajax.php
+++ b/app/code/core/Mage/Shipping/Block/Tracking/Ajax.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Shipping/Block/Tracking/Ajax.php
+++ b/app/code/core/Mage/Shipping/Block/Tracking/Ajax.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Shipping

--- a/app/code/core/Mage/Shipping/Block/Tracking/Ajax.php
+++ b/app/code/core/Mage/Shipping/Block/Tracking/Ajax.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Shipping

--- a/app/code/core/Mage/Shipping/Block/Tracking/Popup.php
+++ b/app/code/core/Mage/Shipping/Block/Tracking/Popup.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Shipping/Block/Tracking/Popup.php
+++ b/app/code/core/Mage/Shipping/Block/Tracking/Popup.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Shipping

--- a/app/code/core/Mage/Shipping/Block/Tracking/Popup.php
+++ b/app/code/core/Mage/Shipping/Block/Tracking/Popup.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Shipping

--- a/app/code/core/Mage/Shipping/Exception.php
+++ b/app/code/core/Mage/Shipping/Exception.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Shipping/Exception.php
+++ b/app/code/core/Mage/Shipping/Exception.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Shipping

--- a/app/code/core/Mage/Shipping/Exception.php
+++ b/app/code/core/Mage/Shipping/Exception.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Shipping

--- a/app/code/core/Mage/Shipping/Helper/Data.php
+++ b/app/code/core/Mage/Shipping/Helper/Data.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Shipping/Helper/Data.php
+++ b/app/code/core/Mage/Shipping/Helper/Data.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Shipping

--- a/app/code/core/Mage/Shipping/Helper/Data.php
+++ b/app/code/core/Mage/Shipping/Helper/Data.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Shipping

--- a/app/code/core/Mage/Shipping/Model/Carrier/Abstract.php
+++ b/app/code/core/Mage/Shipping/Model/Carrier/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Shipping/Model/Carrier/Abstract.php
+++ b/app/code/core/Mage/Shipping/Model/Carrier/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Shipping

--- a/app/code/core/Mage/Shipping/Model/Carrier/Abstract.php
+++ b/app/code/core/Mage/Shipping/Model/Carrier/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Shipping

--- a/app/code/core/Mage/Shipping/Model/Carrier/Flatrate.php
+++ b/app/code/core/Mage/Shipping/Model/Carrier/Flatrate.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Shipping/Model/Carrier/Flatrate.php
+++ b/app/code/core/Mage/Shipping/Model/Carrier/Flatrate.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Shipping

--- a/app/code/core/Mage/Shipping/Model/Carrier/Flatrate.php
+++ b/app/code/core/Mage/Shipping/Model/Carrier/Flatrate.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Shipping

--- a/app/code/core/Mage/Shipping/Model/Carrier/Freeshipping.php
+++ b/app/code/core/Mage/Shipping/Model/Carrier/Freeshipping.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Shipping/Model/Carrier/Freeshipping.php
+++ b/app/code/core/Mage/Shipping/Model/Carrier/Freeshipping.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Shipping

--- a/app/code/core/Mage/Shipping/Model/Carrier/Freeshipping.php
+++ b/app/code/core/Mage/Shipping/Model/Carrier/Freeshipping.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Shipping

--- a/app/code/core/Mage/Shipping/Model/Carrier/Interface.php
+++ b/app/code/core/Mage/Shipping/Model/Carrier/Interface.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Shipping/Model/Carrier/Interface.php
+++ b/app/code/core/Mage/Shipping/Model/Carrier/Interface.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Shipping

--- a/app/code/core/Mage/Shipping/Model/Carrier/Interface.php
+++ b/app/code/core/Mage/Shipping/Model/Carrier/Interface.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Shipping

--- a/app/code/core/Mage/Shipping/Model/Carrier/Pickup.php
+++ b/app/code/core/Mage/Shipping/Model/Carrier/Pickup.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Shipping/Model/Carrier/Pickup.php
+++ b/app/code/core/Mage/Shipping/Model/Carrier/Pickup.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Shipping

--- a/app/code/core/Mage/Shipping/Model/Carrier/Pickup.php
+++ b/app/code/core/Mage/Shipping/Model/Carrier/Pickup.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Shipping

--- a/app/code/core/Mage/Shipping/Model/Carrier/Tablerate.php
+++ b/app/code/core/Mage/Shipping/Model/Carrier/Tablerate.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Shipping/Model/Carrier/Tablerate.php
+++ b/app/code/core/Mage/Shipping/Model/Carrier/Tablerate.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Shipping

--- a/app/code/core/Mage/Shipping/Model/Carrier/Tablerate.php
+++ b/app/code/core/Mage/Shipping/Model/Carrier/Tablerate.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Shipping

--- a/app/code/core/Mage/Shipping/Model/Config.php
+++ b/app/code/core/Mage/Shipping/Model/Config.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Shipping/Model/Config.php
+++ b/app/code/core/Mage/Shipping/Model/Config.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Shipping

--- a/app/code/core/Mage/Shipping/Model/Config.php
+++ b/app/code/core/Mage/Shipping/Model/Config.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Shipping

--- a/app/code/core/Mage/Shipping/Model/Info.php
+++ b/app/code/core/Mage/Shipping/Model/Info.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Shipping/Model/Info.php
+++ b/app/code/core/Mage/Shipping/Model/Info.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Shipping

--- a/app/code/core/Mage/Shipping/Model/Info.php
+++ b/app/code/core/Mage/Shipping/Model/Info.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Shipping

--- a/app/code/core/Mage/Shipping/Model/Mysql4/Carrier/Tablerate.php
+++ b/app/code/core/Mage/Shipping/Model/Mysql4/Carrier/Tablerate.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Shipping/Model/Mysql4/Carrier/Tablerate.php
+++ b/app/code/core/Mage/Shipping/Model/Mysql4/Carrier/Tablerate.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Shipping

--- a/app/code/core/Mage/Shipping/Model/Mysql4/Carrier/Tablerate.php
+++ b/app/code/core/Mage/Shipping/Model/Mysql4/Carrier/Tablerate.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Shipping

--- a/app/code/core/Mage/Shipping/Model/Mysql4/Carrier/Tablerate/Collection.php
+++ b/app/code/core/Mage/Shipping/Model/Mysql4/Carrier/Tablerate/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Shipping/Model/Mysql4/Carrier/Tablerate/Collection.php
+++ b/app/code/core/Mage/Shipping/Model/Mysql4/Carrier/Tablerate/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Shipping

--- a/app/code/core/Mage/Shipping/Model/Mysql4/Carrier/Tablerate/Collection.php
+++ b/app/code/core/Mage/Shipping/Model/Mysql4/Carrier/Tablerate/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Shipping

--- a/app/code/core/Mage/Shipping/Model/Rate/Abstract.php
+++ b/app/code/core/Mage/Shipping/Model/Rate/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Shipping/Model/Rate/Abstract.php
+++ b/app/code/core/Mage/Shipping/Model/Rate/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Shipping

--- a/app/code/core/Mage/Shipping/Model/Rate/Abstract.php
+++ b/app/code/core/Mage/Shipping/Model/Rate/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Shipping

--- a/app/code/core/Mage/Shipping/Model/Rate/Request.php
+++ b/app/code/core/Mage/Shipping/Model/Rate/Request.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Shipping/Model/Rate/Request.php
+++ b/app/code/core/Mage/Shipping/Model/Rate/Request.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Shipping

--- a/app/code/core/Mage/Shipping/Model/Rate/Request.php
+++ b/app/code/core/Mage/Shipping/Model/Rate/Request.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Shipping

--- a/app/code/core/Mage/Shipping/Model/Rate/Result.php
+++ b/app/code/core/Mage/Shipping/Model/Rate/Result.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Shipping/Model/Rate/Result.php
+++ b/app/code/core/Mage/Shipping/Model/Rate/Result.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Shipping

--- a/app/code/core/Mage/Shipping/Model/Rate/Result.php
+++ b/app/code/core/Mage/Shipping/Model/Rate/Result.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Shipping

--- a/app/code/core/Mage/Shipping/Model/Rate/Result/Abstract.php
+++ b/app/code/core/Mage/Shipping/Model/Rate/Result/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Shipping/Model/Rate/Result/Abstract.php
+++ b/app/code/core/Mage/Shipping/Model/Rate/Result/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Shipping

--- a/app/code/core/Mage/Shipping/Model/Rate/Result/Abstract.php
+++ b/app/code/core/Mage/Shipping/Model/Rate/Result/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Shipping

--- a/app/code/core/Mage/Shipping/Model/Rate/Result/Error.php
+++ b/app/code/core/Mage/Shipping/Model/Rate/Result/Error.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Shipping/Model/Rate/Result/Error.php
+++ b/app/code/core/Mage/Shipping/Model/Rate/Result/Error.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Shipping

--- a/app/code/core/Mage/Shipping/Model/Rate/Result/Error.php
+++ b/app/code/core/Mage/Shipping/Model/Rate/Result/Error.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Shipping

--- a/app/code/core/Mage/Shipping/Model/Rate/Result/Method.php
+++ b/app/code/core/Mage/Shipping/Model/Rate/Result/Method.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Shipping/Model/Rate/Result/Method.php
+++ b/app/code/core/Mage/Shipping/Model/Rate/Result/Method.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Shipping

--- a/app/code/core/Mage/Shipping/Model/Rate/Result/Method.php
+++ b/app/code/core/Mage/Shipping/Model/Rate/Result/Method.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Shipping

--- a/app/code/core/Mage/Shipping/Model/Resource/Carrier/Tablerate.php
+++ b/app/code/core/Mage/Shipping/Model/Resource/Carrier/Tablerate.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Shipping/Model/Resource/Carrier/Tablerate.php
+++ b/app/code/core/Mage/Shipping/Model/Resource/Carrier/Tablerate.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Shipping

--- a/app/code/core/Mage/Shipping/Model/Resource/Carrier/Tablerate.php
+++ b/app/code/core/Mage/Shipping/Model/Resource/Carrier/Tablerate.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Shipping

--- a/app/code/core/Mage/Shipping/Model/Resource/Carrier/Tablerate/Collection.php
+++ b/app/code/core/Mage/Shipping/Model/Resource/Carrier/Tablerate/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Shipping/Model/Resource/Carrier/Tablerate/Collection.php
+++ b/app/code/core/Mage/Shipping/Model/Resource/Carrier/Tablerate/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Shipping

--- a/app/code/core/Mage/Shipping/Model/Resource/Carrier/Tablerate/Collection.php
+++ b/app/code/core/Mage/Shipping/Model/Resource/Carrier/Tablerate/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Shipping

--- a/app/code/core/Mage/Shipping/Model/Shipment/Request.php
+++ b/app/code/core/Mage/Shipping/Model/Shipment/Request.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Shipping/Model/Shipment/Request.php
+++ b/app/code/core/Mage/Shipping/Model/Shipment/Request.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Shipping

--- a/app/code/core/Mage/Shipping/Model/Shipment/Request.php
+++ b/app/code/core/Mage/Shipping/Model/Shipment/Request.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Shipping

--- a/app/code/core/Mage/Shipping/Model/Shipment/Return.php
+++ b/app/code/core/Mage/Shipping/Model/Shipment/Return.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Shipping/Model/Shipment/Return.php
+++ b/app/code/core/Mage/Shipping/Model/Shipment/Return.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Shipping

--- a/app/code/core/Mage/Shipping/Model/Shipment/Return.php
+++ b/app/code/core/Mage/Shipping/Model/Shipment/Return.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Shipping

--- a/app/code/core/Mage/Shipping/Model/Shipping.php
+++ b/app/code/core/Mage/Shipping/Model/Shipping.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Shipping/Model/Shipping.php
+++ b/app/code/core/Mage/Shipping/Model/Shipping.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Shipping

--- a/app/code/core/Mage/Shipping/Model/Shipping.php
+++ b/app/code/core/Mage/Shipping/Model/Shipping.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Shipping

--- a/app/code/core/Mage/Shipping/Model/Source/HandlingAction.php
+++ b/app/code/core/Mage/Shipping/Model/Source/HandlingAction.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Shipping/Model/Source/HandlingAction.php
+++ b/app/code/core/Mage/Shipping/Model/Source/HandlingAction.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Shipping

--- a/app/code/core/Mage/Shipping/Model/Source/HandlingAction.php
+++ b/app/code/core/Mage/Shipping/Model/Source/HandlingAction.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Shipping

--- a/app/code/core/Mage/Shipping/Model/Source/HandlingType.php
+++ b/app/code/core/Mage/Shipping/Model/Source/HandlingType.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Shipping/Model/Source/HandlingType.php
+++ b/app/code/core/Mage/Shipping/Model/Source/HandlingType.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Shipping

--- a/app/code/core/Mage/Shipping/Model/Source/HandlingType.php
+++ b/app/code/core/Mage/Shipping/Model/Source/HandlingType.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Shipping

--- a/app/code/core/Mage/Shipping/Model/Tracking/Result.php
+++ b/app/code/core/Mage/Shipping/Model/Tracking/Result.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Shipping/Model/Tracking/Result.php
+++ b/app/code/core/Mage/Shipping/Model/Tracking/Result.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Shipping

--- a/app/code/core/Mage/Shipping/Model/Tracking/Result.php
+++ b/app/code/core/Mage/Shipping/Model/Tracking/Result.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Shipping

--- a/app/code/core/Mage/Shipping/Model/Tracking/Result/Abstract.php
+++ b/app/code/core/Mage/Shipping/Model/Tracking/Result/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Shipping/Model/Tracking/Result/Abstract.php
+++ b/app/code/core/Mage/Shipping/Model/Tracking/Result/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Shipping

--- a/app/code/core/Mage/Shipping/Model/Tracking/Result/Abstract.php
+++ b/app/code/core/Mage/Shipping/Model/Tracking/Result/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Shipping

--- a/app/code/core/Mage/Shipping/Model/Tracking/Result/Error.php
+++ b/app/code/core/Mage/Shipping/Model/Tracking/Result/Error.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Shipping/Model/Tracking/Result/Error.php
+++ b/app/code/core/Mage/Shipping/Model/Tracking/Result/Error.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Shipping

--- a/app/code/core/Mage/Shipping/Model/Tracking/Result/Error.php
+++ b/app/code/core/Mage/Shipping/Model/Tracking/Result/Error.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Shipping

--- a/app/code/core/Mage/Shipping/Model/Tracking/Result/Status.php
+++ b/app/code/core/Mage/Shipping/Model/Tracking/Result/Status.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Shipping/Model/Tracking/Result/Status.php
+++ b/app/code/core/Mage/Shipping/Model/Tracking/Result/Status.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Shipping

--- a/app/code/core/Mage/Shipping/Model/Tracking/Result/Status.php
+++ b/app/code/core/Mage/Shipping/Model/Tracking/Result/Status.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Shipping

--- a/app/code/core/Mage/Shipping/controllers/TrackingController.php
+++ b/app/code/core/Mage/Shipping/controllers/TrackingController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Shipping/controllers/TrackingController.php
+++ b/app/code/core/Mage/Shipping/controllers/TrackingController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Shipping

--- a/app/code/core/Mage/Shipping/controllers/TrackingController.php
+++ b/app/code/core/Mage/Shipping/controllers/TrackingController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Shipping

--- a/app/code/core/Mage/Shipping/etc/adminhtml.xml
+++ b/app/code/core/Mage/Shipping/etc/adminhtml.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Shipping

--- a/app/code/core/Mage/Shipping/etc/adminhtml.xml
+++ b/app/code/core/Mage/Shipping/etc/adminhtml.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Shipping

--- a/app/code/core/Mage/Shipping/etc/adminhtml.xml
+++ b/app/code/core/Mage/Shipping/etc/adminhtml.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Shipping/etc/config.xml
+++ b/app/code/core/Mage/Shipping/etc/config.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Shipping

--- a/app/code/core/Mage/Shipping/etc/config.xml
+++ b/app/code/core/Mage/Shipping/etc/config.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Shipping

--- a/app/code/core/Mage/Shipping/etc/config.xml
+++ b/app/code/core/Mage/Shipping/etc/config.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Shipping/etc/system.xml
+++ b/app/code/core/Mage/Shipping/etc/system.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Shipping

--- a/app/code/core/Mage/Shipping/etc/system.xml
+++ b/app/code/core/Mage/Shipping/etc/system.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Shipping

--- a/app/code/core/Mage/Shipping/etc/system.xml
+++ b/app/code/core/Mage/Shipping/etc/system.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Shipping/sql/shipping_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Shipping/sql/shipping_setup/install-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Shipping/sql/shipping_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Shipping/sql/shipping_setup/install-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Shipping

--- a/app/code/core/Mage/Shipping/sql/shipping_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Shipping/sql/shipping_setup/install-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Shipping

--- a/app/code/core/Mage/Shipping/sql/shipping_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/Shipping/sql/shipping_setup/mysql4-install-0.7.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Shipping/sql/shipping_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/Shipping/sql/shipping_setup/mysql4-install-0.7.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Shipping

--- a/app/code/core/Mage/Shipping/sql/shipping_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/Shipping/sql/shipping_setup/mysql4-install-0.7.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Shipping

--- a/app/code/core/Mage/Shipping/sql/shipping_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/Shipping/sql/shipping_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Shipping/sql/shipping_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/Shipping/sql/shipping_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Shipping

--- a/app/code/core/Mage/Shipping/sql/shipping_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/Shipping/sql/shipping_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Shipping

--- a/app/code/core/Mage/Sitemap/Helper/Data.php
+++ b/app/code/core/Mage/Sitemap/Helper/Data.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sitemap/Helper/Data.php
+++ b/app/code/core/Mage/Sitemap/Helper/Data.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sitemap

--- a/app/code/core/Mage/Sitemap/Helper/Data.php
+++ b/app/code/core/Mage/Sitemap/Helper/Data.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sitemap

--- a/app/code/core/Mage/Sitemap/Model/Mysql4/Catalog/Category.php
+++ b/app/code/core/Mage/Sitemap/Model/Mysql4/Catalog/Category.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sitemap/Model/Mysql4/Catalog/Category.php
+++ b/app/code/core/Mage/Sitemap/Model/Mysql4/Catalog/Category.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sitemap

--- a/app/code/core/Mage/Sitemap/Model/Mysql4/Catalog/Category.php
+++ b/app/code/core/Mage/Sitemap/Model/Mysql4/Catalog/Category.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sitemap

--- a/app/code/core/Mage/Sitemap/Model/Mysql4/Catalog/Product.php
+++ b/app/code/core/Mage/Sitemap/Model/Mysql4/Catalog/Product.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sitemap/Model/Mysql4/Catalog/Product.php
+++ b/app/code/core/Mage/Sitemap/Model/Mysql4/Catalog/Product.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sitemap

--- a/app/code/core/Mage/Sitemap/Model/Mysql4/Catalog/Product.php
+++ b/app/code/core/Mage/Sitemap/Model/Mysql4/Catalog/Product.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sitemap

--- a/app/code/core/Mage/Sitemap/Model/Mysql4/Cms/Page.php
+++ b/app/code/core/Mage/Sitemap/Model/Mysql4/Cms/Page.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sitemap/Model/Mysql4/Cms/Page.php
+++ b/app/code/core/Mage/Sitemap/Model/Mysql4/Cms/Page.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sitemap

--- a/app/code/core/Mage/Sitemap/Model/Mysql4/Cms/Page.php
+++ b/app/code/core/Mage/Sitemap/Model/Mysql4/Cms/Page.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sitemap

--- a/app/code/core/Mage/Sitemap/Model/Mysql4/Sitemap.php
+++ b/app/code/core/Mage/Sitemap/Model/Mysql4/Sitemap.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sitemap/Model/Mysql4/Sitemap.php
+++ b/app/code/core/Mage/Sitemap/Model/Mysql4/Sitemap.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sitemap

--- a/app/code/core/Mage/Sitemap/Model/Mysql4/Sitemap.php
+++ b/app/code/core/Mage/Sitemap/Model/Mysql4/Sitemap.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sitemap

--- a/app/code/core/Mage/Sitemap/Model/Mysql4/Sitemap/Collection.php
+++ b/app/code/core/Mage/Sitemap/Model/Mysql4/Sitemap/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sitemap/Model/Mysql4/Sitemap/Collection.php
+++ b/app/code/core/Mage/Sitemap/Model/Mysql4/Sitemap/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sitemap

--- a/app/code/core/Mage/Sitemap/Model/Mysql4/Sitemap/Collection.php
+++ b/app/code/core/Mage/Sitemap/Model/Mysql4/Sitemap/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sitemap

--- a/app/code/core/Mage/Sitemap/Model/Observer.php
+++ b/app/code/core/Mage/Sitemap/Model/Observer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sitemap/Model/Observer.php
+++ b/app/code/core/Mage/Sitemap/Model/Observer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sitemap

--- a/app/code/core/Mage/Sitemap/Model/Observer.php
+++ b/app/code/core/Mage/Sitemap/Model/Observer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sitemap

--- a/app/code/core/Mage/Sitemap/Model/Resource/Catalog/Abstract.php
+++ b/app/code/core/Mage/Sitemap/Model/Resource/Catalog/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sitemap/Model/Resource/Catalog/Abstract.php
+++ b/app/code/core/Mage/Sitemap/Model/Resource/Catalog/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sitemap

--- a/app/code/core/Mage/Sitemap/Model/Resource/Catalog/Abstract.php
+++ b/app/code/core/Mage/Sitemap/Model/Resource/Catalog/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sitemap

--- a/app/code/core/Mage/Sitemap/Model/Resource/Catalog/Category.php
+++ b/app/code/core/Mage/Sitemap/Model/Resource/Catalog/Category.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sitemap/Model/Resource/Catalog/Category.php
+++ b/app/code/core/Mage/Sitemap/Model/Resource/Catalog/Category.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sitemap

--- a/app/code/core/Mage/Sitemap/Model/Resource/Catalog/Category.php
+++ b/app/code/core/Mage/Sitemap/Model/Resource/Catalog/Category.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sitemap

--- a/app/code/core/Mage/Sitemap/Model/Resource/Catalog/Product.php
+++ b/app/code/core/Mage/Sitemap/Model/Resource/Catalog/Product.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sitemap/Model/Resource/Catalog/Product.php
+++ b/app/code/core/Mage/Sitemap/Model/Resource/Catalog/Product.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sitemap

--- a/app/code/core/Mage/Sitemap/Model/Resource/Catalog/Product.php
+++ b/app/code/core/Mage/Sitemap/Model/Resource/Catalog/Product.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sitemap

--- a/app/code/core/Mage/Sitemap/Model/Resource/Cms/Page.php
+++ b/app/code/core/Mage/Sitemap/Model/Resource/Cms/Page.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sitemap/Model/Resource/Cms/Page.php
+++ b/app/code/core/Mage/Sitemap/Model/Resource/Cms/Page.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sitemap

--- a/app/code/core/Mage/Sitemap/Model/Resource/Cms/Page.php
+++ b/app/code/core/Mage/Sitemap/Model/Resource/Cms/Page.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sitemap

--- a/app/code/core/Mage/Sitemap/Model/Resource/Sitemap.php
+++ b/app/code/core/Mage/Sitemap/Model/Resource/Sitemap.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sitemap/Model/Resource/Sitemap.php
+++ b/app/code/core/Mage/Sitemap/Model/Resource/Sitemap.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sitemap

--- a/app/code/core/Mage/Sitemap/Model/Resource/Sitemap.php
+++ b/app/code/core/Mage/Sitemap/Model/Resource/Sitemap.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sitemap

--- a/app/code/core/Mage/Sitemap/Model/Resource/Sitemap/Collection.php
+++ b/app/code/core/Mage/Sitemap/Model/Resource/Sitemap/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sitemap/Model/Resource/Sitemap/Collection.php
+++ b/app/code/core/Mage/Sitemap/Model/Resource/Sitemap/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sitemap

--- a/app/code/core/Mage/Sitemap/Model/Resource/Sitemap/Collection.php
+++ b/app/code/core/Mage/Sitemap/Model/Resource/Sitemap/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sitemap

--- a/app/code/core/Mage/Sitemap/Model/Sitemap.php
+++ b/app/code/core/Mage/Sitemap/Model/Sitemap.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sitemap/Model/Sitemap.php
+++ b/app/code/core/Mage/Sitemap/Model/Sitemap.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sitemap

--- a/app/code/core/Mage/Sitemap/Model/Sitemap.php
+++ b/app/code/core/Mage/Sitemap/Model/Sitemap.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sitemap

--- a/app/code/core/Mage/Sitemap/etc/adminhtml.xml
+++ b/app/code/core/Mage/Sitemap/etc/adminhtml.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sitemap

--- a/app/code/core/Mage/Sitemap/etc/adminhtml.xml
+++ b/app/code/core/Mage/Sitemap/etc/adminhtml.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sitemap

--- a/app/code/core/Mage/Sitemap/etc/adminhtml.xml
+++ b/app/code/core/Mage/Sitemap/etc/adminhtml.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sitemap/etc/config.xml
+++ b/app/code/core/Mage/Sitemap/etc/config.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sitemap

--- a/app/code/core/Mage/Sitemap/etc/config.xml
+++ b/app/code/core/Mage/Sitemap/etc/config.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sitemap

--- a/app/code/core/Mage/Sitemap/etc/config.xml
+++ b/app/code/core/Mage/Sitemap/etc/config.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sitemap/etc/system.xml
+++ b/app/code/core/Mage/Sitemap/etc/system.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sitemap

--- a/app/code/core/Mage/Sitemap/etc/system.xml
+++ b/app/code/core/Mage/Sitemap/etc/system.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sitemap

--- a/app/code/core/Mage/Sitemap/etc/system.xml
+++ b/app/code/core/Mage/Sitemap/etc/system.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sitemap/sql/sitemap_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Sitemap/sql/sitemap_setup/install-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sitemap/sql/sitemap_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Sitemap/sql/sitemap_setup/install-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sitemap

--- a/app/code/core/Mage/Sitemap/sql/sitemap_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Sitemap/sql/sitemap_setup/install-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sitemap

--- a/app/code/core/Mage/Sitemap/sql/sitemap_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/Sitemap/sql/sitemap_setup/mysql4-install-0.7.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sitemap/sql/sitemap_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/Sitemap/sql/sitemap_setup/mysql4-install-0.7.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sitemap

--- a/app/code/core/Mage/Sitemap/sql/sitemap_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/Sitemap/sql/sitemap_setup/mysql4-install-0.7.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sitemap

--- a/app/code/core/Mage/Sitemap/sql/sitemap_setup/mysql4-upgrade-0.7.0-0.7.1.php
+++ b/app/code/core/Mage/Sitemap/sql/sitemap_setup/mysql4-upgrade-0.7.0-0.7.1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sitemap/sql/sitemap_setup/mysql4-upgrade-0.7.0-0.7.1.php
+++ b/app/code/core/Mage/Sitemap/sql/sitemap_setup/mysql4-upgrade-0.7.0-0.7.1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sitemap

--- a/app/code/core/Mage/Sitemap/sql/sitemap_setup/mysql4-upgrade-0.7.0-0.7.1.php
+++ b/app/code/core/Mage/Sitemap/sql/sitemap_setup/mysql4-upgrade-0.7.0-0.7.1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sitemap

--- a/app/code/core/Mage/Sitemap/sql/sitemap_setup/mysql4-upgrade-0.7.1-0.7.2.php
+++ b/app/code/core/Mage/Sitemap/sql/sitemap_setup/mysql4-upgrade-0.7.1-0.7.2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sitemap/sql/sitemap_setup/mysql4-upgrade-0.7.1-0.7.2.php
+++ b/app/code/core/Mage/Sitemap/sql/sitemap_setup/mysql4-upgrade-0.7.1-0.7.2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sitemap

--- a/app/code/core/Mage/Sitemap/sql/sitemap_setup/mysql4-upgrade-0.7.1-0.7.2.php
+++ b/app/code/core/Mage/Sitemap/sql/sitemap_setup/mysql4-upgrade-0.7.1-0.7.2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sitemap

--- a/app/code/core/Mage/Sitemap/sql/sitemap_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/Sitemap/sql/sitemap_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Sitemap/sql/sitemap_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/Sitemap/sql/sitemap_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sitemap

--- a/app/code/core/Mage/Sitemap/sql/sitemap_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/Sitemap/sql/sitemap_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sitemap

--- a/app/code/core/Mage/Tag/Block/All.php
+++ b/app/code/core/Mage/Tag/Block/All.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tag

--- a/app/code/core/Mage/Tag/Block/All.php
+++ b/app/code/core/Mage/Tag/Block/All.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tag/Block/All.php
+++ b/app/code/core/Mage/Tag/Block/All.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tag

--- a/app/code/core/Mage/Tag/Block/Customer/Recent.php
+++ b/app/code/core/Mage/Tag/Block/Customer/Recent.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tag

--- a/app/code/core/Mage/Tag/Block/Customer/Recent.php
+++ b/app/code/core/Mage/Tag/Block/Customer/Recent.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tag/Block/Customer/Recent.php
+++ b/app/code/core/Mage/Tag/Block/Customer/Recent.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tag

--- a/app/code/core/Mage/Tag/Block/Customer/Tags.php
+++ b/app/code/core/Mage/Tag/Block/Customer/Tags.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tag

--- a/app/code/core/Mage/Tag/Block/Customer/Tags.php
+++ b/app/code/core/Mage/Tag/Block/Customer/Tags.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tag/Block/Customer/Tags.php
+++ b/app/code/core/Mage/Tag/Block/Customer/Tags.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tag

--- a/app/code/core/Mage/Tag/Block/Customer/View.php
+++ b/app/code/core/Mage/Tag/Block/Customer/View.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tag

--- a/app/code/core/Mage/Tag/Block/Customer/View.php
+++ b/app/code/core/Mage/Tag/Block/Customer/View.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tag/Block/Customer/View.php
+++ b/app/code/core/Mage/Tag/Block/Customer/View.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tag

--- a/app/code/core/Mage/Tag/Block/Popular.php
+++ b/app/code/core/Mage/Tag/Block/Popular.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tag

--- a/app/code/core/Mage/Tag/Block/Popular.php
+++ b/app/code/core/Mage/Tag/Block/Popular.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tag/Block/Popular.php
+++ b/app/code/core/Mage/Tag/Block/Popular.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tag

--- a/app/code/core/Mage/Tag/Block/Product/List.php
+++ b/app/code/core/Mage/Tag/Block/Product/List.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tag

--- a/app/code/core/Mage/Tag/Block/Product/List.php
+++ b/app/code/core/Mage/Tag/Block/Product/List.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tag/Block/Product/List.php
+++ b/app/code/core/Mage/Tag/Block/Product/List.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tag

--- a/app/code/core/Mage/Tag/Block/Product/Result.php
+++ b/app/code/core/Mage/Tag/Block/Product/Result.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tag

--- a/app/code/core/Mage/Tag/Block/Product/Result.php
+++ b/app/code/core/Mage/Tag/Block/Product/Result.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tag/Block/Product/Result.php
+++ b/app/code/core/Mage/Tag/Block/Product/Result.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tag

--- a/app/code/core/Mage/Tag/Helper/Data.php
+++ b/app/code/core/Mage/Tag/Helper/Data.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tag

--- a/app/code/core/Mage/Tag/Helper/Data.php
+++ b/app/code/core/Mage/Tag/Helper/Data.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tag/Helper/Data.php
+++ b/app/code/core/Mage/Tag/Helper/Data.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tag

--- a/app/code/core/Mage/Tag/Model/Api.php
+++ b/app/code/core/Mage/Tag/Model/Api.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tag

--- a/app/code/core/Mage/Tag/Model/Api.php
+++ b/app/code/core/Mage/Tag/Model/Api.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tag/Model/Api.php
+++ b/app/code/core/Mage/Tag/Model/Api.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tag

--- a/app/code/core/Mage/Tag/Model/Api/V2.php
+++ b/app/code/core/Mage/Tag/Model/Api/V2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tag

--- a/app/code/core/Mage/Tag/Model/Api/V2.php
+++ b/app/code/core/Mage/Tag/Model/Api/V2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tag/Model/Api/V2.php
+++ b/app/code/core/Mage/Tag/Model/Api/V2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tag

--- a/app/code/core/Mage/Tag/Model/Entity/Customer/Collection.php
+++ b/app/code/core/Mage/Tag/Model/Entity/Customer/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tag

--- a/app/code/core/Mage/Tag/Model/Entity/Customer/Collection.php
+++ b/app/code/core/Mage/Tag/Model/Entity/Customer/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tag/Model/Entity/Customer/Collection.php
+++ b/app/code/core/Mage/Tag/Model/Entity/Customer/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tag

--- a/app/code/core/Mage/Tag/Model/Indexer/Summary.php
+++ b/app/code/core/Mage/Tag/Model/Indexer/Summary.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tag

--- a/app/code/core/Mage/Tag/Model/Indexer/Summary.php
+++ b/app/code/core/Mage/Tag/Model/Indexer/Summary.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tag/Model/Indexer/Summary.php
+++ b/app/code/core/Mage/Tag/Model/Indexer/Summary.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tag

--- a/app/code/core/Mage/Tag/Model/Mysql4/Customer/Collection.php
+++ b/app/code/core/Mage/Tag/Model/Mysql4/Customer/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tag

--- a/app/code/core/Mage/Tag/Model/Mysql4/Customer/Collection.php
+++ b/app/code/core/Mage/Tag/Model/Mysql4/Customer/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tag/Model/Mysql4/Customer/Collection.php
+++ b/app/code/core/Mage/Tag/Model/Mysql4/Customer/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tag

--- a/app/code/core/Mage/Tag/Model/Mysql4/Indexer/Summary.php
+++ b/app/code/core/Mage/Tag/Model/Mysql4/Indexer/Summary.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tag

--- a/app/code/core/Mage/Tag/Model/Mysql4/Indexer/Summary.php
+++ b/app/code/core/Mage/Tag/Model/Mysql4/Indexer/Summary.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tag/Model/Mysql4/Indexer/Summary.php
+++ b/app/code/core/Mage/Tag/Model/Mysql4/Indexer/Summary.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tag

--- a/app/code/core/Mage/Tag/Model/Mysql4/Popular/Collection.php
+++ b/app/code/core/Mage/Tag/Model/Mysql4/Popular/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tag

--- a/app/code/core/Mage/Tag/Model/Mysql4/Popular/Collection.php
+++ b/app/code/core/Mage/Tag/Model/Mysql4/Popular/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tag/Model/Mysql4/Popular/Collection.php
+++ b/app/code/core/Mage/Tag/Model/Mysql4/Popular/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tag

--- a/app/code/core/Mage/Tag/Model/Mysql4/Product/Collection.php
+++ b/app/code/core/Mage/Tag/Model/Mysql4/Product/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tag

--- a/app/code/core/Mage/Tag/Model/Mysql4/Product/Collection.php
+++ b/app/code/core/Mage/Tag/Model/Mysql4/Product/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tag/Model/Mysql4/Product/Collection.php
+++ b/app/code/core/Mage/Tag/Model/Mysql4/Product/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tag

--- a/app/code/core/Mage/Tag/Model/Mysql4/Tag.php
+++ b/app/code/core/Mage/Tag/Model/Mysql4/Tag.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tag

--- a/app/code/core/Mage/Tag/Model/Mysql4/Tag.php
+++ b/app/code/core/Mage/Tag/Model/Mysql4/Tag.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tag/Model/Mysql4/Tag.php
+++ b/app/code/core/Mage/Tag/Model/Mysql4/Tag.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tag

--- a/app/code/core/Mage/Tag/Model/Mysql4/Tag/Collection.php
+++ b/app/code/core/Mage/Tag/Model/Mysql4/Tag/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tag

--- a/app/code/core/Mage/Tag/Model/Mysql4/Tag/Collection.php
+++ b/app/code/core/Mage/Tag/Model/Mysql4/Tag/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tag/Model/Mysql4/Tag/Collection.php
+++ b/app/code/core/Mage/Tag/Model/Mysql4/Tag/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tag

--- a/app/code/core/Mage/Tag/Model/Mysql4/Tag/Relation.php
+++ b/app/code/core/Mage/Tag/Model/Mysql4/Tag/Relation.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tag

--- a/app/code/core/Mage/Tag/Model/Mysql4/Tag/Relation.php
+++ b/app/code/core/Mage/Tag/Model/Mysql4/Tag/Relation.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tag/Model/Mysql4/Tag/Relation.php
+++ b/app/code/core/Mage/Tag/Model/Mysql4/Tag/Relation.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tag

--- a/app/code/core/Mage/Tag/Model/Resource/Customer/Collection.php
+++ b/app/code/core/Mage/Tag/Model/Resource/Customer/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tag

--- a/app/code/core/Mage/Tag/Model/Resource/Customer/Collection.php
+++ b/app/code/core/Mage/Tag/Model/Resource/Customer/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tag/Model/Resource/Customer/Collection.php
+++ b/app/code/core/Mage/Tag/Model/Resource/Customer/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tag

--- a/app/code/core/Mage/Tag/Model/Resource/Indexer/Summary.php
+++ b/app/code/core/Mage/Tag/Model/Resource/Indexer/Summary.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tag

--- a/app/code/core/Mage/Tag/Model/Resource/Indexer/Summary.php
+++ b/app/code/core/Mage/Tag/Model/Resource/Indexer/Summary.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tag/Model/Resource/Indexer/Summary.php
+++ b/app/code/core/Mage/Tag/Model/Resource/Indexer/Summary.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tag

--- a/app/code/core/Mage/Tag/Model/Resource/Popular/Collection.php
+++ b/app/code/core/Mage/Tag/Model/Resource/Popular/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tag

--- a/app/code/core/Mage/Tag/Model/Resource/Popular/Collection.php
+++ b/app/code/core/Mage/Tag/Model/Resource/Popular/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tag/Model/Resource/Popular/Collection.php
+++ b/app/code/core/Mage/Tag/Model/Resource/Popular/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tag

--- a/app/code/core/Mage/Tag/Model/Resource/Product/Collection.php
+++ b/app/code/core/Mage/Tag/Model/Resource/Product/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tag

--- a/app/code/core/Mage/Tag/Model/Resource/Product/Collection.php
+++ b/app/code/core/Mage/Tag/Model/Resource/Product/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tag/Model/Resource/Product/Collection.php
+++ b/app/code/core/Mage/Tag/Model/Resource/Product/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tag

--- a/app/code/core/Mage/Tag/Model/Resource/Tag.php
+++ b/app/code/core/Mage/Tag/Model/Resource/Tag.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tag

--- a/app/code/core/Mage/Tag/Model/Resource/Tag.php
+++ b/app/code/core/Mage/Tag/Model/Resource/Tag.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tag/Model/Resource/Tag.php
+++ b/app/code/core/Mage/Tag/Model/Resource/Tag.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tag

--- a/app/code/core/Mage/Tag/Model/Resource/Tag/Collection.php
+++ b/app/code/core/Mage/Tag/Model/Resource/Tag/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tag

--- a/app/code/core/Mage/Tag/Model/Resource/Tag/Collection.php
+++ b/app/code/core/Mage/Tag/Model/Resource/Tag/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tag/Model/Resource/Tag/Collection.php
+++ b/app/code/core/Mage/Tag/Model/Resource/Tag/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tag

--- a/app/code/core/Mage/Tag/Model/Resource/Tag/Relation.php
+++ b/app/code/core/Mage/Tag/Model/Resource/Tag/Relation.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tag

--- a/app/code/core/Mage/Tag/Model/Resource/Tag/Relation.php
+++ b/app/code/core/Mage/Tag/Model/Resource/Tag/Relation.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tag/Model/Resource/Tag/Relation.php
+++ b/app/code/core/Mage/Tag/Model/Resource/Tag/Relation.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tag

--- a/app/code/core/Mage/Tag/Model/Session.php
+++ b/app/code/core/Mage/Tag/Model/Session.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tag

--- a/app/code/core/Mage/Tag/Model/Session.php
+++ b/app/code/core/Mage/Tag/Model/Session.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tag/Model/Session.php
+++ b/app/code/core/Mage/Tag/Model/Session.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tag

--- a/app/code/core/Mage/Tag/Model/Tag.php
+++ b/app/code/core/Mage/Tag/Model/Tag.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tag

--- a/app/code/core/Mage/Tag/Model/Tag.php
+++ b/app/code/core/Mage/Tag/Model/Tag.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tag/Model/Tag.php
+++ b/app/code/core/Mage/Tag/Model/Tag.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tag

--- a/app/code/core/Mage/Tag/Model/Tag/Relation.php
+++ b/app/code/core/Mage/Tag/Model/Tag/Relation.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tag

--- a/app/code/core/Mage/Tag/Model/Tag/Relation.php
+++ b/app/code/core/Mage/Tag/Model/Tag/Relation.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tag/Model/Tag/Relation.php
+++ b/app/code/core/Mage/Tag/Model/Tag/Relation.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tag

--- a/app/code/core/Mage/Tag/controllers/CustomerController.php
+++ b/app/code/core/Mage/Tag/controllers/CustomerController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tag

--- a/app/code/core/Mage/Tag/controllers/CustomerController.php
+++ b/app/code/core/Mage/Tag/controllers/CustomerController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tag/controllers/CustomerController.php
+++ b/app/code/core/Mage/Tag/controllers/CustomerController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tag

--- a/app/code/core/Mage/Tag/controllers/IndexController.php
+++ b/app/code/core/Mage/Tag/controllers/IndexController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tag

--- a/app/code/core/Mage/Tag/controllers/IndexController.php
+++ b/app/code/core/Mage/Tag/controllers/IndexController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tag/controllers/IndexController.php
+++ b/app/code/core/Mage/Tag/controllers/IndexController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tag

--- a/app/code/core/Mage/Tag/controllers/ListController.php
+++ b/app/code/core/Mage/Tag/controllers/ListController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tag

--- a/app/code/core/Mage/Tag/controllers/ListController.php
+++ b/app/code/core/Mage/Tag/controllers/ListController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tag/controllers/ListController.php
+++ b/app/code/core/Mage/Tag/controllers/ListController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tag

--- a/app/code/core/Mage/Tag/controllers/ProductController.php
+++ b/app/code/core/Mage/Tag/controllers/ProductController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tag

--- a/app/code/core/Mage/Tag/controllers/ProductController.php
+++ b/app/code/core/Mage/Tag/controllers/ProductController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tag/controllers/ProductController.php
+++ b/app/code/core/Mage/Tag/controllers/ProductController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tag

--- a/app/code/core/Mage/Tag/etc/adminhtml.xml
+++ b/app/code/core/Mage/Tag/etc/adminhtml.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tag

--- a/app/code/core/Mage/Tag/etc/adminhtml.xml
+++ b/app/code/core/Mage/Tag/etc/adminhtml.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tag

--- a/app/code/core/Mage/Tag/etc/adminhtml.xml
+++ b/app/code/core/Mage/Tag/etc/adminhtml.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tag/etc/api.xml
+++ b/app/code/core/Mage/Tag/etc/api.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tag

--- a/app/code/core/Mage/Tag/etc/api.xml
+++ b/app/code/core/Mage/Tag/etc/api.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tag

--- a/app/code/core/Mage/Tag/etc/api.xml
+++ b/app/code/core/Mage/Tag/etc/api.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tag/etc/config.xml
+++ b/app/code/core/Mage/Tag/etc/config.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tag

--- a/app/code/core/Mage/Tag/etc/config.xml
+++ b/app/code/core/Mage/Tag/etc/config.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tag

--- a/app/code/core/Mage/Tag/etc/config.xml
+++ b/app/code/core/Mage/Tag/etc/config.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tag/sql/tag_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Tag/sql/tag_setup/install-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tag

--- a/app/code/core/Mage/Tag/sql/tag_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Tag/sql/tag_setup/install-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tag/sql/tag_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Tag/sql/tag_setup/install-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tag

--- a/app/code/core/Mage/Tag/sql/tag_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/Tag/sql/tag_setup/mysql4-install-0.7.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tag

--- a/app/code/core/Mage/Tag/sql/tag_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/Tag/sql/tag_setup/mysql4-install-0.7.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tag/sql/tag_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/Tag/sql/tag_setup/mysql4-install-0.7.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tag

--- a/app/code/core/Mage/Tag/sql/tag_setup/mysql4-upgrade-0.7.0-0.7.1.php
+++ b/app/code/core/Mage/Tag/sql/tag_setup/mysql4-upgrade-0.7.0-0.7.1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tag

--- a/app/code/core/Mage/Tag/sql/tag_setup/mysql4-upgrade-0.7.0-0.7.1.php
+++ b/app/code/core/Mage/Tag/sql/tag_setup/mysql4-upgrade-0.7.0-0.7.1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tag/sql/tag_setup/mysql4-upgrade-0.7.0-0.7.1.php
+++ b/app/code/core/Mage/Tag/sql/tag_setup/mysql4-upgrade-0.7.0-0.7.1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tag

--- a/app/code/core/Mage/Tag/sql/tag_setup/mysql4-upgrade-0.7.1-0.7.2.php
+++ b/app/code/core/Mage/Tag/sql/tag_setup/mysql4-upgrade-0.7.1-0.7.2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tag

--- a/app/code/core/Mage/Tag/sql/tag_setup/mysql4-upgrade-0.7.1-0.7.2.php
+++ b/app/code/core/Mage/Tag/sql/tag_setup/mysql4-upgrade-0.7.1-0.7.2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tag/sql/tag_setup/mysql4-upgrade-0.7.1-0.7.2.php
+++ b/app/code/core/Mage/Tag/sql/tag_setup/mysql4-upgrade-0.7.1-0.7.2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tag

--- a/app/code/core/Mage/Tag/sql/tag_setup/mysql4-upgrade-0.7.2-0.7.3.php
+++ b/app/code/core/Mage/Tag/sql/tag_setup/mysql4-upgrade-0.7.2-0.7.3.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tag

--- a/app/code/core/Mage/Tag/sql/tag_setup/mysql4-upgrade-0.7.2-0.7.3.php
+++ b/app/code/core/Mage/Tag/sql/tag_setup/mysql4-upgrade-0.7.2-0.7.3.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tag/sql/tag_setup/mysql4-upgrade-0.7.2-0.7.3.php
+++ b/app/code/core/Mage/Tag/sql/tag_setup/mysql4-upgrade-0.7.2-0.7.3.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tag

--- a/app/code/core/Mage/Tag/sql/tag_setup/mysql4-upgrade-0.7.3-0.7.4.php
+++ b/app/code/core/Mage/Tag/sql/tag_setup/mysql4-upgrade-0.7.3-0.7.4.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tag

--- a/app/code/core/Mage/Tag/sql/tag_setup/mysql4-upgrade-0.7.3-0.7.4.php
+++ b/app/code/core/Mage/Tag/sql/tag_setup/mysql4-upgrade-0.7.3-0.7.4.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tag/sql/tag_setup/mysql4-upgrade-0.7.3-0.7.4.php
+++ b/app/code/core/Mage/Tag/sql/tag_setup/mysql4-upgrade-0.7.3-0.7.4.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tag

--- a/app/code/core/Mage/Tag/sql/tag_setup/mysql4-upgrade-0.7.4-0.7.5.php
+++ b/app/code/core/Mage/Tag/sql/tag_setup/mysql4-upgrade-0.7.4-0.7.5.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tag

--- a/app/code/core/Mage/Tag/sql/tag_setup/mysql4-upgrade-0.7.4-0.7.5.php
+++ b/app/code/core/Mage/Tag/sql/tag_setup/mysql4-upgrade-0.7.4-0.7.5.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tag/sql/tag_setup/mysql4-upgrade-0.7.4-0.7.5.php
+++ b/app/code/core/Mage/Tag/sql/tag_setup/mysql4-upgrade-0.7.4-0.7.5.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tag

--- a/app/code/core/Mage/Tag/sql/tag_setup/mysql4-upgrade-0.7.5-0.7.6.php
+++ b/app/code/core/Mage/Tag/sql/tag_setup/mysql4-upgrade-0.7.5-0.7.6.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tag

--- a/app/code/core/Mage/Tag/sql/tag_setup/mysql4-upgrade-0.7.5-0.7.6.php
+++ b/app/code/core/Mage/Tag/sql/tag_setup/mysql4-upgrade-0.7.5-0.7.6.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tag/sql/tag_setup/mysql4-upgrade-0.7.5-0.7.6.php
+++ b/app/code/core/Mage/Tag/sql/tag_setup/mysql4-upgrade-0.7.5-0.7.6.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tag

--- a/app/code/core/Mage/Tag/sql/tag_setup/mysql4-upgrade-0.7.6-0.7.7.php
+++ b/app/code/core/Mage/Tag/sql/tag_setup/mysql4-upgrade-0.7.6-0.7.7.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tag

--- a/app/code/core/Mage/Tag/sql/tag_setup/mysql4-upgrade-0.7.6-0.7.7.php
+++ b/app/code/core/Mage/Tag/sql/tag_setup/mysql4-upgrade-0.7.6-0.7.7.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tag/sql/tag_setup/mysql4-upgrade-0.7.6-0.7.7.php
+++ b/app/code/core/Mage/Tag/sql/tag_setup/mysql4-upgrade-0.7.6-0.7.7.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tag

--- a/app/code/core/Mage/Tag/sql/tag_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/Tag/sql/tag_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tag

--- a/app/code/core/Mage/Tag/sql/tag_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/Tag/sql/tag_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tag/sql/tag_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/Tag/sql/tag_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tag

--- a/app/code/core/Mage/Tax/Block/Adminhtml/Frontend/Region/Updater.php
+++ b/app/code/core/Mage/Tax/Block/Adminhtml/Frontend/Region/Updater.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Block/Adminhtml/Frontend/Region/Updater.php
+++ b/app/code/core/Mage/Tax/Block/Adminhtml/Frontend/Region/Updater.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/Block/Adminhtml/Frontend/Region/Updater.php
+++ b/app/code/core/Mage/Tax/Block/Adminhtml/Frontend/Region/Updater.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Block/Adminhtml/Notifications.php
+++ b/app/code/core/Mage/Tax/Block/Adminhtml/Notifications.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Block/Adminhtml/Notifications.php
+++ b/app/code/core/Mage/Tax/Block/Adminhtml/Notifications.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/Block/Adminhtml/Notifications.php
+++ b/app/code/core/Mage/Tax/Block/Adminhtml/Notifications.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Block/Checkout/Discount.php
+++ b/app/code/core/Mage/Tax/Block/Checkout/Discount.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Block/Checkout/Discount.php
+++ b/app/code/core/Mage/Tax/Block/Checkout/Discount.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/Block/Checkout/Discount.php
+++ b/app/code/core/Mage/Tax/Block/Checkout/Discount.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Block/Checkout/Grandtotal.php
+++ b/app/code/core/Mage/Tax/Block/Checkout/Grandtotal.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Block/Checkout/Grandtotal.php
+++ b/app/code/core/Mage/Tax/Block/Checkout/Grandtotal.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/Block/Checkout/Grandtotal.php
+++ b/app/code/core/Mage/Tax/Block/Checkout/Grandtotal.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Block/Checkout/Shipping.php
+++ b/app/code/core/Mage/Tax/Block/Checkout/Shipping.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Block/Checkout/Shipping.php
+++ b/app/code/core/Mage/Tax/Block/Checkout/Shipping.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/Block/Checkout/Shipping.php
+++ b/app/code/core/Mage/Tax/Block/Checkout/Shipping.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Block/Checkout/Subtotal.php
+++ b/app/code/core/Mage/Tax/Block/Checkout/Subtotal.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Block/Checkout/Subtotal.php
+++ b/app/code/core/Mage/Tax/Block/Checkout/Subtotal.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/Block/Checkout/Subtotal.php
+++ b/app/code/core/Mage/Tax/Block/Checkout/Subtotal.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Block/Checkout/Tax.php
+++ b/app/code/core/Mage/Tax/Block/Checkout/Tax.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Block/Checkout/Tax.php
+++ b/app/code/core/Mage/Tax/Block/Checkout/Tax.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/Block/Checkout/Tax.php
+++ b/app/code/core/Mage/Tax/Block/Checkout/Tax.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Block/Sales/Order/Tax.php
+++ b/app/code/core/Mage/Tax/Block/Sales/Order/Tax.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Block/Sales/Order/Tax.php
+++ b/app/code/core/Mage/Tax/Block/Sales/Order/Tax.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/Block/Sales/Order/Tax.php
+++ b/app/code/core/Mage/Tax/Block/Sales/Order/Tax.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Exception.php
+++ b/app/code/core/Mage/Tax/Exception.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Exception.php
+++ b/app/code/core/Mage/Tax/Exception.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/Exception.php
+++ b/app/code/core/Mage/Tax/Exception.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Helper/Data.php
+++ b/app/code/core/Mage/Tax/Helper/Data.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Helper/Data.php
+++ b/app/code/core/Mage/Tax/Helper/Data.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/Helper/Data.php
+++ b/app/code/core/Mage/Tax/Helper/Data.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Calculation.php
+++ b/app/code/core/Mage/Tax/Model/Calculation.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Calculation.php
+++ b/app/code/core/Mage/Tax/Model/Calculation.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/Model/Calculation.php
+++ b/app/code/core/Mage/Tax/Model/Calculation.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Calculation/Rate.php
+++ b/app/code/core/Mage/Tax/Model/Calculation/Rate.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Calculation/Rate.php
+++ b/app/code/core/Mage/Tax/Model/Calculation/Rate.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/Model/Calculation/Rate.php
+++ b/app/code/core/Mage/Tax/Model/Calculation/Rate.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Calculation/Rate/Title.php
+++ b/app/code/core/Mage/Tax/Model/Calculation/Rate/Title.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Calculation/Rate/Title.php
+++ b/app/code/core/Mage/Tax/Model/Calculation/Rate/Title.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/Model/Calculation/Rate/Title.php
+++ b/app/code/core/Mage/Tax/Model/Calculation/Rate/Title.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Calculation/Rule.php
+++ b/app/code/core/Mage/Tax/Model/Calculation/Rule.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Calculation/Rule.php
+++ b/app/code/core/Mage/Tax/Model/Calculation/Rule.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/Model/Calculation/Rule.php
+++ b/app/code/core/Mage/Tax/Model/Calculation/Rule.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Class.php
+++ b/app/code/core/Mage/Tax/Model/Class.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Class.php
+++ b/app/code/core/Mage/Tax/Model/Class.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/Model/Class.php
+++ b/app/code/core/Mage/Tax/Model/Class.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Class/Source/Customer.php
+++ b/app/code/core/Mage/Tax/Model/Class/Source/Customer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Class/Source/Customer.php
+++ b/app/code/core/Mage/Tax/Model/Class/Source/Customer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/Model/Class/Source/Customer.php
+++ b/app/code/core/Mage/Tax/Model/Class/Source/Customer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Class/Source/Product.php
+++ b/app/code/core/Mage/Tax/Model/Class/Source/Product.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Class/Source/Product.php
+++ b/app/code/core/Mage/Tax/Model/Class/Source/Product.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/Model/Class/Source/Product.php
+++ b/app/code/core/Mage/Tax/Model/Class/Source/Product.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Config.php
+++ b/app/code/core/Mage/Tax/Model/Config.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Config.php
+++ b/app/code/core/Mage/Tax/Model/Config.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/Model/Config.php
+++ b/app/code/core/Mage/Tax/Model/Config.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Config/Notification.php
+++ b/app/code/core/Mage/Tax/Model/Config/Notification.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Config/Notification.php
+++ b/app/code/core/Mage/Tax/Model/Config/Notification.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/Model/Config/Notification.php
+++ b/app/code/core/Mage/Tax/Model/Config/Notification.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Config/Price/Include.php
+++ b/app/code/core/Mage/Tax/Model/Config/Price/Include.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Config/Price/Include.php
+++ b/app/code/core/Mage/Tax/Model/Config/Price/Include.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/Model/Config/Price/Include.php
+++ b/app/code/core/Mage/Tax/Model/Config/Price/Include.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Mysql4/Calculation.php
+++ b/app/code/core/Mage/Tax/Model/Mysql4/Calculation.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Mysql4/Calculation.php
+++ b/app/code/core/Mage/Tax/Model/Mysql4/Calculation.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/Model/Mysql4/Calculation.php
+++ b/app/code/core/Mage/Tax/Model/Mysql4/Calculation.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Mysql4/Calculation/Collection.php
+++ b/app/code/core/Mage/Tax/Model/Mysql4/Calculation/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Mysql4/Calculation/Collection.php
+++ b/app/code/core/Mage/Tax/Model/Mysql4/Calculation/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/Model/Mysql4/Calculation/Collection.php
+++ b/app/code/core/Mage/Tax/Model/Mysql4/Calculation/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Mysql4/Calculation/Rate.php
+++ b/app/code/core/Mage/Tax/Model/Mysql4/Calculation/Rate.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Mysql4/Calculation/Rate.php
+++ b/app/code/core/Mage/Tax/Model/Mysql4/Calculation/Rate.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/Model/Mysql4/Calculation/Rate.php
+++ b/app/code/core/Mage/Tax/Model/Mysql4/Calculation/Rate.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Mysql4/Calculation/Rate/Collection.php
+++ b/app/code/core/Mage/Tax/Model/Mysql4/Calculation/Rate/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Mysql4/Calculation/Rate/Collection.php
+++ b/app/code/core/Mage/Tax/Model/Mysql4/Calculation/Rate/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/Model/Mysql4/Calculation/Rate/Collection.php
+++ b/app/code/core/Mage/Tax/Model/Mysql4/Calculation/Rate/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Mysql4/Calculation/Rate/Title.php
+++ b/app/code/core/Mage/Tax/Model/Mysql4/Calculation/Rate/Title.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Mysql4/Calculation/Rate/Title.php
+++ b/app/code/core/Mage/Tax/Model/Mysql4/Calculation/Rate/Title.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/Model/Mysql4/Calculation/Rate/Title.php
+++ b/app/code/core/Mage/Tax/Model/Mysql4/Calculation/Rate/Title.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Mysql4/Calculation/Rate/Title/Collection.php
+++ b/app/code/core/Mage/Tax/Model/Mysql4/Calculation/Rate/Title/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Mysql4/Calculation/Rate/Title/Collection.php
+++ b/app/code/core/Mage/Tax/Model/Mysql4/Calculation/Rate/Title/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/Model/Mysql4/Calculation/Rate/Title/Collection.php
+++ b/app/code/core/Mage/Tax/Model/Mysql4/Calculation/Rate/Title/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Mysql4/Calculation/Rule.php
+++ b/app/code/core/Mage/Tax/Model/Mysql4/Calculation/Rule.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Mysql4/Calculation/Rule.php
+++ b/app/code/core/Mage/Tax/Model/Mysql4/Calculation/Rule.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/Model/Mysql4/Calculation/Rule.php
+++ b/app/code/core/Mage/Tax/Model/Mysql4/Calculation/Rule.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Mysql4/Calculation/Rule/Collection.php
+++ b/app/code/core/Mage/Tax/Model/Mysql4/Calculation/Rule/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Mysql4/Calculation/Rule/Collection.php
+++ b/app/code/core/Mage/Tax/Model/Mysql4/Calculation/Rule/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/Model/Mysql4/Calculation/Rule/Collection.php
+++ b/app/code/core/Mage/Tax/Model/Mysql4/Calculation/Rule/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Mysql4/Class.php
+++ b/app/code/core/Mage/Tax/Model/Mysql4/Class.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Mysql4/Class.php
+++ b/app/code/core/Mage/Tax/Model/Mysql4/Class.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/Model/Mysql4/Class.php
+++ b/app/code/core/Mage/Tax/Model/Mysql4/Class.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Mysql4/Class/Collection.php
+++ b/app/code/core/Mage/Tax/Model/Mysql4/Class/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Mysql4/Class/Collection.php
+++ b/app/code/core/Mage/Tax/Model/Mysql4/Class/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/Model/Mysql4/Class/Collection.php
+++ b/app/code/core/Mage/Tax/Model/Mysql4/Class/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Mysql4/Report/Collection.php
+++ b/app/code/core/Mage/Tax/Model/Mysql4/Report/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Mysql4/Report/Collection.php
+++ b/app/code/core/Mage/Tax/Model/Mysql4/Report/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/Model/Mysql4/Report/Collection.php
+++ b/app/code/core/Mage/Tax/Model/Mysql4/Report/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Mysql4/Report/Tax.php
+++ b/app/code/core/Mage/Tax/Model/Mysql4/Report/Tax.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Mysql4/Report/Tax.php
+++ b/app/code/core/Mage/Tax/Model/Mysql4/Report/Tax.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/Model/Mysql4/Report/Tax.php
+++ b/app/code/core/Mage/Tax/Model/Mysql4/Report/Tax.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Mysql4/Report/Updatedat/Collection.php
+++ b/app/code/core/Mage/Tax/Model/Mysql4/Report/Updatedat/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Mysql4/Report/Updatedat/Collection.php
+++ b/app/code/core/Mage/Tax/Model/Mysql4/Report/Updatedat/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/Model/Mysql4/Report/Updatedat/Collection.php
+++ b/app/code/core/Mage/Tax/Model/Mysql4/Report/Updatedat/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Mysql4/Sales/Order/Tax.php
+++ b/app/code/core/Mage/Tax/Model/Mysql4/Sales/Order/Tax.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Mysql4/Sales/Order/Tax.php
+++ b/app/code/core/Mage/Tax/Model/Mysql4/Sales/Order/Tax.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/Model/Mysql4/Sales/Order/Tax.php
+++ b/app/code/core/Mage/Tax/Model/Mysql4/Sales/Order/Tax.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Mysql4/Sales/Order/Tax/Collection.php
+++ b/app/code/core/Mage/Tax/Model/Mysql4/Sales/Order/Tax/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Mysql4/Sales/Order/Tax/Collection.php
+++ b/app/code/core/Mage/Tax/Model/Mysql4/Sales/Order/Tax/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/Model/Mysql4/Sales/Order/Tax/Collection.php
+++ b/app/code/core/Mage/Tax/Model/Mysql4/Sales/Order/Tax/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Mysql4/Setup.php
+++ b/app/code/core/Mage/Tax/Model/Mysql4/Setup.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Mysql4/Setup.php
+++ b/app/code/core/Mage/Tax/Model/Mysql4/Setup.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/Model/Mysql4/Setup.php
+++ b/app/code/core/Mage/Tax/Model/Mysql4/Setup.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Observer.php
+++ b/app/code/core/Mage/Tax/Model/Observer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Observer.php
+++ b/app/code/core/Mage/Tax/Model/Observer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/Model/Observer.php
+++ b/app/code/core/Mage/Tax/Model/Observer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Resource/Calculation.php
+++ b/app/code/core/Mage/Tax/Model/Resource/Calculation.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Resource/Calculation.php
+++ b/app/code/core/Mage/Tax/Model/Resource/Calculation.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/Model/Resource/Calculation.php
+++ b/app/code/core/Mage/Tax/Model/Resource/Calculation.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Resource/Calculation/Collection.php
+++ b/app/code/core/Mage/Tax/Model/Resource/Calculation/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Resource/Calculation/Collection.php
+++ b/app/code/core/Mage/Tax/Model/Resource/Calculation/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/Model/Resource/Calculation/Collection.php
+++ b/app/code/core/Mage/Tax/Model/Resource/Calculation/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Resource/Calculation/Rate.php
+++ b/app/code/core/Mage/Tax/Model/Resource/Calculation/Rate.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Resource/Calculation/Rate.php
+++ b/app/code/core/Mage/Tax/Model/Resource/Calculation/Rate.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/Model/Resource/Calculation/Rate.php
+++ b/app/code/core/Mage/Tax/Model/Resource/Calculation/Rate.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Resource/Calculation/Rate/Collection.php
+++ b/app/code/core/Mage/Tax/Model/Resource/Calculation/Rate/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Resource/Calculation/Rate/Collection.php
+++ b/app/code/core/Mage/Tax/Model/Resource/Calculation/Rate/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/Model/Resource/Calculation/Rate/Collection.php
+++ b/app/code/core/Mage/Tax/Model/Resource/Calculation/Rate/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Resource/Calculation/Rate/Title.php
+++ b/app/code/core/Mage/Tax/Model/Resource/Calculation/Rate/Title.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Resource/Calculation/Rate/Title.php
+++ b/app/code/core/Mage/Tax/Model/Resource/Calculation/Rate/Title.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/Model/Resource/Calculation/Rate/Title.php
+++ b/app/code/core/Mage/Tax/Model/Resource/Calculation/Rate/Title.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Resource/Calculation/Rate/Title/Collection.php
+++ b/app/code/core/Mage/Tax/Model/Resource/Calculation/Rate/Title/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Resource/Calculation/Rate/Title/Collection.php
+++ b/app/code/core/Mage/Tax/Model/Resource/Calculation/Rate/Title/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/Model/Resource/Calculation/Rate/Title/Collection.php
+++ b/app/code/core/Mage/Tax/Model/Resource/Calculation/Rate/Title/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Resource/Calculation/Rule.php
+++ b/app/code/core/Mage/Tax/Model/Resource/Calculation/Rule.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Resource/Calculation/Rule.php
+++ b/app/code/core/Mage/Tax/Model/Resource/Calculation/Rule.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/Model/Resource/Calculation/Rule.php
+++ b/app/code/core/Mage/Tax/Model/Resource/Calculation/Rule.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Resource/Calculation/Rule/Collection.php
+++ b/app/code/core/Mage/Tax/Model/Resource/Calculation/Rule/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Resource/Calculation/Rule/Collection.php
+++ b/app/code/core/Mage/Tax/Model/Resource/Calculation/Rule/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/Model/Resource/Calculation/Rule/Collection.php
+++ b/app/code/core/Mage/Tax/Model/Resource/Calculation/Rule/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Resource/Class.php
+++ b/app/code/core/Mage/Tax/Model/Resource/Class.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Resource/Class.php
+++ b/app/code/core/Mage/Tax/Model/Resource/Class.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/Model/Resource/Class.php
+++ b/app/code/core/Mage/Tax/Model/Resource/Class.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Resource/Class/Collection.php
+++ b/app/code/core/Mage/Tax/Model/Resource/Class/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Resource/Class/Collection.php
+++ b/app/code/core/Mage/Tax/Model/Resource/Class/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/Model/Resource/Class/Collection.php
+++ b/app/code/core/Mage/Tax/Model/Resource/Class/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Resource/Report/Collection.php
+++ b/app/code/core/Mage/Tax/Model/Resource/Report/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Resource/Report/Collection.php
+++ b/app/code/core/Mage/Tax/Model/Resource/Report/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/Model/Resource/Report/Collection.php
+++ b/app/code/core/Mage/Tax/Model/Resource/Report/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Resource/Report/Tax.php
+++ b/app/code/core/Mage/Tax/Model/Resource/Report/Tax.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Resource/Report/Tax.php
+++ b/app/code/core/Mage/Tax/Model/Resource/Report/Tax.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/Model/Resource/Report/Tax.php
+++ b/app/code/core/Mage/Tax/Model/Resource/Report/Tax.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Resource/Report/Tax/Createdat.php
+++ b/app/code/core/Mage/Tax/Model/Resource/Report/Tax/Createdat.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Resource/Report/Tax/Createdat.php
+++ b/app/code/core/Mage/Tax/Model/Resource/Report/Tax/Createdat.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/Model/Resource/Report/Tax/Createdat.php
+++ b/app/code/core/Mage/Tax/Model/Resource/Report/Tax/Createdat.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Resource/Report/Tax/Updatedat.php
+++ b/app/code/core/Mage/Tax/Model/Resource/Report/Tax/Updatedat.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Resource/Report/Tax/Updatedat.php
+++ b/app/code/core/Mage/Tax/Model/Resource/Report/Tax/Updatedat.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/Model/Resource/Report/Tax/Updatedat.php
+++ b/app/code/core/Mage/Tax/Model/Resource/Report/Tax/Updatedat.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Resource/Report/Updatedat/Collection.php
+++ b/app/code/core/Mage/Tax/Model/Resource/Report/Updatedat/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Resource/Report/Updatedat/Collection.php
+++ b/app/code/core/Mage/Tax/Model/Resource/Report/Updatedat/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/Model/Resource/Report/Updatedat/Collection.php
+++ b/app/code/core/Mage/Tax/Model/Resource/Report/Updatedat/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Resource/Sales/Order/Tax.php
+++ b/app/code/core/Mage/Tax/Model/Resource/Sales/Order/Tax.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Resource/Sales/Order/Tax.php
+++ b/app/code/core/Mage/Tax/Model/Resource/Sales/Order/Tax.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/Model/Resource/Sales/Order/Tax.php
+++ b/app/code/core/Mage/Tax/Model/Resource/Sales/Order/Tax.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Resource/Sales/Order/Tax/Collection.php
+++ b/app/code/core/Mage/Tax/Model/Resource/Sales/Order/Tax/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Resource/Sales/Order/Tax/Collection.php
+++ b/app/code/core/Mage/Tax/Model/Resource/Sales/Order/Tax/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/Model/Resource/Sales/Order/Tax/Collection.php
+++ b/app/code/core/Mage/Tax/Model/Resource/Sales/Order/Tax/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Resource/Sales/Order/Tax/Item.php
+++ b/app/code/core/Mage/Tax/Model/Resource/Sales/Order/Tax/Item.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Resource/Sales/Order/Tax/Item.php
+++ b/app/code/core/Mage/Tax/Model/Resource/Sales/Order/Tax/Item.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/Model/Resource/Sales/Order/Tax/Item.php
+++ b/app/code/core/Mage/Tax/Model/Resource/Sales/Order/Tax/Item.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Resource/Sales/Order/Tax/Item/Collection.php
+++ b/app/code/core/Mage/Tax/Model/Resource/Sales/Order/Tax/Item/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Resource/Sales/Order/Tax/Item/Collection.php
+++ b/app/code/core/Mage/Tax/Model/Resource/Sales/Order/Tax/Item/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/Model/Resource/Sales/Order/Tax/Item/Collection.php
+++ b/app/code/core/Mage/Tax/Model/Resource/Sales/Order/Tax/Item/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Resource/Setup.php
+++ b/app/code/core/Mage/Tax/Model/Resource/Setup.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Resource/Setup.php
+++ b/app/code/core/Mage/Tax/Model/Resource/Setup.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/Model/Resource/Setup.php
+++ b/app/code/core/Mage/Tax/Model/Resource/Setup.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Sales/Order/Tax.php
+++ b/app/code/core/Mage/Tax/Model/Sales/Order/Tax.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Sales/Order/Tax.php
+++ b/app/code/core/Mage/Tax/Model/Sales/Order/Tax.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/Model/Sales/Order/Tax.php
+++ b/app/code/core/Mage/Tax/Model/Sales/Order/Tax.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Sales/Order/Tax/Item.php
+++ b/app/code/core/Mage/Tax/Model/Sales/Order/Tax/Item.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Sales/Order/Tax/Item.php
+++ b/app/code/core/Mage/Tax/Model/Sales/Order/Tax/Item.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/Model/Sales/Order/Tax/Item.php
+++ b/app/code/core/Mage/Tax/Model/Sales/Order/Tax/Item.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Sales/Pdf/Grandtotal.php
+++ b/app/code/core/Mage/Tax/Model/Sales/Pdf/Grandtotal.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Sales/Pdf/Grandtotal.php
+++ b/app/code/core/Mage/Tax/Model/Sales/Pdf/Grandtotal.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/Model/Sales/Pdf/Grandtotal.php
+++ b/app/code/core/Mage/Tax/Model/Sales/Pdf/Grandtotal.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Sales/Pdf/Shipping.php
+++ b/app/code/core/Mage/Tax/Model/Sales/Pdf/Shipping.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Sales/Pdf/Shipping.php
+++ b/app/code/core/Mage/Tax/Model/Sales/Pdf/Shipping.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/Model/Sales/Pdf/Shipping.php
+++ b/app/code/core/Mage/Tax/Model/Sales/Pdf/Shipping.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Sales/Pdf/Subtotal.php
+++ b/app/code/core/Mage/Tax/Model/Sales/Pdf/Subtotal.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Sales/Pdf/Subtotal.php
+++ b/app/code/core/Mage/Tax/Model/Sales/Pdf/Subtotal.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/Model/Sales/Pdf/Subtotal.php
+++ b/app/code/core/Mage/Tax/Model/Sales/Pdf/Subtotal.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Sales/Pdf/Tax.php
+++ b/app/code/core/Mage/Tax/Model/Sales/Pdf/Tax.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Sales/Pdf/Tax.php
+++ b/app/code/core/Mage/Tax/Model/Sales/Pdf/Tax.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/Model/Sales/Pdf/Tax.php
+++ b/app/code/core/Mage/Tax/Model/Sales/Pdf/Tax.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Sales/Total/Quote/Discount.php
+++ b/app/code/core/Mage/Tax/Model/Sales/Total/Quote/Discount.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Sales/Total/Quote/Discount.php
+++ b/app/code/core/Mage/Tax/Model/Sales/Total/Quote/Discount.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/Model/Sales/Total/Quote/Discount.php
+++ b/app/code/core/Mage/Tax/Model/Sales/Total/Quote/Discount.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Sales/Total/Quote/Nominal/Subtotal.php
+++ b/app/code/core/Mage/Tax/Model/Sales/Total/Quote/Nominal/Subtotal.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Sales/Total/Quote/Nominal/Subtotal.php
+++ b/app/code/core/Mage/Tax/Model/Sales/Total/Quote/Nominal/Subtotal.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/Model/Sales/Total/Quote/Nominal/Subtotal.php
+++ b/app/code/core/Mage/Tax/Model/Sales/Total/Quote/Nominal/Subtotal.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Sales/Total/Quote/Nominal/Tax.php
+++ b/app/code/core/Mage/Tax/Model/Sales/Total/Quote/Nominal/Tax.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Sales/Total/Quote/Nominal/Tax.php
+++ b/app/code/core/Mage/Tax/Model/Sales/Total/Quote/Nominal/Tax.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/Model/Sales/Total/Quote/Nominal/Tax.php
+++ b/app/code/core/Mage/Tax/Model/Sales/Total/Quote/Nominal/Tax.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Sales/Total/Quote/Shipping.php
+++ b/app/code/core/Mage/Tax/Model/Sales/Total/Quote/Shipping.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Sales/Total/Quote/Shipping.php
+++ b/app/code/core/Mage/Tax/Model/Sales/Total/Quote/Shipping.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/Model/Sales/Total/Quote/Shipping.php
+++ b/app/code/core/Mage/Tax/Model/Sales/Total/Quote/Shipping.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Sales/Total/Quote/Subtotal.php
+++ b/app/code/core/Mage/Tax/Model/Sales/Total/Quote/Subtotal.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Sales/Total/Quote/Subtotal.php
+++ b/app/code/core/Mage/Tax/Model/Sales/Total/Quote/Subtotal.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/Model/Sales/Total/Quote/Subtotal.php
+++ b/app/code/core/Mage/Tax/Model/Sales/Total/Quote/Subtotal.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Sales/Total/Quote/Tax.php
+++ b/app/code/core/Mage/Tax/Model/Sales/Total/Quote/Tax.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/Sales/Total/Quote/Tax.php
+++ b/app/code/core/Mage/Tax/Model/Sales/Total/Quote/Tax.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/Model/Sales/Total/Quote/Tax.php
+++ b/app/code/core/Mage/Tax/Model/Sales/Total/Quote/Tax.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/System/Config/Source/Algorithm.php
+++ b/app/code/core/Mage/Tax/Model/System/Config/Source/Algorithm.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/System/Config/Source/Algorithm.php
+++ b/app/code/core/Mage/Tax/Model/System/Config/Source/Algorithm.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/Model/System/Config/Source/Algorithm.php
+++ b/app/code/core/Mage/Tax/Model/System/Config/Source/Algorithm.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/System/Config/Source/Apply.php
+++ b/app/code/core/Mage/Tax/Model/System/Config/Source/Apply.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/System/Config/Source/Apply.php
+++ b/app/code/core/Mage/Tax/Model/System/Config/Source/Apply.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/Model/System/Config/Source/Apply.php
+++ b/app/code/core/Mage/Tax/Model/System/Config/Source/Apply.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/System/Config/Source/PriceType.php
+++ b/app/code/core/Mage/Tax/Model/System/Config/Source/PriceType.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/System/Config/Source/PriceType.php
+++ b/app/code/core/Mage/Tax/Model/System/Config/Source/PriceType.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/Model/System/Config/Source/PriceType.php
+++ b/app/code/core/Mage/Tax/Model/System/Config/Source/PriceType.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/System/Config/Source/Tax/Country.php
+++ b/app/code/core/Mage/Tax/Model/System/Config/Source/Tax/Country.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/System/Config/Source/Tax/Country.php
+++ b/app/code/core/Mage/Tax/Model/System/Config/Source/Tax/Country.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/Model/System/Config/Source/Tax/Country.php
+++ b/app/code/core/Mage/Tax/Model/System/Config/Source/Tax/Country.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/System/Config/Source/Tax/Display/Type.php
+++ b/app/code/core/Mage/Tax/Model/System/Config/Source/Tax/Display/Type.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/System/Config/Source/Tax/Display/Type.php
+++ b/app/code/core/Mage/Tax/Model/System/Config/Source/Tax/Display/Type.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/Model/System/Config/Source/Tax/Display/Type.php
+++ b/app/code/core/Mage/Tax/Model/System/Config/Source/Tax/Display/Type.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/System/Config/Source/Tax/Region.php
+++ b/app/code/core/Mage/Tax/Model/System/Config/Source/Tax/Region.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/Model/System/Config/Source/Tax/Region.php
+++ b/app/code/core/Mage/Tax/Model/System/Config/Source/Tax/Region.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/Model/System/Config/Source/Tax/Region.php
+++ b/app/code/core/Mage/Tax/Model/System/Config/Source/Tax/Region.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/data/tax_setup/data-install-1.6.0.0.php
+++ b/app/code/core/Mage/Tax/data/tax_setup/data-install-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/data/tax_setup/data-install-1.6.0.0.php
+++ b/app/code/core/Mage/Tax/data/tax_setup/data-install-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/data/tax_setup/data-install-1.6.0.0.php
+++ b/app/code/core/Mage/Tax/data/tax_setup/data-install-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/etc/adminhtml.xml
+++ b/app/code/core/Mage/Tax/etc/adminhtml.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/etc/adminhtml.xml
+++ b/app/code/core/Mage/Tax/etc/adminhtml.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/etc/adminhtml.xml
+++ b/app/code/core/Mage/Tax/etc/adminhtml.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/etc/config.xml
+++ b/app/code/core/Mage/Tax/etc/config.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/etc/config.xml
+++ b/app/code/core/Mage/Tax/etc/config.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/etc/config.xml
+++ b/app/code/core/Mage/Tax/etc/config.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/etc/system.xml
+++ b/app/code/core/Mage/Tax/etc/system.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/etc/system.xml
+++ b/app/code/core/Mage/Tax/etc/system.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/etc/system.xml
+++ b/app/code/core/Mage/Tax/etc/system.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/sql/tax_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Tax/sql/tax_setup/install-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/sql/tax_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Tax/sql/tax_setup/install-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/sql/tax_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Tax/sql/tax_setup/install-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/sql/tax_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/Tax/sql/tax_setup/mysql4-install-0.7.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/sql/tax_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/Tax/sql/tax_setup/mysql4-install-0.7.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/sql/tax_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/Tax/sql/tax_setup/mysql4-install-0.7.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/sql/tax_setup/mysql4-install-1.4.0.0.php
+++ b/app/code/core/Mage/Tax/sql/tax_setup/mysql4-install-1.4.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/sql/tax_setup/mysql4-install-1.4.0.0.php
+++ b/app/code/core/Mage/Tax/sql/tax_setup/mysql4-install-1.4.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/sql/tax_setup/mysql4-install-1.4.0.0.php
+++ b/app/code/core/Mage/Tax/sql/tax_setup/mysql4-install-1.4.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-0.6.1-0.7.0.php
+++ b/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-0.6.1-0.7.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-0.6.1-0.7.0.php
+++ b/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-0.6.1-0.7.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-0.6.1-0.7.0.php
+++ b/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-0.6.1-0.7.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-0.7.0-0.7.1.php
+++ b/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-0.7.0-0.7.1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-0.7.0-0.7.1.php
+++ b/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-0.7.0-0.7.1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-0.7.0-0.7.1.php
+++ b/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-0.7.0-0.7.1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-0.7.1-0.7.2.php
+++ b/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-0.7.1-0.7.2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-0.7.1-0.7.2.php
+++ b/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-0.7.1-0.7.2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-0.7.1-0.7.2.php
+++ b/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-0.7.1-0.7.2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-0.7.10-0.7.11.php
+++ b/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-0.7.10-0.7.11.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-0.7.10-0.7.11.php
+++ b/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-0.7.10-0.7.11.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-0.7.10-0.7.11.php
+++ b/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-0.7.10-0.7.11.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-0.7.11-0.7.12.php
+++ b/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-0.7.11-0.7.12.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-0.7.11-0.7.12.php
+++ b/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-0.7.11-0.7.12.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-0.7.11-0.7.12.php
+++ b/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-0.7.11-0.7.12.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-0.7.12-0.7.13.php
+++ b/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-0.7.12-0.7.13.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-0.7.12-0.7.13.php
+++ b/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-0.7.12-0.7.13.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-0.7.12-0.7.13.php
+++ b/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-0.7.12-0.7.13.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-0.7.2-0.7.3.php
+++ b/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-0.7.2-0.7.3.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-0.7.2-0.7.3.php
+++ b/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-0.7.2-0.7.3.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-0.7.2-0.7.3.php
+++ b/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-0.7.2-0.7.3.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-0.7.3-0.7.4.php
+++ b/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-0.7.3-0.7.4.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-0.7.3-0.7.4.php
+++ b/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-0.7.3-0.7.4.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-0.7.3-0.7.4.php
+++ b/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-0.7.3-0.7.4.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-0.7.4-0.7.5.php
+++ b/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-0.7.4-0.7.5.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-0.7.4-0.7.5.php
+++ b/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-0.7.4-0.7.5.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-0.7.4-0.7.5.php
+++ b/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-0.7.4-0.7.5.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-0.7.5-0.7.6.php
+++ b/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-0.7.5-0.7.6.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-0.7.5-0.7.6.php
+++ b/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-0.7.5-0.7.6.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-0.7.5-0.7.6.php
+++ b/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-0.7.5-0.7.6.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-0.7.6-0.7.7.php
+++ b/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-0.7.6-0.7.7.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-0.7.6-0.7.7.php
+++ b/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-0.7.6-0.7.7.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-0.7.6-0.7.7.php
+++ b/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-0.7.6-0.7.7.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-0.7.7-0.7.8.php
+++ b/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-0.7.7-0.7.8.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-0.7.7-0.7.8.php
+++ b/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-0.7.7-0.7.8.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-0.7.7-0.7.8.php
+++ b/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-0.7.7-0.7.8.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-0.7.8-0.7.9.php
+++ b/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-0.7.8-0.7.9.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-0.7.8-0.7.9.php
+++ b/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-0.7.8-0.7.9.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-0.7.8-0.7.9.php
+++ b/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-0.7.8-0.7.9.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-0.7.9-0.7.10.php
+++ b/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-0.7.9-0.7.10.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-0.7.9-0.7.10.php
+++ b/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-0.7.9-0.7.10.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-0.7.9-0.7.10.php
+++ b/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-0.7.9-0.7.10.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-1.3.9-1.4.0.php
+++ b/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-1.3.9-1.4.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-1.3.9-1.4.0.php
+++ b/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-1.3.9-1.4.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-1.3.9-1.4.0.php
+++ b/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-1.3.9-1.4.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-1.4.0.0-1.4.0.1.php
+++ b/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-1.4.0.0-1.4.0.1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-1.4.0.0-1.4.0.1.php
+++ b/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-1.4.0.0-1.4.0.1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-1.4.0.0-1.4.0.1.php
+++ b/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-1.4.0.0-1.4.0.1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-1.4.0.1-1.4.0.2.php
+++ b/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-1.4.0.1-1.4.0.2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-1.4.0.1-1.4.0.2.php
+++ b/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-1.4.0.1-1.4.0.2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-1.4.0.1-1.4.0.2.php
+++ b/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-1.4.0.1-1.4.0.2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/Tax/sql/tax_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/sql/tax_setup/upgrade-1.6.0.0-1.6.0.1.php
+++ b/app/code/core/Mage/Tax/sql/tax_setup/upgrade-1.6.0.0-1.6.0.1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/sql/tax_setup/upgrade-1.6.0.0-1.6.0.1.php
+++ b/app/code/core/Mage/Tax/sql/tax_setup/upgrade-1.6.0.0-1.6.0.1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/sql/tax_setup/upgrade-1.6.0.0-1.6.0.1.php
+++ b/app/code/core/Mage/Tax/sql/tax_setup/upgrade-1.6.0.0-1.6.0.1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/sql/tax_setup/upgrade-1.6.0.1-1.6.0.2.php
+++ b/app/code/core/Mage/Tax/sql/tax_setup/upgrade-1.6.0.1-1.6.0.2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/sql/tax_setup/upgrade-1.6.0.1-1.6.0.2.php
+++ b/app/code/core/Mage/Tax/sql/tax_setup/upgrade-1.6.0.1-1.6.0.2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/sql/tax_setup/upgrade-1.6.0.1-1.6.0.2.php
+++ b/app/code/core/Mage/Tax/sql/tax_setup/upgrade-1.6.0.1-1.6.0.2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/sql/tax_setup/upgrade-1.6.0.2-1.6.0.3.php
+++ b/app/code/core/Mage/Tax/sql/tax_setup/upgrade-1.6.0.2-1.6.0.3.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/sql/tax_setup/upgrade-1.6.0.2-1.6.0.3.php
+++ b/app/code/core/Mage/Tax/sql/tax_setup/upgrade-1.6.0.2-1.6.0.3.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/sql/tax_setup/upgrade-1.6.0.2-1.6.0.3.php
+++ b/app/code/core/Mage/Tax/sql/tax_setup/upgrade-1.6.0.2-1.6.0.3.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/sql/tax_setup/upgrade-1.6.0.3-1.6.0.4.php
+++ b/app/code/core/Mage/Tax/sql/tax_setup/upgrade-1.6.0.3-1.6.0.4.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Tax/sql/tax_setup/upgrade-1.6.0.3-1.6.0.4.php
+++ b/app/code/core/Mage/Tax/sql/tax_setup/upgrade-1.6.0.3-1.6.0.4.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Tax/sql/tax_setup/upgrade-1.6.0.3-1.6.0.4.php
+++ b/app/code/core/Mage/Tax/sql/tax_setup/upgrade-1.6.0.3-1.6.0.4.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/code/core/Mage/Uploader/Block/Abstract.php
+++ b/app/code/core/Mage/Uploader/Block/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Uploader

--- a/app/code/core/Mage/Uploader/Block/Abstract.php
+++ b/app/code/core/Mage/Uploader/Block/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Uploader

--- a/app/code/core/Mage/Uploader/Block/Abstract.php
+++ b/app/code/core/Mage/Uploader/Block/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Uploader/Block/Multiple.php
+++ b/app/code/core/Mage/Uploader/Block/Multiple.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Uploader

--- a/app/code/core/Mage/Uploader/Block/Multiple.php
+++ b/app/code/core/Mage/Uploader/Block/Multiple.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Uploader

--- a/app/code/core/Mage/Uploader/Block/Multiple.php
+++ b/app/code/core/Mage/Uploader/Block/Multiple.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Uploader/Block/Single.php
+++ b/app/code/core/Mage/Uploader/Block/Single.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Uploader

--- a/app/code/core/Mage/Uploader/Block/Single.php
+++ b/app/code/core/Mage/Uploader/Block/Single.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Uploader

--- a/app/code/core/Mage/Uploader/Block/Single.php
+++ b/app/code/core/Mage/Uploader/Block/Single.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Uploader/Helper/Data.php
+++ b/app/code/core/Mage/Uploader/Helper/Data.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Uploader

--- a/app/code/core/Mage/Uploader/Helper/Data.php
+++ b/app/code/core/Mage/Uploader/Helper/Data.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Uploader

--- a/app/code/core/Mage/Uploader/Helper/Data.php
+++ b/app/code/core/Mage/Uploader/Helper/Data.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Uploader/Helper/File.php
+++ b/app/code/core/Mage/Uploader/Helper/File.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Uploader

--- a/app/code/core/Mage/Uploader/Helper/File.php
+++ b/app/code/core/Mage/Uploader/Helper/File.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Uploader

--- a/app/code/core/Mage/Uploader/Helper/File.php
+++ b/app/code/core/Mage/Uploader/Helper/File.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Uploader/Model/Config/Abstract.php
+++ b/app/code/core/Mage/Uploader/Model/Config/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Uploader

--- a/app/code/core/Mage/Uploader/Model/Config/Abstract.php
+++ b/app/code/core/Mage/Uploader/Model/Config/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Uploader

--- a/app/code/core/Mage/Uploader/Model/Config/Abstract.php
+++ b/app/code/core/Mage/Uploader/Model/Config/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Uploader/Model/Config/Browsebutton.php
+++ b/app/code/core/Mage/Uploader/Model/Config/Browsebutton.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Uploader

--- a/app/code/core/Mage/Uploader/Model/Config/Browsebutton.php
+++ b/app/code/core/Mage/Uploader/Model/Config/Browsebutton.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Uploader

--- a/app/code/core/Mage/Uploader/Model/Config/Browsebutton.php
+++ b/app/code/core/Mage/Uploader/Model/Config/Browsebutton.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Uploader/Model/Config/Misc.php
+++ b/app/code/core/Mage/Uploader/Model/Config/Misc.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Uploader

--- a/app/code/core/Mage/Uploader/Model/Config/Misc.php
+++ b/app/code/core/Mage/Uploader/Model/Config/Misc.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Uploader

--- a/app/code/core/Mage/Uploader/Model/Config/Misc.php
+++ b/app/code/core/Mage/Uploader/Model/Config/Misc.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Uploader/Model/Config/Uploader.php
+++ b/app/code/core/Mage/Uploader/Model/Config/Uploader.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Uploader

--- a/app/code/core/Mage/Uploader/Model/Config/Uploader.php
+++ b/app/code/core/Mage/Uploader/Model/Config/Uploader.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Uploader

--- a/app/code/core/Mage/Uploader/Model/Config/Uploader.php
+++ b/app/code/core/Mage/Uploader/Model/Config/Uploader.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Uploader/etc/config.xml
+++ b/app/code/core/Mage/Uploader/etc/config.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Uploader

--- a/app/code/core/Mage/Uploader/etc/config.xml
+++ b/app/code/core/Mage/Uploader/etc/config.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Uploader

--- a/app/code/core/Mage/Uploader/etc/config.xml
+++ b/app/code/core/Mage/Uploader/etc/config.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Uploader/etc/jstranslator.xml
+++ b/app/code/core/Mage/Uploader/etc/jstranslator.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Uploader

--- a/app/code/core/Mage/Uploader/etc/jstranslator.xml
+++ b/app/code/core/Mage/Uploader/etc/jstranslator.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Uploader

--- a/app/code/core/Mage/Uploader/etc/jstranslator.xml
+++ b/app/code/core/Mage/Uploader/etc/jstranslator.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Usa/Block/Adminhtml/Dhl/Unitofmeasure.php
+++ b/app/code/core/Mage/Usa/Block/Adminhtml/Dhl/Unitofmeasure.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Block/Adminhtml/Dhl/Unitofmeasure.php
+++ b/app/code/core/Mage/Usa/Block/Adminhtml/Dhl/Unitofmeasure.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Usa/Block/Adminhtml/Dhl/Unitofmeasure.php
+++ b/app/code/core/Mage/Usa/Block/Adminhtml/Dhl/Unitofmeasure.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Helper/Data.php
+++ b/app/code/core/Mage/Usa/Helper/Data.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Helper/Data.php
+++ b/app/code/core/Mage/Usa/Helper/Data.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Usa/Helper/Data.php
+++ b/app/code/core/Mage/Usa/Helper/Data.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Abstract.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Abstract.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Abstract.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Abstract/Backend/Abstract.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Abstract/Backend/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Abstract/Backend/Abstract.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Abstract/Backend/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Abstract/Backend/Abstract.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Abstract/Backend/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Abstract/Source/Mode.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Abstract/Source/Mode.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Abstract/Source/Mode.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Abstract/Source/Mode.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Abstract/Source/Mode.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Abstract/Source/Mode.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Abstract/Source/Requesttype.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Abstract/Source/Requesttype.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Abstract/Source/Requesttype.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Abstract/Source/Requesttype.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Abstract/Source/Requesttype.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Abstract/Source/Requesttype.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/Abstract.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/Abstract.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/Abstract.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/International.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/International.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/International.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/International.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/International.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/International.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/International/Source/Contenttype.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/International/Source/Contenttype.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/International/Source/Contenttype.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/International/Source/Contenttype.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/International/Source/Contenttype.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/International/Source/Contenttype.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/International/Source/Method/Abstract.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/International/Source/Method/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/International/Source/Method/Abstract.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/International/Source/Method/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/International/Source/Method/Abstract.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/International/Source/Method/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/International/Source/Method/Doc.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/International/Source/Method/Doc.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/International/Source/Method/Doc.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/International/Source/Method/Doc.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/International/Source/Method/Doc.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/International/Source/Method/Doc.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/International/Source/Method/Freedoc.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/International/Source/Method/Freedoc.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/International/Source/Method/Freedoc.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/International/Source/Method/Freedoc.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/International/Source/Method/Freedoc.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/International/Source/Method/Freedoc.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/International/Source/Method/Freenondoc.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/International/Source/Method/Freenondoc.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/International/Source/Method/Freenondoc.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/International/Source/Method/Freenondoc.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/International/Source/Method/Freenondoc.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/International/Source/Method/Freenondoc.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/International/Source/Method/Nondoc.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/International/Source/Method/Nondoc.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/International/Source/Method/Nondoc.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/International/Source/Method/Nondoc.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/International/Source/Method/Nondoc.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/International/Source/Method/Nondoc.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/International/Source/Method/Size.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/International/Source/Method/Size.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/International/Source/Method/Size.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/International/Source/Method/Size.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/International/Source/Method/Size.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/International/Source/Method/Size.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/International/Source/Method/Unitofmeasure.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/International/Source/Method/Unitofmeasure.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/International/Source/Method/Unitofmeasure.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/International/Source/Method/Unitofmeasure.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/International/Source/Method/Unitofmeasure.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/International/Source/Method/Unitofmeasure.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/Label/Pdf.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/Label/Pdf.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/Label/Pdf.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/Label/Pdf.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/Label/Pdf.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/Label/Pdf.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/Label/Pdf/Page.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/Label/Pdf/Page.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/Label/Pdf/Page.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/Label/Pdf/Page.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/Label/Pdf/Page.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/Label/Pdf/Page.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/Label/Pdf/PageBuilder.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/Label/Pdf/PageBuilder.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/Label/Pdf/PageBuilder.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/Label/Pdf/PageBuilder.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/Label/Pdf/PageBuilder.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/Label/Pdf/PageBuilder.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/Source/Dutypaymenttype.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/Source/Dutypaymenttype.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/Source/Dutypaymenttype.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/Source/Dutypaymenttype.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/Source/Dutypaymenttype.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/Source/Dutypaymenttype.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/Source/Freemethod.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/Source/Freemethod.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/Source/Freemethod.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/Source/Freemethod.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/Source/Freemethod.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/Source/Freemethod.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/Source/Method.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/Source/Method.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/Source/Method.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/Source/Method.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/Source/Method.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/Source/Method.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/Source/Protection/Rounding.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/Source/Protection/Rounding.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/Source/Protection/Rounding.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/Source/Protection/Rounding.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/Source/Protection/Rounding.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/Source/Protection/Rounding.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/Source/Protection/Value.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/Source/Protection/Value.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/Source/Protection/Value.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/Source/Protection/Value.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/Source/Protection/Value.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/Source/Protection/Value.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/Source/Shipmenttype.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/Source/Shipmenttype.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/Source/Shipmenttype.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/Source/Shipmenttype.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/Source/Shipmenttype.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Dhl/Source/Shipmenttype.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Fedex.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Fedex.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Fedex.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Fedex.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Fedex.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Fedex.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Fedex/Source/Dropoff.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Fedex/Source/Dropoff.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Fedex/Source/Dropoff.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Fedex/Source/Dropoff.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Fedex/Source/Dropoff.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Fedex/Source/Dropoff.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Fedex/Source/Freemethod.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Fedex/Source/Freemethod.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Fedex/Source/Freemethod.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Fedex/Source/Freemethod.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Fedex/Source/Freemethod.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Fedex/Source/Freemethod.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Fedex/Source/Method.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Fedex/Source/Method.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Fedex/Source/Method.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Fedex/Source/Method.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Fedex/Source/Method.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Fedex/Source/Method.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Fedex/Source/Packaging.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Fedex/Source/Packaging.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Fedex/Source/Packaging.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Fedex/Source/Packaging.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Fedex/Source/Packaging.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Fedex/Source/Packaging.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Fedex/Source/Unitofmeasure.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Fedex/Source/Unitofmeasure.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Fedex/Source/Unitofmeasure.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Fedex/Source/Unitofmeasure.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Fedex/Source/Unitofmeasure.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Fedex/Source/Unitofmeasure.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups/Backend/Freemethod.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups/Backend/Freemethod.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups/Backend/Freemethod.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups/Backend/Freemethod.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups/Backend/Freemethod.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups/Backend/Freemethod.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups/Backend/OriginShipment.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups/Backend/OriginShipment.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups/Backend/OriginShipment.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups/Backend/OriginShipment.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups/Backend/OriginShipment.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups/Backend/OriginShipment.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups/Backend/Type.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups/Backend/Type.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups/Backend/Type.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups/Backend/Type.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups/Backend/Type.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups/Backend/Type.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups/Source/Container.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups/Source/Container.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups/Source/Container.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups/Source/Container.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups/Source/Container.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups/Source/Container.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups/Source/DestType.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups/Source/DestType.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups/Source/DestType.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups/Source/DestType.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups/Source/DestType.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups/Source/DestType.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups/Source/Freemethod.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups/Source/Freemethod.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups/Source/Freemethod.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups/Source/Freemethod.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups/Source/Freemethod.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups/Source/Freemethod.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups/Source/Method.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups/Source/Method.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups/Source/Method.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups/Source/Method.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups/Source/Method.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups/Source/Method.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups/Source/Mode.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups/Source/Mode.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups/Source/Mode.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups/Source/Mode.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups/Source/Mode.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups/Source/Mode.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups/Source/OriginShipment.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups/Source/OriginShipment.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups/Source/OriginShipment.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups/Source/OriginShipment.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups/Source/OriginShipment.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups/Source/OriginShipment.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups/Source/Pickup.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups/Source/Pickup.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups/Source/Pickup.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups/Source/Pickup.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups/Source/Pickup.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups/Source/Pickup.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups/Source/Type.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups/Source/Type.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups/Source/Type.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups/Source/Type.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups/Source/Type.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups/Source/Type.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups/Source/Unitofmeasure.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups/Source/Unitofmeasure.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups/Source/Unitofmeasure.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups/Source/Unitofmeasure.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups/Source/Unitofmeasure.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups/Source/Unitofmeasure.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Usps.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Usps.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Usps.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Usps.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Usps.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Usps.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Usps/Source/Container.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Usps/Source/Container.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Usps/Source/Container.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Usps/Source/Container.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Usps/Source/Container.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Usps/Source/Container.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Usps/Source/Freemethod.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Usps/Source/Freemethod.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Usps/Source/Freemethod.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Usps/Source/Freemethod.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Usps/Source/Freemethod.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Usps/Source/Freemethod.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Usps/Source/Machinable.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Usps/Source/Machinable.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Usps/Source/Machinable.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Usps/Source/Machinable.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Usps/Source/Machinable.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Usps/Source/Machinable.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Usps/Source/Method.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Usps/Source/Method.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Usps/Source/Method.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Usps/Source/Method.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Usps/Source/Method.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Usps/Source/Method.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Usps/Source/Size.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Usps/Source/Size.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Usps/Source/Size.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Usps/Source/Size.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Usps/Source/Size.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Usps/Source/Size.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/etc/config.xml
+++ b/app/code/core/Mage/Usa/etc/config.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/etc/config.xml
+++ b/app/code/core/Mage/Usa/etc/config.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/etc/config.xml
+++ b/app/code/core/Mage/Usa/etc/config.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Usa/etc/dhl/international/countries.xml
+++ b/app/code/core/Mage/Usa/etc/dhl/international/countries.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/etc/dhl/international/countries.xml
+++ b/app/code/core/Mage/Usa/etc/dhl/international/countries.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/etc/dhl/international/countries.xml
+++ b/app/code/core/Mage/Usa/etc/dhl/international/countries.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Usa/etc/system.xml
+++ b/app/code/core/Mage/Usa/etc/system.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/etc/system.xml
+++ b/app/code/core/Mage/Usa/etc/system.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/etc/system.xml
+++ b/app/code/core/Mage/Usa/etc/system.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Usa/sql/usa_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Usa/sql/usa_setup/install-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/sql/usa_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Usa/sql/usa_setup/install-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Usa/sql/usa_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Usa/sql/usa_setup/install-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/sql/usa_setup/mysql4-upgrade-0.7.0-0.7.1.php
+++ b/app/code/core/Mage/Usa/sql/usa_setup/mysql4-upgrade-0.7.0-0.7.1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/sql/usa_setup/mysql4-upgrade-0.7.0-0.7.1.php
+++ b/app/code/core/Mage/Usa/sql/usa_setup/mysql4-upgrade-0.7.0-0.7.1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Usa/sql/usa_setup/mysql4-upgrade-0.7.0-0.7.1.php
+++ b/app/code/core/Mage/Usa/sql/usa_setup/mysql4-upgrade-0.7.0-0.7.1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/sql/usa_setup/upgrade-1.6.0.0-1.6.0.1.php
+++ b/app/code/core/Mage/Usa/sql/usa_setup/upgrade-1.6.0.0-1.6.0.1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/sql/usa_setup/upgrade-1.6.0.0-1.6.0.1.php
+++ b/app/code/core/Mage/Usa/sql/usa_setup/upgrade-1.6.0.0-1.6.0.1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Usa/sql/usa_setup/upgrade-1.6.0.0-1.6.0.1.php
+++ b/app/code/core/Mage/Usa/sql/usa_setup/upgrade-1.6.0.0-1.6.0.1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/sql/usa_setup/upgrade-1.6.0.1-1.6.0.2.php
+++ b/app/code/core/Mage/Usa/sql/usa_setup/upgrade-1.6.0.1-1.6.0.2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/sql/usa_setup/upgrade-1.6.0.1-1.6.0.2.php
+++ b/app/code/core/Mage/Usa/sql/usa_setup/upgrade-1.6.0.1-1.6.0.2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Usa/sql/usa_setup/upgrade-1.6.0.1-1.6.0.2.php
+++ b/app/code/core/Mage/Usa/sql/usa_setup/upgrade-1.6.0.1-1.6.0.2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/sql/usa_setup/upgrade-1.6.0.2-1.6.0.3.php
+++ b/app/code/core/Mage/Usa/sql/usa_setup/upgrade-1.6.0.2-1.6.0.3.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Usa/sql/usa_setup/upgrade-1.6.0.2-1.6.0.3.php
+++ b/app/code/core/Mage/Usa/sql/usa_setup/upgrade-1.6.0.2-1.6.0.3.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Usa/sql/usa_setup/upgrade-1.6.0.2-1.6.0.3.php
+++ b/app/code/core/Mage/Usa/sql/usa_setup/upgrade-1.6.0.2-1.6.0.3.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/code/core/Mage/Weee/Block/Element/Weee/Tax.php
+++ b/app/code/core/Mage/Weee/Block/Element/Weee/Tax.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Weee/Block/Element/Weee/Tax.php
+++ b/app/code/core/Mage/Weee/Block/Element/Weee/Tax.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Weee

--- a/app/code/core/Mage/Weee/Block/Element/Weee/Tax.php
+++ b/app/code/core/Mage/Weee/Block/Element/Weee/Tax.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Weee

--- a/app/code/core/Mage/Weee/Block/Renderer/Weee/Tax.php
+++ b/app/code/core/Mage/Weee/Block/Renderer/Weee/Tax.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Weee/Block/Renderer/Weee/Tax.php
+++ b/app/code/core/Mage/Weee/Block/Renderer/Weee/Tax.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Weee

--- a/app/code/core/Mage/Weee/Block/Renderer/Weee/Tax.php
+++ b/app/code/core/Mage/Weee/Block/Renderer/Weee/Tax.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Weee

--- a/app/code/core/Mage/Weee/Helper/Data.php
+++ b/app/code/core/Mage/Weee/Helper/Data.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Weee/Helper/Data.php
+++ b/app/code/core/Mage/Weee/Helper/Data.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Weee

--- a/app/code/core/Mage/Weee/Helper/Data.php
+++ b/app/code/core/Mage/Weee/Helper/Data.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Weee

--- a/app/code/core/Mage/Weee/Model/Attribute/Backend/Weee/Tax.php
+++ b/app/code/core/Mage/Weee/Model/Attribute/Backend/Weee/Tax.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Weee/Model/Attribute/Backend/Weee/Tax.php
+++ b/app/code/core/Mage/Weee/Model/Attribute/Backend/Weee/Tax.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Weee

--- a/app/code/core/Mage/Weee/Model/Attribute/Backend/Weee/Tax.php
+++ b/app/code/core/Mage/Weee/Model/Attribute/Backend/Weee/Tax.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Weee

--- a/app/code/core/Mage/Weee/Model/Config/Source/Display.php
+++ b/app/code/core/Mage/Weee/Model/Config/Source/Display.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Weee/Model/Config/Source/Display.php
+++ b/app/code/core/Mage/Weee/Model/Config/Source/Display.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Weee

--- a/app/code/core/Mage/Weee/Model/Config/Source/Display.php
+++ b/app/code/core/Mage/Weee/Model/Config/Source/Display.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Weee

--- a/app/code/core/Mage/Weee/Model/Config/Source/Fpt/Tax.php
+++ b/app/code/core/Mage/Weee/Model/Config/Source/Fpt/Tax.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Weee/Model/Config/Source/Fpt/Tax.php
+++ b/app/code/core/Mage/Weee/Model/Config/Source/Fpt/Tax.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Weee

--- a/app/code/core/Mage/Weee/Model/Config/Source/Fpt/Tax.php
+++ b/app/code/core/Mage/Weee/Model/Config/Source/Fpt/Tax.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Weee

--- a/app/code/core/Mage/Weee/Model/Mysql4/Attribute/Backend/Weee/Tax.php
+++ b/app/code/core/Mage/Weee/Model/Mysql4/Attribute/Backend/Weee/Tax.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Weee/Model/Mysql4/Attribute/Backend/Weee/Tax.php
+++ b/app/code/core/Mage/Weee/Model/Mysql4/Attribute/Backend/Weee/Tax.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Weee

--- a/app/code/core/Mage/Weee/Model/Mysql4/Attribute/Backend/Weee/Tax.php
+++ b/app/code/core/Mage/Weee/Model/Mysql4/Attribute/Backend/Weee/Tax.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Weee

--- a/app/code/core/Mage/Weee/Model/Mysql4/Setup.php
+++ b/app/code/core/Mage/Weee/Model/Mysql4/Setup.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Weee/Model/Mysql4/Setup.php
+++ b/app/code/core/Mage/Weee/Model/Mysql4/Setup.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Weee

--- a/app/code/core/Mage/Weee/Model/Mysql4/Setup.php
+++ b/app/code/core/Mage/Weee/Model/Mysql4/Setup.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Weee

--- a/app/code/core/Mage/Weee/Model/Mysql4/Tax.php
+++ b/app/code/core/Mage/Weee/Model/Mysql4/Tax.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Weee/Model/Mysql4/Tax.php
+++ b/app/code/core/Mage/Weee/Model/Mysql4/Tax.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Weee

--- a/app/code/core/Mage/Weee/Model/Mysql4/Tax.php
+++ b/app/code/core/Mage/Weee/Model/Mysql4/Tax.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Weee

--- a/app/code/core/Mage/Weee/Model/Observer.php
+++ b/app/code/core/Mage/Weee/Model/Observer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Weee/Model/Observer.php
+++ b/app/code/core/Mage/Weee/Model/Observer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Weee

--- a/app/code/core/Mage/Weee/Model/Observer.php
+++ b/app/code/core/Mage/Weee/Model/Observer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Weee

--- a/app/code/core/Mage/Weee/Model/Resource/Attribute/Backend/Weee/Tax.php
+++ b/app/code/core/Mage/Weee/Model/Resource/Attribute/Backend/Weee/Tax.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Weee/Model/Resource/Attribute/Backend/Weee/Tax.php
+++ b/app/code/core/Mage/Weee/Model/Resource/Attribute/Backend/Weee/Tax.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Weee

--- a/app/code/core/Mage/Weee/Model/Resource/Attribute/Backend/Weee/Tax.php
+++ b/app/code/core/Mage/Weee/Model/Resource/Attribute/Backend/Weee/Tax.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Weee

--- a/app/code/core/Mage/Weee/Model/Resource/Setup.php
+++ b/app/code/core/Mage/Weee/Model/Resource/Setup.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Weee/Model/Resource/Setup.php
+++ b/app/code/core/Mage/Weee/Model/Resource/Setup.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Weee

--- a/app/code/core/Mage/Weee/Model/Resource/Setup.php
+++ b/app/code/core/Mage/Weee/Model/Resource/Setup.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Weee

--- a/app/code/core/Mage/Weee/Model/Resource/Tax.php
+++ b/app/code/core/Mage/Weee/Model/Resource/Tax.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Weee/Model/Resource/Tax.php
+++ b/app/code/core/Mage/Weee/Model/Resource/Tax.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Weee

--- a/app/code/core/Mage/Weee/Model/Resource/Tax.php
+++ b/app/code/core/Mage/Weee/Model/Resource/Tax.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Weee

--- a/app/code/core/Mage/Weee/Model/Tax.php
+++ b/app/code/core/Mage/Weee/Model/Tax.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Weee/Model/Tax.php
+++ b/app/code/core/Mage/Weee/Model/Tax.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Weee

--- a/app/code/core/Mage/Weee/Model/Tax.php
+++ b/app/code/core/Mage/Weee/Model/Tax.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Weee

--- a/app/code/core/Mage/Weee/Model/Total/Creditmemo/Weee.php
+++ b/app/code/core/Mage/Weee/Model/Total/Creditmemo/Weee.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Weee/Model/Total/Creditmemo/Weee.php
+++ b/app/code/core/Mage/Weee/Model/Total/Creditmemo/Weee.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Weee

--- a/app/code/core/Mage/Weee/Model/Total/Creditmemo/Weee.php
+++ b/app/code/core/Mage/Weee/Model/Total/Creditmemo/Weee.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Weee

--- a/app/code/core/Mage/Weee/Model/Total/Invoice/Weee.php
+++ b/app/code/core/Mage/Weee/Model/Total/Invoice/Weee.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Weee/Model/Total/Invoice/Weee.php
+++ b/app/code/core/Mage/Weee/Model/Total/Invoice/Weee.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Weee

--- a/app/code/core/Mage/Weee/Model/Total/Invoice/Weee.php
+++ b/app/code/core/Mage/Weee/Model/Total/Invoice/Weee.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Weee

--- a/app/code/core/Mage/Weee/Model/Total/Quote/Nominal/Weee.php
+++ b/app/code/core/Mage/Weee/Model/Total/Quote/Nominal/Weee.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Weee/Model/Total/Quote/Nominal/Weee.php
+++ b/app/code/core/Mage/Weee/Model/Total/Quote/Nominal/Weee.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Weee

--- a/app/code/core/Mage/Weee/Model/Total/Quote/Nominal/Weee.php
+++ b/app/code/core/Mage/Weee/Model/Total/Quote/Nominal/Weee.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Weee

--- a/app/code/core/Mage/Weee/Model/Total/Quote/Weee.php
+++ b/app/code/core/Mage/Weee/Model/Total/Quote/Weee.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Weee/Model/Total/Quote/Weee.php
+++ b/app/code/core/Mage/Weee/Model/Total/Quote/Weee.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Weee

--- a/app/code/core/Mage/Weee/Model/Total/Quote/Weee.php
+++ b/app/code/core/Mage/Weee/Model/Total/Quote/Weee.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Weee

--- a/app/code/core/Mage/Weee/etc/config.xml
+++ b/app/code/core/Mage/Weee/etc/config.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Weee

--- a/app/code/core/Mage/Weee/etc/config.xml
+++ b/app/code/core/Mage/Weee/etc/config.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Weee/etc/config.xml
+++ b/app/code/core/Mage/Weee/etc/config.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Weee

--- a/app/code/core/Mage/Weee/etc/system.xml
+++ b/app/code/core/Mage/Weee/etc/system.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Weee

--- a/app/code/core/Mage/Weee/etc/system.xml
+++ b/app/code/core/Mage/Weee/etc/system.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Weee/etc/system.xml
+++ b/app/code/core/Mage/Weee/etc/system.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Weee

--- a/app/code/core/Mage/Weee/sql/weee_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Weee/sql/weee_setup/install-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Weee/sql/weee_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Weee/sql/weee_setup/install-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Weee

--- a/app/code/core/Mage/Weee/sql/weee_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Weee/sql/weee_setup/install-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Weee

--- a/app/code/core/Mage/Weee/sql/weee_setup/mysql4-install-0.1.php
+++ b/app/code/core/Mage/Weee/sql/weee_setup/mysql4-install-0.1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Weee/sql/weee_setup/mysql4-install-0.1.php
+++ b/app/code/core/Mage/Weee/sql/weee_setup/mysql4-install-0.1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Weee

--- a/app/code/core/Mage/Weee/sql/weee_setup/mysql4-install-0.1.php
+++ b/app/code/core/Mage/Weee/sql/weee_setup/mysql4-install-0.1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Weee

--- a/app/code/core/Mage/Weee/sql/weee_setup/mysql4-upgrade-0.1-0.2.php
+++ b/app/code/core/Mage/Weee/sql/weee_setup/mysql4-upgrade-0.1-0.2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Weee/sql/weee_setup/mysql4-upgrade-0.1-0.2.php
+++ b/app/code/core/Mage/Weee/sql/weee_setup/mysql4-upgrade-0.1-0.2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Weee

--- a/app/code/core/Mage/Weee/sql/weee_setup/mysql4-upgrade-0.1-0.2.php
+++ b/app/code/core/Mage/Weee/sql/weee_setup/mysql4-upgrade-0.1-0.2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Weee

--- a/app/code/core/Mage/Weee/sql/weee_setup/mysql4-upgrade-0.10-0.11.php
+++ b/app/code/core/Mage/Weee/sql/weee_setup/mysql4-upgrade-0.10-0.11.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Weee/sql/weee_setup/mysql4-upgrade-0.10-0.11.php
+++ b/app/code/core/Mage/Weee/sql/weee_setup/mysql4-upgrade-0.10-0.11.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Weee

--- a/app/code/core/Mage/Weee/sql/weee_setup/mysql4-upgrade-0.10-0.11.php
+++ b/app/code/core/Mage/Weee/sql/weee_setup/mysql4-upgrade-0.10-0.11.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Weee

--- a/app/code/core/Mage/Weee/sql/weee_setup/mysql4-upgrade-0.11-0.12.php
+++ b/app/code/core/Mage/Weee/sql/weee_setup/mysql4-upgrade-0.11-0.12.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Weee/sql/weee_setup/mysql4-upgrade-0.11-0.12.php
+++ b/app/code/core/Mage/Weee/sql/weee_setup/mysql4-upgrade-0.11-0.12.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Weee

--- a/app/code/core/Mage/Weee/sql/weee_setup/mysql4-upgrade-0.11-0.12.php
+++ b/app/code/core/Mage/Weee/sql/weee_setup/mysql4-upgrade-0.11-0.12.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Weee

--- a/app/code/core/Mage/Weee/sql/weee_setup/mysql4-upgrade-0.12-0.13.php
+++ b/app/code/core/Mage/Weee/sql/weee_setup/mysql4-upgrade-0.12-0.13.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Weee/sql/weee_setup/mysql4-upgrade-0.12-0.13.php
+++ b/app/code/core/Mage/Weee/sql/weee_setup/mysql4-upgrade-0.12-0.13.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Weee

--- a/app/code/core/Mage/Weee/sql/weee_setup/mysql4-upgrade-0.12-0.13.php
+++ b/app/code/core/Mage/Weee/sql/weee_setup/mysql4-upgrade-0.12-0.13.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Weee

--- a/app/code/core/Mage/Weee/sql/weee_setup/mysql4-upgrade-0.2-0.3.php
+++ b/app/code/core/Mage/Weee/sql/weee_setup/mysql4-upgrade-0.2-0.3.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Weee/sql/weee_setup/mysql4-upgrade-0.2-0.3.php
+++ b/app/code/core/Mage/Weee/sql/weee_setup/mysql4-upgrade-0.2-0.3.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Weee

--- a/app/code/core/Mage/Weee/sql/weee_setup/mysql4-upgrade-0.2-0.3.php
+++ b/app/code/core/Mage/Weee/sql/weee_setup/mysql4-upgrade-0.2-0.3.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Weee

--- a/app/code/core/Mage/Weee/sql/weee_setup/mysql4-upgrade-0.3-0.4.php
+++ b/app/code/core/Mage/Weee/sql/weee_setup/mysql4-upgrade-0.3-0.4.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Weee/sql/weee_setup/mysql4-upgrade-0.3-0.4.php
+++ b/app/code/core/Mage/Weee/sql/weee_setup/mysql4-upgrade-0.3-0.4.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Weee

--- a/app/code/core/Mage/Weee/sql/weee_setup/mysql4-upgrade-0.3-0.4.php
+++ b/app/code/core/Mage/Weee/sql/weee_setup/mysql4-upgrade-0.3-0.4.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Weee

--- a/app/code/core/Mage/Weee/sql/weee_setup/mysql4-upgrade-0.4-0.5.php
+++ b/app/code/core/Mage/Weee/sql/weee_setup/mysql4-upgrade-0.4-0.5.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Weee/sql/weee_setup/mysql4-upgrade-0.4-0.5.php
+++ b/app/code/core/Mage/Weee/sql/weee_setup/mysql4-upgrade-0.4-0.5.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Weee

--- a/app/code/core/Mage/Weee/sql/weee_setup/mysql4-upgrade-0.4-0.5.php
+++ b/app/code/core/Mage/Weee/sql/weee_setup/mysql4-upgrade-0.4-0.5.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Weee

--- a/app/code/core/Mage/Weee/sql/weee_setup/mysql4-upgrade-0.5-0.6.php
+++ b/app/code/core/Mage/Weee/sql/weee_setup/mysql4-upgrade-0.5-0.6.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Weee/sql/weee_setup/mysql4-upgrade-0.5-0.6.php
+++ b/app/code/core/Mage/Weee/sql/weee_setup/mysql4-upgrade-0.5-0.6.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Weee

--- a/app/code/core/Mage/Weee/sql/weee_setup/mysql4-upgrade-0.5-0.6.php
+++ b/app/code/core/Mage/Weee/sql/weee_setup/mysql4-upgrade-0.5-0.6.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Weee

--- a/app/code/core/Mage/Weee/sql/weee_setup/mysql4-upgrade-0.6-0.7.php
+++ b/app/code/core/Mage/Weee/sql/weee_setup/mysql4-upgrade-0.6-0.7.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Weee/sql/weee_setup/mysql4-upgrade-0.6-0.7.php
+++ b/app/code/core/Mage/Weee/sql/weee_setup/mysql4-upgrade-0.6-0.7.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Weee

--- a/app/code/core/Mage/Weee/sql/weee_setup/mysql4-upgrade-0.6-0.7.php
+++ b/app/code/core/Mage/Weee/sql/weee_setup/mysql4-upgrade-0.6-0.7.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Weee

--- a/app/code/core/Mage/Weee/sql/weee_setup/mysql4-upgrade-0.7-0.8.php
+++ b/app/code/core/Mage/Weee/sql/weee_setup/mysql4-upgrade-0.7-0.8.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Weee/sql/weee_setup/mysql4-upgrade-0.7-0.8.php
+++ b/app/code/core/Mage/Weee/sql/weee_setup/mysql4-upgrade-0.7-0.8.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Weee

--- a/app/code/core/Mage/Weee/sql/weee_setup/mysql4-upgrade-0.7-0.8.php
+++ b/app/code/core/Mage/Weee/sql/weee_setup/mysql4-upgrade-0.7-0.8.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Weee

--- a/app/code/core/Mage/Weee/sql/weee_setup/mysql4-upgrade-0.8-0.9.php
+++ b/app/code/core/Mage/Weee/sql/weee_setup/mysql4-upgrade-0.8-0.9.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Weee/sql/weee_setup/mysql4-upgrade-0.8-0.9.php
+++ b/app/code/core/Mage/Weee/sql/weee_setup/mysql4-upgrade-0.8-0.9.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Weee

--- a/app/code/core/Mage/Weee/sql/weee_setup/mysql4-upgrade-0.8-0.9.php
+++ b/app/code/core/Mage/Weee/sql/weee_setup/mysql4-upgrade-0.8-0.9.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Weee

--- a/app/code/core/Mage/Weee/sql/weee_setup/mysql4-upgrade-0.9-0.10.php
+++ b/app/code/core/Mage/Weee/sql/weee_setup/mysql4-upgrade-0.9-0.10.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Weee/sql/weee_setup/mysql4-upgrade-0.9-0.10.php
+++ b/app/code/core/Mage/Weee/sql/weee_setup/mysql4-upgrade-0.9-0.10.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Weee

--- a/app/code/core/Mage/Weee/sql/weee_setup/mysql4-upgrade-0.9-0.10.php
+++ b/app/code/core/Mage/Weee/sql/weee_setup/mysql4-upgrade-0.9-0.10.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Weee

--- a/app/code/core/Mage/Weee/sql/weee_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/Weee/sql/weee_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Weee/sql/weee_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/Weee/sql/weee_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Weee

--- a/app/code/core/Mage/Weee/sql/weee_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/Weee/sql/weee_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Weee

--- a/app/code/core/Mage/Widget/Block/Adminhtml/Widget.php
+++ b/app/code/core/Mage/Widget/Block/Adminhtml/Widget.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Widget

--- a/app/code/core/Mage/Widget/Block/Adminhtml/Widget.php
+++ b/app/code/core/Mage/Widget/Block/Adminhtml/Widget.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Widget/Block/Adminhtml/Widget.php
+++ b/app/code/core/Mage/Widget/Block/Adminhtml/Widget.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Widget

--- a/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Chooser.php
+++ b/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Chooser.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Widget

--- a/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Chooser.php
+++ b/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Chooser.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Chooser.php
+++ b/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Chooser.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Widget

--- a/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Form.php
+++ b/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Widget

--- a/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Form.php
+++ b/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Form.php
+++ b/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Widget

--- a/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Instance.php
+++ b/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Instance.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Widget

--- a/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Instance.php
+++ b/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Instance.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Instance.php
+++ b/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Instance.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Widget

--- a/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Instance/Edit.php
+++ b/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Instance/Edit.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Widget

--- a/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Instance/Edit.php
+++ b/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Instance/Edit.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Instance/Edit.php
+++ b/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Instance/Edit.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Widget

--- a/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Instance/Edit/Chooser/Block.php
+++ b/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Instance/Edit/Chooser/Block.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Widget

--- a/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Instance/Edit/Chooser/Block.php
+++ b/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Instance/Edit/Chooser/Block.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Instance/Edit/Chooser/Block.php
+++ b/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Instance/Edit/Chooser/Block.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Widget

--- a/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Instance/Edit/Chooser/Layout.php
+++ b/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Instance/Edit/Chooser/Layout.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Widget

--- a/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Instance/Edit/Chooser/Layout.php
+++ b/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Instance/Edit/Chooser/Layout.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Instance/Edit/Chooser/Layout.php
+++ b/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Instance/Edit/Chooser/Layout.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Widget

--- a/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Instance/Edit/Chooser/Template.php
+++ b/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Instance/Edit/Chooser/Template.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Widget

--- a/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Instance/Edit/Chooser/Template.php
+++ b/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Instance/Edit/Chooser/Template.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Instance/Edit/Chooser/Template.php
+++ b/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Instance/Edit/Chooser/Template.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Widget

--- a/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Instance/Edit/Form.php
+++ b/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Instance/Edit/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Widget

--- a/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Instance/Edit/Form.php
+++ b/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Instance/Edit/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Instance/Edit/Form.php
+++ b/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Instance/Edit/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Widget

--- a/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Instance/Edit/Tab/Main.php
+++ b/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Instance/Edit/Tab/Main.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Widget

--- a/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Instance/Edit/Tab/Main.php
+++ b/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Instance/Edit/Tab/Main.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Instance/Edit/Tab/Main.php
+++ b/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Instance/Edit/Tab/Main.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Widget

--- a/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Instance/Edit/Tab/Main/Layout.php
+++ b/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Instance/Edit/Tab/Main/Layout.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Widget

--- a/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Instance/Edit/Tab/Main/Layout.php
+++ b/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Instance/Edit/Tab/Main/Layout.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Instance/Edit/Tab/Main/Layout.php
+++ b/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Instance/Edit/Tab/Main/Layout.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Widget

--- a/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Instance/Edit/Tab/Properties.php
+++ b/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Instance/Edit/Tab/Properties.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Widget

--- a/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Instance/Edit/Tab/Properties.php
+++ b/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Instance/Edit/Tab/Properties.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Instance/Edit/Tab/Properties.php
+++ b/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Instance/Edit/Tab/Properties.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Widget

--- a/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Instance/Edit/Tab/Settings.php
+++ b/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Instance/Edit/Tab/Settings.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Widget

--- a/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Instance/Edit/Tab/Settings.php
+++ b/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Instance/Edit/Tab/Settings.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Instance/Edit/Tab/Settings.php
+++ b/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Instance/Edit/Tab/Settings.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Widget

--- a/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Instance/Edit/Tabs.php
+++ b/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Instance/Edit/Tabs.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Widget

--- a/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Instance/Edit/Tabs.php
+++ b/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Instance/Edit/Tabs.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Instance/Edit/Tabs.php
+++ b/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Instance/Edit/Tabs.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Widget

--- a/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Instance/Grid.php
+++ b/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Instance/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Widget

--- a/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Instance/Grid.php
+++ b/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Instance/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Instance/Grid.php
+++ b/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Instance/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Widget

--- a/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Options.php
+++ b/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Options.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Widget

--- a/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Options.php
+++ b/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Options.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Options.php
+++ b/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Options.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Widget

--- a/app/code/core/Mage/Widget/Block/Interface.php
+++ b/app/code/core/Mage/Widget/Block/Interface.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Widget

--- a/app/code/core/Mage/Widget/Block/Interface.php
+++ b/app/code/core/Mage/Widget/Block/Interface.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Widget/Block/Interface.php
+++ b/app/code/core/Mage/Widget/Block/Interface.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Widget

--- a/app/code/core/Mage/Widget/Helper/Data.php
+++ b/app/code/core/Mage/Widget/Helper/Data.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Widget

--- a/app/code/core/Mage/Widget/Helper/Data.php
+++ b/app/code/core/Mage/Widget/Helper/Data.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Widget/Helper/Data.php
+++ b/app/code/core/Mage/Widget/Helper/Data.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Widget

--- a/app/code/core/Mage/Widget/Model/Mysql4/Widget.php
+++ b/app/code/core/Mage/Widget/Model/Mysql4/Widget.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Widget

--- a/app/code/core/Mage/Widget/Model/Mysql4/Widget.php
+++ b/app/code/core/Mage/Widget/Model/Mysql4/Widget.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Widget/Model/Mysql4/Widget.php
+++ b/app/code/core/Mage/Widget/Model/Mysql4/Widget.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Widget

--- a/app/code/core/Mage/Widget/Model/Mysql4/Widget/Instance.php
+++ b/app/code/core/Mage/Widget/Model/Mysql4/Widget/Instance.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Widget

--- a/app/code/core/Mage/Widget/Model/Mysql4/Widget/Instance.php
+++ b/app/code/core/Mage/Widget/Model/Mysql4/Widget/Instance.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Widget/Model/Mysql4/Widget/Instance.php
+++ b/app/code/core/Mage/Widget/Model/Mysql4/Widget/Instance.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Widget

--- a/app/code/core/Mage/Widget/Model/Mysql4/Widget/Instance/Collection.php
+++ b/app/code/core/Mage/Widget/Model/Mysql4/Widget/Instance/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Widget

--- a/app/code/core/Mage/Widget/Model/Mysql4/Widget/Instance/Collection.php
+++ b/app/code/core/Mage/Widget/Model/Mysql4/Widget/Instance/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Widget/Model/Mysql4/Widget/Instance/Collection.php
+++ b/app/code/core/Mage/Widget/Model/Mysql4/Widget/Instance/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Widget

--- a/app/code/core/Mage/Widget/Model/Observer.php
+++ b/app/code/core/Mage/Widget/Model/Observer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Widget

--- a/app/code/core/Mage/Widget/Model/Observer.php
+++ b/app/code/core/Mage/Widget/Model/Observer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Widget/Model/Observer.php
+++ b/app/code/core/Mage/Widget/Model/Observer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Widget

--- a/app/code/core/Mage/Widget/Model/Resource/Widget.php
+++ b/app/code/core/Mage/Widget/Model/Resource/Widget.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Widget

--- a/app/code/core/Mage/Widget/Model/Resource/Widget.php
+++ b/app/code/core/Mage/Widget/Model/Resource/Widget.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Widget/Model/Resource/Widget.php
+++ b/app/code/core/Mage/Widget/Model/Resource/Widget.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Widget

--- a/app/code/core/Mage/Widget/Model/Resource/Widget/Instance.php
+++ b/app/code/core/Mage/Widget/Model/Resource/Widget/Instance.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Widget

--- a/app/code/core/Mage/Widget/Model/Resource/Widget/Instance.php
+++ b/app/code/core/Mage/Widget/Model/Resource/Widget/Instance.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Widget/Model/Resource/Widget/Instance.php
+++ b/app/code/core/Mage/Widget/Model/Resource/Widget/Instance.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Widget

--- a/app/code/core/Mage/Widget/Model/Resource/Widget/Instance/Collection.php
+++ b/app/code/core/Mage/Widget/Model/Resource/Widget/Instance/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Widget

--- a/app/code/core/Mage/Widget/Model/Resource/Widget/Instance/Collection.php
+++ b/app/code/core/Mage/Widget/Model/Resource/Widget/Instance/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Widget/Model/Resource/Widget/Instance/Collection.php
+++ b/app/code/core/Mage/Widget/Model/Resource/Widget/Instance/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Widget

--- a/app/code/core/Mage/Widget/Model/Template/Filter.php
+++ b/app/code/core/Mage/Widget/Model/Template/Filter.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Widget

--- a/app/code/core/Mage/Widget/Model/Template/Filter.php
+++ b/app/code/core/Mage/Widget/Model/Template/Filter.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Widget/Model/Template/Filter.php
+++ b/app/code/core/Mage/Widget/Model/Template/Filter.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Widget

--- a/app/code/core/Mage/Widget/Model/Widget.php
+++ b/app/code/core/Mage/Widget/Model/Widget.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Widget

--- a/app/code/core/Mage/Widget/Model/Widget.php
+++ b/app/code/core/Mage/Widget/Model/Widget.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Widget/Model/Widget.php
+++ b/app/code/core/Mage/Widget/Model/Widget.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Widget

--- a/app/code/core/Mage/Widget/Model/Widget/Config.php
+++ b/app/code/core/Mage/Widget/Model/Widget/Config.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Widget

--- a/app/code/core/Mage/Widget/Model/Widget/Config.php
+++ b/app/code/core/Mage/Widget/Model/Widget/Config.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Widget/Model/Widget/Config.php
+++ b/app/code/core/Mage/Widget/Model/Widget/Config.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Widget

--- a/app/code/core/Mage/Widget/Model/Widget/Instance.php
+++ b/app/code/core/Mage/Widget/Model/Widget/Instance.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Widget

--- a/app/code/core/Mage/Widget/Model/Widget/Instance.php
+++ b/app/code/core/Mage/Widget/Model/Widget/Instance.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Widget/Model/Widget/Instance.php
+++ b/app/code/core/Mage/Widget/Model/Widget/Instance.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Widget

--- a/app/code/core/Mage/Widget/controllers/Adminhtml/Widget/InstanceController.php
+++ b/app/code/core/Mage/Widget/controllers/Adminhtml/Widget/InstanceController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Widget

--- a/app/code/core/Mage/Widget/controllers/Adminhtml/Widget/InstanceController.php
+++ b/app/code/core/Mage/Widget/controllers/Adminhtml/Widget/InstanceController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Widget/controllers/Adminhtml/Widget/InstanceController.php
+++ b/app/code/core/Mage/Widget/controllers/Adminhtml/Widget/InstanceController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Widget

--- a/app/code/core/Mage/Widget/controllers/Adminhtml/WidgetController.php
+++ b/app/code/core/Mage/Widget/controllers/Adminhtml/WidgetController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Widget

--- a/app/code/core/Mage/Widget/controllers/Adminhtml/WidgetController.php
+++ b/app/code/core/Mage/Widget/controllers/Adminhtml/WidgetController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Widget/controllers/Adminhtml/WidgetController.php
+++ b/app/code/core/Mage/Widget/controllers/Adminhtml/WidgetController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Widget

--- a/app/code/core/Mage/Widget/etc/adminhtml.xml
+++ b/app/code/core/Mage/Widget/etc/adminhtml.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Widget

--- a/app/code/core/Mage/Widget/etc/adminhtml.xml
+++ b/app/code/core/Mage/Widget/etc/adminhtml.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Widget/etc/adminhtml.xml
+++ b/app/code/core/Mage/Widget/etc/adminhtml.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Widget

--- a/app/code/core/Mage/Widget/etc/config.xml
+++ b/app/code/core/Mage/Widget/etc/config.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Widget

--- a/app/code/core/Mage/Widget/etc/config.xml
+++ b/app/code/core/Mage/Widget/etc/config.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Widget/etc/config.xml
+++ b/app/code/core/Mage/Widget/etc/config.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Widget

--- a/app/code/core/Mage/Widget/etc/jstranslator.xml
+++ b/app/code/core/Mage/Widget/etc/jstranslator.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Widget

--- a/app/code/core/Mage/Widget/etc/jstranslator.xml
+++ b/app/code/core/Mage/Widget/etc/jstranslator.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Widget/etc/jstranslator.xml
+++ b/app/code/core/Mage/Widget/etc/jstranslator.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Widget

--- a/app/code/core/Mage/Widget/sql/widget_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Widget/sql/widget_setup/install-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Widget

--- a/app/code/core/Mage/Widget/sql/widget_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Widget/sql/widget_setup/install-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Widget/sql/widget_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Widget/sql/widget_setup/install-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Widget

--- a/app/code/core/Mage/Widget/sql/widget_setup/mysql4-install-1.4.0.0.0.php
+++ b/app/code/core/Mage/Widget/sql/widget_setup/mysql4-install-1.4.0.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Widget

--- a/app/code/core/Mage/Widget/sql/widget_setup/mysql4-install-1.4.0.0.0.php
+++ b/app/code/core/Mage/Widget/sql/widget_setup/mysql4-install-1.4.0.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Widget/sql/widget_setup/mysql4-install-1.4.0.0.0.php
+++ b/app/code/core/Mage/Widget/sql/widget_setup/mysql4-install-1.4.0.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Widget

--- a/app/code/core/Mage/Widget/sql/widget_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/Widget/sql/widget_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Widget

--- a/app/code/core/Mage/Widget/sql/widget_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/Widget/sql/widget_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Widget/sql/widget_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/Widget/sql/widget_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Widget

--- a/app/code/core/Mage/Wishlist/Block/Abstract.php
+++ b/app/code/core/Mage/Wishlist/Block/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/Block/Abstract.php
+++ b/app/code/core/Mage/Wishlist/Block/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Wishlist/Block/Abstract.php
+++ b/app/code/core/Mage/Wishlist/Block/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/Block/Customer/Sharing.php
+++ b/app/code/core/Mage/Wishlist/Block/Customer/Sharing.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/Block/Customer/Sharing.php
+++ b/app/code/core/Mage/Wishlist/Block/Customer/Sharing.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Wishlist/Block/Customer/Sharing.php
+++ b/app/code/core/Mage/Wishlist/Block/Customer/Sharing.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/Block/Customer/Sidebar.php
+++ b/app/code/core/Mage/Wishlist/Block/Customer/Sidebar.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/Block/Customer/Sidebar.php
+++ b/app/code/core/Mage/Wishlist/Block/Customer/Sidebar.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Wishlist/Block/Customer/Sidebar.php
+++ b/app/code/core/Mage/Wishlist/Block/Customer/Sidebar.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/Block/Customer/Wishlist.php
+++ b/app/code/core/Mage/Wishlist/Block/Customer/Wishlist.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/Block/Customer/Wishlist.php
+++ b/app/code/core/Mage/Wishlist/Block/Customer/Wishlist.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Wishlist/Block/Customer/Wishlist.php
+++ b/app/code/core/Mage/Wishlist/Block/Customer/Wishlist.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/Block/Customer/Wishlist/Button.php
+++ b/app/code/core/Mage/Wishlist/Block/Customer/Wishlist/Button.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/Block/Customer/Wishlist/Button.php
+++ b/app/code/core/Mage/Wishlist/Block/Customer/Wishlist/Button.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Wishlist/Block/Customer/Wishlist/Button.php
+++ b/app/code/core/Mage/Wishlist/Block/Customer/Wishlist/Button.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/Block/Customer/Wishlist/Item/Column.php
+++ b/app/code/core/Mage/Wishlist/Block/Customer/Wishlist/Item/Column.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/Block/Customer/Wishlist/Item/Column.php
+++ b/app/code/core/Mage/Wishlist/Block/Customer/Wishlist/Item/Column.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Wishlist/Block/Customer/Wishlist/Item/Column.php
+++ b/app/code/core/Mage/Wishlist/Block/Customer/Wishlist/Item/Column.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/Block/Customer/Wishlist/Item/Column/Cart.php
+++ b/app/code/core/Mage/Wishlist/Block/Customer/Wishlist/Item/Column/Cart.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/Block/Customer/Wishlist/Item/Column/Cart.php
+++ b/app/code/core/Mage/Wishlist/Block/Customer/Wishlist/Item/Column/Cart.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Wishlist/Block/Customer/Wishlist/Item/Column/Cart.php
+++ b/app/code/core/Mage/Wishlist/Block/Customer/Wishlist/Item/Column/Cart.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/Block/Customer/Wishlist/Item/Column/Comment.php
+++ b/app/code/core/Mage/Wishlist/Block/Customer/Wishlist/Item/Column/Comment.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/Block/Customer/Wishlist/Item/Column/Comment.php
+++ b/app/code/core/Mage/Wishlist/Block/Customer/Wishlist/Item/Column/Comment.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Wishlist/Block/Customer/Wishlist/Item/Column/Comment.php
+++ b/app/code/core/Mage/Wishlist/Block/Customer/Wishlist/Item/Column/Comment.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/Block/Customer/Wishlist/Item/Column/Image.php
+++ b/app/code/core/Mage/Wishlist/Block/Customer/Wishlist/Item/Column/Image.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/Block/Customer/Wishlist/Item/Column/Image.php
+++ b/app/code/core/Mage/Wishlist/Block/Customer/Wishlist/Item/Column/Image.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Wishlist/Block/Customer/Wishlist/Item/Column/Image.php
+++ b/app/code/core/Mage/Wishlist/Block/Customer/Wishlist/Item/Column/Image.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/Block/Customer/Wishlist/Item/Column/Remove.php
+++ b/app/code/core/Mage/Wishlist/Block/Customer/Wishlist/Item/Column/Remove.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/Block/Customer/Wishlist/Item/Column/Remove.php
+++ b/app/code/core/Mage/Wishlist/Block/Customer/Wishlist/Item/Column/Remove.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Wishlist/Block/Customer/Wishlist/Item/Column/Remove.php
+++ b/app/code/core/Mage/Wishlist/Block/Customer/Wishlist/Item/Column/Remove.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/Block/Customer/Wishlist/Item/Options.php
+++ b/app/code/core/Mage/Wishlist/Block/Customer/Wishlist/Item/Options.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/Block/Customer/Wishlist/Item/Options.php
+++ b/app/code/core/Mage/Wishlist/Block/Customer/Wishlist/Item/Options.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Wishlist/Block/Customer/Wishlist/Item/Options.php
+++ b/app/code/core/Mage/Wishlist/Block/Customer/Wishlist/Item/Options.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/Block/Customer/Wishlist/Items.php
+++ b/app/code/core/Mage/Wishlist/Block/Customer/Wishlist/Items.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/Block/Customer/Wishlist/Items.php
+++ b/app/code/core/Mage/Wishlist/Block/Customer/Wishlist/Items.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Wishlist/Block/Customer/Wishlist/Items.php
+++ b/app/code/core/Mage/Wishlist/Block/Customer/Wishlist/Items.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/Block/Item/Configure.php
+++ b/app/code/core/Mage/Wishlist/Block/Item/Configure.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/Block/Item/Configure.php
+++ b/app/code/core/Mage/Wishlist/Block/Item/Configure.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Wishlist/Block/Item/Configure.php
+++ b/app/code/core/Mage/Wishlist/Block/Item/Configure.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/Block/Links.php
+++ b/app/code/core/Mage/Wishlist/Block/Links.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/Block/Links.php
+++ b/app/code/core/Mage/Wishlist/Block/Links.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Wishlist/Block/Links.php
+++ b/app/code/core/Mage/Wishlist/Block/Links.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/Block/Render/Item/Price.php
+++ b/app/code/core/Mage/Wishlist/Block/Render/Item/Price.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/Block/Render/Item/Price.php
+++ b/app/code/core/Mage/Wishlist/Block/Render/Item/Price.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Wishlist/Block/Render/Item/Price.php
+++ b/app/code/core/Mage/Wishlist/Block/Render/Item/Price.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/Block/Share/Email/Items.php
+++ b/app/code/core/Mage/Wishlist/Block/Share/Email/Items.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/Block/Share/Email/Items.php
+++ b/app/code/core/Mage/Wishlist/Block/Share/Email/Items.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Wishlist/Block/Share/Email/Items.php
+++ b/app/code/core/Mage/Wishlist/Block/Share/Email/Items.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/Block/Share/Email/Rss.php
+++ b/app/code/core/Mage/Wishlist/Block/Share/Email/Rss.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/Block/Share/Email/Rss.php
+++ b/app/code/core/Mage/Wishlist/Block/Share/Email/Rss.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Wishlist/Block/Share/Email/Rss.php
+++ b/app/code/core/Mage/Wishlist/Block/Share/Email/Rss.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/Block/Share/Wishlist.php
+++ b/app/code/core/Mage/Wishlist/Block/Share/Wishlist.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/Block/Share/Wishlist.php
+++ b/app/code/core/Mage/Wishlist/Block/Share/Wishlist.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Wishlist/Block/Share/Wishlist.php
+++ b/app/code/core/Mage/Wishlist/Block/Share/Wishlist.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/Controller/Abstract.php
+++ b/app/code/core/Mage/Wishlist/Controller/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/Controller/Abstract.php
+++ b/app/code/core/Mage/Wishlist/Controller/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Wishlist/Controller/Abstract.php
+++ b/app/code/core/Mage/Wishlist/Controller/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/Helper/Data.php
+++ b/app/code/core/Mage/Wishlist/Helper/Data.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/Helper/Data.php
+++ b/app/code/core/Mage/Wishlist/Helper/Data.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Wishlist/Helper/Data.php
+++ b/app/code/core/Mage/Wishlist/Helper/Data.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/Model/Config.php
+++ b/app/code/core/Mage/Wishlist/Model/Config.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/Model/Config.php
+++ b/app/code/core/Mage/Wishlist/Model/Config.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Wishlist/Model/Config.php
+++ b/app/code/core/Mage/Wishlist/Model/Config.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/Model/Config/Source/Summary.php
+++ b/app/code/core/Mage/Wishlist/Model/Config/Source/Summary.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/Model/Config/Source/Summary.php
+++ b/app/code/core/Mage/Wishlist/Model/Config/Source/Summary.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Wishlist/Model/Config/Source/Summary.php
+++ b/app/code/core/Mage/Wishlist/Model/Config/Source/Summary.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/Model/Item.php
+++ b/app/code/core/Mage/Wishlist/Model/Item.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/Model/Item.php
+++ b/app/code/core/Mage/Wishlist/Model/Item.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Wishlist/Model/Item.php
+++ b/app/code/core/Mage/Wishlist/Model/Item.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/Model/Item/Option.php
+++ b/app/code/core/Mage/Wishlist/Model/Item/Option.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/Model/Item/Option.php
+++ b/app/code/core/Mage/Wishlist/Model/Item/Option.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Wishlist/Model/Item/Option.php
+++ b/app/code/core/Mage/Wishlist/Model/Item/Option.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/Model/Mysql4/Item.php
+++ b/app/code/core/Mage/Wishlist/Model/Mysql4/Item.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/Model/Mysql4/Item.php
+++ b/app/code/core/Mage/Wishlist/Model/Mysql4/Item.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Wishlist/Model/Mysql4/Item.php
+++ b/app/code/core/Mage/Wishlist/Model/Mysql4/Item.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/Model/Mysql4/Item/Collection.php
+++ b/app/code/core/Mage/Wishlist/Model/Mysql4/Item/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/Model/Mysql4/Item/Collection.php
+++ b/app/code/core/Mage/Wishlist/Model/Mysql4/Item/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Wishlist/Model/Mysql4/Item/Collection.php
+++ b/app/code/core/Mage/Wishlist/Model/Mysql4/Item/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/Model/Mysql4/Item/Option.php
+++ b/app/code/core/Mage/Wishlist/Model/Mysql4/Item/Option.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/Model/Mysql4/Item/Option.php
+++ b/app/code/core/Mage/Wishlist/Model/Mysql4/Item/Option.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Wishlist/Model/Mysql4/Item/Option.php
+++ b/app/code/core/Mage/Wishlist/Model/Mysql4/Item/Option.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/Model/Mysql4/Item/Option/Collection.php
+++ b/app/code/core/Mage/Wishlist/Model/Mysql4/Item/Option/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/Model/Mysql4/Item/Option/Collection.php
+++ b/app/code/core/Mage/Wishlist/Model/Mysql4/Item/Option/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Wishlist/Model/Mysql4/Item/Option/Collection.php
+++ b/app/code/core/Mage/Wishlist/Model/Mysql4/Item/Option/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/Model/Mysql4/Product/Collection.php
+++ b/app/code/core/Mage/Wishlist/Model/Mysql4/Product/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/Model/Mysql4/Product/Collection.php
+++ b/app/code/core/Mage/Wishlist/Model/Mysql4/Product/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Wishlist/Model/Mysql4/Product/Collection.php
+++ b/app/code/core/Mage/Wishlist/Model/Mysql4/Product/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/Model/Mysql4/Wishlist.php
+++ b/app/code/core/Mage/Wishlist/Model/Mysql4/Wishlist.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/Model/Mysql4/Wishlist.php
+++ b/app/code/core/Mage/Wishlist/Model/Mysql4/Wishlist.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Wishlist/Model/Mysql4/Wishlist.php
+++ b/app/code/core/Mage/Wishlist/Model/Mysql4/Wishlist.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/Model/Mysql4/Wishlist/Collection.php
+++ b/app/code/core/Mage/Wishlist/Model/Mysql4/Wishlist/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/Model/Mysql4/Wishlist/Collection.php
+++ b/app/code/core/Mage/Wishlist/Model/Mysql4/Wishlist/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Wishlist/Model/Mysql4/Wishlist/Collection.php
+++ b/app/code/core/Mage/Wishlist/Model/Mysql4/Wishlist/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/Model/Observer.php
+++ b/app/code/core/Mage/Wishlist/Model/Observer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/Model/Observer.php
+++ b/app/code/core/Mage/Wishlist/Model/Observer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Wishlist/Model/Observer.php
+++ b/app/code/core/Mage/Wishlist/Model/Observer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/Model/Resource/Item.php
+++ b/app/code/core/Mage/Wishlist/Model/Resource/Item.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/Model/Resource/Item.php
+++ b/app/code/core/Mage/Wishlist/Model/Resource/Item.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Wishlist/Model/Resource/Item.php
+++ b/app/code/core/Mage/Wishlist/Model/Resource/Item.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/Model/Resource/Item/Collection.php
+++ b/app/code/core/Mage/Wishlist/Model/Resource/Item/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/Model/Resource/Item/Collection.php
+++ b/app/code/core/Mage/Wishlist/Model/Resource/Item/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Wishlist/Model/Resource/Item/Collection.php
+++ b/app/code/core/Mage/Wishlist/Model/Resource/Item/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/Model/Resource/Item/Option.php
+++ b/app/code/core/Mage/Wishlist/Model/Resource/Item/Option.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/Model/Resource/Item/Option.php
+++ b/app/code/core/Mage/Wishlist/Model/Resource/Item/Option.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Wishlist/Model/Resource/Item/Option.php
+++ b/app/code/core/Mage/Wishlist/Model/Resource/Item/Option.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/Model/Resource/Item/Option/Collection.php
+++ b/app/code/core/Mage/Wishlist/Model/Resource/Item/Option/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/Model/Resource/Item/Option/Collection.php
+++ b/app/code/core/Mage/Wishlist/Model/Resource/Item/Option/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Wishlist/Model/Resource/Item/Option/Collection.php
+++ b/app/code/core/Mage/Wishlist/Model/Resource/Item/Option/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/Model/Resource/Product/Collection.php
+++ b/app/code/core/Mage/Wishlist/Model/Resource/Product/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/Model/Resource/Product/Collection.php
+++ b/app/code/core/Mage/Wishlist/Model/Resource/Product/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Wishlist/Model/Resource/Product/Collection.php
+++ b/app/code/core/Mage/Wishlist/Model/Resource/Product/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/Model/Resource/Wishlist.php
+++ b/app/code/core/Mage/Wishlist/Model/Resource/Wishlist.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/Model/Resource/Wishlist.php
+++ b/app/code/core/Mage/Wishlist/Model/Resource/Wishlist.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Wishlist/Model/Resource/Wishlist.php
+++ b/app/code/core/Mage/Wishlist/Model/Resource/Wishlist.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/Model/Resource/Wishlist/Collection.php
+++ b/app/code/core/Mage/Wishlist/Model/Resource/Wishlist/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/Model/Resource/Wishlist/Collection.php
+++ b/app/code/core/Mage/Wishlist/Model/Resource/Wishlist/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Wishlist/Model/Resource/Wishlist/Collection.php
+++ b/app/code/core/Mage/Wishlist/Model/Resource/Wishlist/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/Model/Session.php
+++ b/app/code/core/Mage/Wishlist/Model/Session.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/Model/Session.php
+++ b/app/code/core/Mage/Wishlist/Model/Session.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Wishlist/Model/Session.php
+++ b/app/code/core/Mage/Wishlist/Model/Session.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/Model/Wishlist.php
+++ b/app/code/core/Mage/Wishlist/Model/Wishlist.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/Model/Wishlist.php
+++ b/app/code/core/Mage/Wishlist/Model/Wishlist.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Wishlist/Model/Wishlist.php
+++ b/app/code/core/Mage/Wishlist/Model/Wishlist.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/controllers/IndexController.php
+++ b/app/code/core/Mage/Wishlist/controllers/IndexController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/controllers/IndexController.php
+++ b/app/code/core/Mage/Wishlist/controllers/IndexController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Wishlist/controllers/IndexController.php
+++ b/app/code/core/Mage/Wishlist/controllers/IndexController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/controllers/SharedController.php
+++ b/app/code/core/Mage/Wishlist/controllers/SharedController.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/controllers/SharedController.php
+++ b/app/code/core/Mage/Wishlist/controllers/SharedController.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Wishlist/controllers/SharedController.php
+++ b/app/code/core/Mage/Wishlist/controllers/SharedController.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/etc/adminhtml.xml
+++ b/app/code/core/Mage/Wishlist/etc/adminhtml.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/etc/adminhtml.xml
+++ b/app/code/core/Mage/Wishlist/etc/adminhtml.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/etc/adminhtml.xml
+++ b/app/code/core/Mage/Wishlist/etc/adminhtml.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Wishlist/etc/config.xml
+++ b/app/code/core/Mage/Wishlist/etc/config.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/etc/config.xml
+++ b/app/code/core/Mage/Wishlist/etc/config.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/etc/config.xml
+++ b/app/code/core/Mage/Wishlist/etc/config.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Wishlist/etc/system.xml
+++ b/app/code/core/Mage/Wishlist/etc/system.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/etc/system.xml
+++ b/app/code/core/Mage/Wishlist/etc/system.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/etc/system.xml
+++ b/app/code/core/Mage/Wishlist/etc/system.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Wishlist/sql/wishlist_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Wishlist/sql/wishlist_setup/install-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/sql/wishlist_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Wishlist/sql/wishlist_setup/install-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Wishlist/sql/wishlist_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Wishlist/sql/wishlist_setup/install-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/sql/wishlist_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/Wishlist/sql/wishlist_setup/mysql4-install-0.7.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/sql/wishlist_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/Wishlist/sql/wishlist_setup/mysql4-install-0.7.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Wishlist/sql/wishlist_setup/mysql4-install-0.7.0.php
+++ b/app/code/core/Mage/Wishlist/sql/wishlist_setup/mysql4-install-0.7.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/sql/wishlist_setup/mysql4-upgrade-0.7.0-0.7.1.php
+++ b/app/code/core/Mage/Wishlist/sql/wishlist_setup/mysql4-upgrade-0.7.0-0.7.1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/sql/wishlist_setup/mysql4-upgrade-0.7.0-0.7.1.php
+++ b/app/code/core/Mage/Wishlist/sql/wishlist_setup/mysql4-upgrade-0.7.0-0.7.1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Wishlist/sql/wishlist_setup/mysql4-upgrade-0.7.0-0.7.1.php
+++ b/app/code/core/Mage/Wishlist/sql/wishlist_setup/mysql4-upgrade-0.7.0-0.7.1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/sql/wishlist_setup/mysql4-upgrade-0.7.1-0.7.2.php
+++ b/app/code/core/Mage/Wishlist/sql/wishlist_setup/mysql4-upgrade-0.7.1-0.7.2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/sql/wishlist_setup/mysql4-upgrade-0.7.1-0.7.2.php
+++ b/app/code/core/Mage/Wishlist/sql/wishlist_setup/mysql4-upgrade-0.7.1-0.7.2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Wishlist/sql/wishlist_setup/mysql4-upgrade-0.7.1-0.7.2.php
+++ b/app/code/core/Mage/Wishlist/sql/wishlist_setup/mysql4-upgrade-0.7.1-0.7.2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/sql/wishlist_setup/mysql4-upgrade-0.7.2-0.7.4.php
+++ b/app/code/core/Mage/Wishlist/sql/wishlist_setup/mysql4-upgrade-0.7.2-0.7.4.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/sql/wishlist_setup/mysql4-upgrade-0.7.2-0.7.4.php
+++ b/app/code/core/Mage/Wishlist/sql/wishlist_setup/mysql4-upgrade-0.7.2-0.7.4.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Wishlist/sql/wishlist_setup/mysql4-upgrade-0.7.2-0.7.4.php
+++ b/app/code/core/Mage/Wishlist/sql/wishlist_setup/mysql4-upgrade-0.7.2-0.7.4.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/sql/wishlist_setup/mysql4-upgrade-0.7.4-0.7.5.php
+++ b/app/code/core/Mage/Wishlist/sql/wishlist_setup/mysql4-upgrade-0.7.4-0.7.5.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/sql/wishlist_setup/mysql4-upgrade-0.7.4-0.7.5.php
+++ b/app/code/core/Mage/Wishlist/sql/wishlist_setup/mysql4-upgrade-0.7.4-0.7.5.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Wishlist/sql/wishlist_setup/mysql4-upgrade-0.7.4-0.7.5.php
+++ b/app/code/core/Mage/Wishlist/sql/wishlist_setup/mysql4-upgrade-0.7.4-0.7.5.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/sql/wishlist_setup/mysql4-upgrade-0.7.5-0.7.6.php
+++ b/app/code/core/Mage/Wishlist/sql/wishlist_setup/mysql4-upgrade-0.7.5-0.7.6.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/sql/wishlist_setup/mysql4-upgrade-0.7.5-0.7.6.php
+++ b/app/code/core/Mage/Wishlist/sql/wishlist_setup/mysql4-upgrade-0.7.5-0.7.6.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Wishlist/sql/wishlist_setup/mysql4-upgrade-0.7.5-0.7.6.php
+++ b/app/code/core/Mage/Wishlist/sql/wishlist_setup/mysql4-upgrade-0.7.5-0.7.6.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/sql/wishlist_setup/mysql4-upgrade-0.7.6-0.7.7.php
+++ b/app/code/core/Mage/Wishlist/sql/wishlist_setup/mysql4-upgrade-0.7.6-0.7.7.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/sql/wishlist_setup/mysql4-upgrade-0.7.6-0.7.7.php
+++ b/app/code/core/Mage/Wishlist/sql/wishlist_setup/mysql4-upgrade-0.7.6-0.7.7.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Wishlist/sql/wishlist_setup/mysql4-upgrade-0.7.6-0.7.7.php
+++ b/app/code/core/Mage/Wishlist/sql/wishlist_setup/mysql4-upgrade-0.7.6-0.7.7.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/sql/wishlist_setup/mysql4-upgrade-0.7.7-0.7.8.php
+++ b/app/code/core/Mage/Wishlist/sql/wishlist_setup/mysql4-upgrade-0.7.7-0.7.8.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/sql/wishlist_setup/mysql4-upgrade-0.7.7-0.7.8.php
+++ b/app/code/core/Mage/Wishlist/sql/wishlist_setup/mysql4-upgrade-0.7.7-0.7.8.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Wishlist/sql/wishlist_setup/mysql4-upgrade-0.7.7-0.7.8.php
+++ b/app/code/core/Mage/Wishlist/sql/wishlist_setup/mysql4-upgrade-0.7.7-0.7.8.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/sql/wishlist_setup/mysql4-upgrade-0.7.8-0.7.9.php
+++ b/app/code/core/Mage/Wishlist/sql/wishlist_setup/mysql4-upgrade-0.7.8-0.7.9.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/sql/wishlist_setup/mysql4-upgrade-0.7.8-0.7.9.php
+++ b/app/code/core/Mage/Wishlist/sql/wishlist_setup/mysql4-upgrade-0.7.8-0.7.9.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Wishlist/sql/wishlist_setup/mysql4-upgrade-0.7.8-0.7.9.php
+++ b/app/code/core/Mage/Wishlist/sql/wishlist_setup/mysql4-upgrade-0.7.8-0.7.9.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/sql/wishlist_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/Wishlist/sql/wishlist_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/code/core/Mage/Wishlist/sql/wishlist_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/Wishlist/sql/wishlist_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/code/core/Mage/Wishlist/sql/wishlist_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
+++ b/app/code/core/Mage/Wishlist/sql/wishlist_setup/mysql4-upgrade-1.5.9.9-1.6.0.0.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/design/adminhtml/default/default/etc/theme.xml
+++ b/app/design/adminhtml/default/default/etc/theme.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/etc/theme.xml
+++ b/app/design/adminhtml/default/default/etc/theme.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/etc/theme.xml
+++ b/app/design/adminhtml/default/default/etc/theme.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/layout/admin.xml
+++ b/app/design/adminhtml/default/default/layout/admin.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/layout/admin.xml
+++ b/app/design/adminhtml/default/default/layout/admin.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/layout/admin.xml
+++ b/app/design/adminhtml/default/default/layout/admin.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/layout/adminnotification.xml
+++ b/app/design/adminhtml/default/default/layout/adminnotification.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/layout/adminnotification.xml
+++ b/app/design/adminhtml/default/default/layout/adminnotification.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/layout/adminnotification.xml
+++ b/app/design/adminhtml/default/default/layout/adminnotification.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/layout/api2.xml
+++ b/app/design/adminhtml/default/default/layout/api2.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/layout/api2.xml
+++ b/app/design/adminhtml/default/default/layout/api2.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/layout/api2.xml
+++ b/app/design/adminhtml/default/default/layout/api2.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/layout/authorizenet.xml
+++ b/app/design/adminhtml/default/default/layout/authorizenet.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/layout/authorizenet.xml
+++ b/app/design/adminhtml/default/default/layout/authorizenet.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/layout/authorizenet.xml
+++ b/app/design/adminhtml/default/default/layout/authorizenet.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/layout/bundle.xml
+++ b/app/design/adminhtml/default/default/layout/bundle.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/layout/bundle.xml
+++ b/app/design/adminhtml/default/default/layout/bundle.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/layout/bundle.xml
+++ b/app/design/adminhtml/default/default/layout/bundle.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/layout/captcha.xml
+++ b/app/design/adminhtml/default/default/layout/captcha.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/layout/captcha.xml
+++ b/app/design/adminhtml/default/default/layout/captcha.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/layout/captcha.xml
+++ b/app/design/adminhtml/default/default/layout/captcha.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/layout/catalog.xml
+++ b/app/design/adminhtml/default/default/layout/catalog.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/layout/catalog.xml
+++ b/app/design/adminhtml/default/default/layout/catalog.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/layout/catalog.xml
+++ b/app/design/adminhtml/default/default/layout/catalog.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/layout/centinel.xml
+++ b/app/design/adminhtml/default/default/layout/centinel.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/layout/centinel.xml
+++ b/app/design/adminhtml/default/default/layout/centinel.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/layout/centinel.xml
+++ b/app/design/adminhtml/default/default/layout/centinel.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/layout/cms.xml
+++ b/app/design/adminhtml/default/default/layout/cms.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/layout/cms.xml
+++ b/app/design/adminhtml/default/default/layout/cms.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/layout/cms.xml
+++ b/app/design/adminhtml/default/default/layout/cms.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/layout/currencysymbol.xml
+++ b/app/design/adminhtml/default/default/layout/currencysymbol.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/layout/currencysymbol.xml
+++ b/app/design/adminhtml/default/default/layout/currencysymbol.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/layout/currencysymbol.xml
+++ b/app/design/adminhtml/default/default/layout/currencysymbol.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/layout/customer.xml
+++ b/app/design/adminhtml/default/default/layout/customer.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/layout/customer.xml
+++ b/app/design/adminhtml/default/default/layout/customer.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/layout/customer.xml
+++ b/app/design/adminhtml/default/default/layout/customer.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/layout/dataflow.xml
+++ b/app/design/adminhtml/default/default/layout/dataflow.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/layout/dataflow.xml
+++ b/app/design/adminhtml/default/default/layout/dataflow.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/layout/dataflow.xml
+++ b/app/design/adminhtml/default/default/layout/dataflow.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/layout/downloadable.xml
+++ b/app/design/adminhtml/default/default/layout/downloadable.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/layout/downloadable.xml
+++ b/app/design/adminhtml/default/default/layout/downloadable.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/layout/downloadable.xml
+++ b/app/design/adminhtml/default/default/layout/downloadable.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/layout/giftmessage.xml
+++ b/app/design/adminhtml/default/default/layout/giftmessage.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/layout/giftmessage.xml
+++ b/app/design/adminhtml/default/default/layout/giftmessage.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/layout/giftmessage.xml
+++ b/app/design/adminhtml/default/default/layout/giftmessage.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/layout/importexport.xml
+++ b/app/design/adminhtml/default/default/layout/importexport.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/layout/importexport.xml
+++ b/app/design/adminhtml/default/default/layout/importexport.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/layout/importexport.xml
+++ b/app/design/adminhtml/default/default/layout/importexport.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/layout/index.xml
+++ b/app/design/adminhtml/default/default/layout/index.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/layout/index.xml
+++ b/app/design/adminhtml/default/default/layout/index.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/layout/index.xml
+++ b/app/design/adminhtml/default/default/layout/index.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/layout/main.xml
+++ b/app/design/adminhtml/default/default/layout/main.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/layout/main.xml
+++ b/app/design/adminhtml/default/default/layout/main.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/layout/main.xml
+++ b/app/design/adminhtml/default/default/layout/main.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/layout/newsletter.xml
+++ b/app/design/adminhtml/default/default/layout/newsletter.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/layout/newsletter.xml
+++ b/app/design/adminhtml/default/default/layout/newsletter.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/layout/newsletter.xml
+++ b/app/design/adminhtml/default/default/layout/newsletter.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/layout/oauth.xml
+++ b/app/design/adminhtml/default/default/layout/oauth.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/layout/oauth.xml
+++ b/app/design/adminhtml/default/default/layout/oauth.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/layout/oauth.xml
+++ b/app/design/adminhtml/default/default/layout/oauth.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/layout/promo.xml
+++ b/app/design/adminhtml/default/default/layout/promo.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/layout/promo.xml
+++ b/app/design/adminhtml/default/default/layout/promo.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/layout/promo.xml
+++ b/app/design/adminhtml/default/default/layout/promo.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/layout/report.xml
+++ b/app/design/adminhtml/default/default/layout/report.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/layout/report.xml
+++ b/app/design/adminhtml/default/default/layout/report.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/layout/report.xml
+++ b/app/design/adminhtml/default/default/layout/report.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/layout/rss.xml
+++ b/app/design/adminhtml/default/default/layout/rss.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/layout/rss.xml
+++ b/app/design/adminhtml/default/default/layout/rss.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/layout/rss.xml
+++ b/app/design/adminhtml/default/default/layout/rss.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/layout/sales.xml
+++ b/app/design/adminhtml/default/default/layout/sales.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/layout/sales.xml
+++ b/app/design/adminhtml/default/default/layout/sales.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/layout/sales.xml
+++ b/app/design/adminhtml/default/default/layout/sales.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/layout/search.xml
+++ b/app/design/adminhtml/default/default/layout/search.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/layout/search.xml
+++ b/app/design/adminhtml/default/default/layout/search.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/layout/search.xml
+++ b/app/design/adminhtml/default/default/layout/search.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/layout/tag.xml
+++ b/app/design/adminhtml/default/default/layout/tag.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/layout/tag.xml
+++ b/app/design/adminhtml/default/default/layout/tag.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/layout/tag.xml
+++ b/app/design/adminhtml/default/default/layout/tag.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/layout/tax.xml
+++ b/app/design/adminhtml/default/default/layout/tax.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/layout/tax.xml
+++ b/app/design/adminhtml/default/default/layout/tax.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/layout/tax.xml
+++ b/app/design/adminhtml/default/default/layout/tax.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/layout/widget.xml
+++ b/app/design/adminhtml/default/default/layout/widget.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/layout/widget.xml
+++ b/app/design/adminhtml/default/default/layout/widget.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/layout/widget.xml
+++ b/app/design/adminhtml/default/default/layout/widget.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/access_denied.phtml
+++ b/app/design/adminhtml/default/default/template/access_denied.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/access_denied.phtml
+++ b/app/design/adminhtml/default/default/template/access_denied.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/access_denied.phtml
+++ b/app/design/adminhtml/default/default/template/access_denied.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/api/role_users_grid_js.phtml
+++ b/app/design/adminhtml/default/default/template/api/role_users_grid_js.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/api/role_users_grid_js.phtml
+++ b/app/design/adminhtml/default/default/template/api/role_users_grid_js.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/api/role_users_grid_js.phtml
+++ b/app/design/adminhtml/default/default/template/api/role_users_grid_js.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/api/roleinfo.phtml
+++ b/app/design/adminhtml/default/default/template/api/roleinfo.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/api/roleinfo.phtml
+++ b/app/design/adminhtml/default/default/template/api/roleinfo.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/api/roleinfo.phtml
+++ b/app/design/adminhtml/default/default/template/api/roleinfo.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/api/roles.phtml
+++ b/app/design/adminhtml/default/default/template/api/roles.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/api/roles.phtml
+++ b/app/design/adminhtml/default/default/template/api/roles.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/api/roles.phtml
+++ b/app/design/adminhtml/default/default/template/api/roles.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/api/rolesedit.phtml
+++ b/app/design/adminhtml/default/default/template/api/rolesedit.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/api/rolesedit.phtml
+++ b/app/design/adminhtml/default/default/template/api/rolesedit.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/api/rolesedit.phtml
+++ b/app/design/adminhtml/default/default/template/api/rolesedit.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/api/rolesusers.phtml
+++ b/app/design/adminhtml/default/default/template/api/rolesusers.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/api/rolesusers.phtml
+++ b/app/design/adminhtml/default/default/template/api/rolesusers.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/api/rolesusers.phtml
+++ b/app/design/adminhtml/default/default/template/api/rolesusers.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/api/user_roles_grid_js.phtml
+++ b/app/design/adminhtml/default/default/template/api/user_roles_grid_js.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/api/user_roles_grid_js.phtml
+++ b/app/design/adminhtml/default/default/template/api/user_roles_grid_js.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/api/user_roles_grid_js.phtml
+++ b/app/design/adminhtml/default/default/template/api/user_roles_grid_js.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/api/userinfo.phtml
+++ b/app/design/adminhtml/default/default/template/api/userinfo.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/api/userinfo.phtml
+++ b/app/design/adminhtml/default/default/template/api/userinfo.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/api/userinfo.phtml
+++ b/app/design/adminhtml/default/default/template/api/userinfo.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/api/usernroles.phtml
+++ b/app/design/adminhtml/default/default/template/api/usernroles.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/api/usernroles.phtml
+++ b/app/design/adminhtml/default/default/template/api/usernroles.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/api/usernroles.phtml
+++ b/app/design/adminhtml/default/default/template/api/usernroles.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/api/userroles.phtml
+++ b/app/design/adminhtml/default/default/template/api/userroles.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/api/userroles.phtml
+++ b/app/design/adminhtml/default/default/template/api/userroles.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/api/userroles.phtml
+++ b/app/design/adminhtml/default/default/template/api/userroles.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/api/users.phtml
+++ b/app/design/adminhtml/default/default/template/api/users.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/api/users.phtml
+++ b/app/design/adminhtml/default/default/template/api/users.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/api/users.phtml
+++ b/app/design/adminhtml/default/default/template/api/users.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/api2/attribute/buttons.phtml
+++ b/app/design/adminhtml/default/default/template/api2/attribute/buttons.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/api2/attribute/buttons.phtml
+++ b/app/design/adminhtml/default/default/template/api2/attribute/buttons.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/api2/attribute/buttons.phtml
+++ b/app/design/adminhtml/default/default/template/api2/attribute/buttons.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/api2/attribute/resource.phtml
+++ b/app/design/adminhtml/default/default/template/api2/attribute/resource.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/api2/attribute/resource.phtml
+++ b/app/design/adminhtml/default/default/template/api2/attribute/resource.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/api2/attribute/resource.phtml
+++ b/app/design/adminhtml/default/default/template/api2/attribute/resource.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/api2/permissions/user/edit/tab/roles/js.phtml
+++ b/app/design/adminhtml/default/default/template/api2/permissions/user/edit/tab/roles/js.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/api2/permissions/user/edit/tab/roles/js.phtml
+++ b/app/design/adminhtml/default/default/template/api2/permissions/user/edit/tab/roles/js.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/api2/permissions/user/edit/tab/roles/js.phtml
+++ b/app/design/adminhtml/default/default/template/api2/permissions/user/edit/tab/roles/js.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/api2/role/buttons.phtml
+++ b/app/design/adminhtml/default/default/template/api2/role/buttons.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/api2/role/buttons.phtml
+++ b/app/design/adminhtml/default/default/template/api2/role/buttons.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/api2/role/buttons.phtml
+++ b/app/design/adminhtml/default/default/template/api2/role/buttons.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/api2/role/users_grid_js.phtml
+++ b/app/design/adminhtml/default/default/template/api2/role/users_grid_js.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/api2/role/users_grid_js.phtml
+++ b/app/design/adminhtml/default/default/template/api2/role/users_grid_js.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/api2/role/users_grid_js.phtml
+++ b/app/design/adminhtml/default/default/template/api2/role/users_grid_js.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/authorizenet/directpost/iframe.phtml
+++ b/app/design/adminhtml/default/default/template/authorizenet/directpost/iframe.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/authorizenet/directpost/iframe.phtml
+++ b/app/design/adminhtml/default/default/template/authorizenet/directpost/iframe.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/authorizenet/directpost/iframe.phtml
+++ b/app/design/adminhtml/default/default/template/authorizenet/directpost/iframe.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/authorizenet/directpost/info.phtml
+++ b/app/design/adminhtml/default/default/template/authorizenet/directpost/info.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/authorizenet/directpost/info.phtml
+++ b/app/design/adminhtml/default/default/template/authorizenet/directpost/info.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/authorizenet/directpost/info.phtml
+++ b/app/design/adminhtml/default/default/template/authorizenet/directpost/info.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/bundle/product/composite/fieldset/options/bundle.phtml
+++ b/app/design/adminhtml/default/default/template/bundle/product/composite/fieldset/options/bundle.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/bundle/product/composite/fieldset/options/bundle.phtml
+++ b/app/design/adminhtml/default/default/template/bundle/product/composite/fieldset/options/bundle.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/bundle/product/composite/fieldset/options/bundle.phtml
+++ b/app/design/adminhtml/default/default/template/bundle/product/composite/fieldset/options/bundle.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/bundle/product/composite/fieldset/options/type/checkbox.phtml
+++ b/app/design/adminhtml/default/default/template/bundle/product/composite/fieldset/options/type/checkbox.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/bundle/product/composite/fieldset/options/type/checkbox.phtml
+++ b/app/design/adminhtml/default/default/template/bundle/product/composite/fieldset/options/type/checkbox.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/bundle/product/composite/fieldset/options/type/checkbox.phtml
+++ b/app/design/adminhtml/default/default/template/bundle/product/composite/fieldset/options/type/checkbox.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/bundle/product/composite/fieldset/options/type/multi.phtml
+++ b/app/design/adminhtml/default/default/template/bundle/product/composite/fieldset/options/type/multi.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/bundle/product/composite/fieldset/options/type/multi.phtml
+++ b/app/design/adminhtml/default/default/template/bundle/product/composite/fieldset/options/type/multi.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/bundle/product/composite/fieldset/options/type/multi.phtml
+++ b/app/design/adminhtml/default/default/template/bundle/product/composite/fieldset/options/type/multi.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/bundle/product/composite/fieldset/options/type/radio.phtml
+++ b/app/design/adminhtml/default/default/template/bundle/product/composite/fieldset/options/type/radio.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/bundle/product/composite/fieldset/options/type/radio.phtml
+++ b/app/design/adminhtml/default/default/template/bundle/product/composite/fieldset/options/type/radio.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/bundle/product/composite/fieldset/options/type/radio.phtml
+++ b/app/design/adminhtml/default/default/template/bundle/product/composite/fieldset/options/type/radio.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/bundle/product/composite/fieldset/options/type/select.phtml
+++ b/app/design/adminhtml/default/default/template/bundle/product/composite/fieldset/options/type/select.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/bundle/product/composite/fieldset/options/type/select.phtml
+++ b/app/design/adminhtml/default/default/template/bundle/product/composite/fieldset/options/type/select.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/bundle/product/composite/fieldset/options/type/select.phtml
+++ b/app/design/adminhtml/default/default/template/bundle/product/composite/fieldset/options/type/select.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/bundle/product/edit/bundle.phtml
+++ b/app/design/adminhtml/default/default/template/bundle/product/edit/bundle.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/bundle/product/edit/bundle.phtml
+++ b/app/design/adminhtml/default/default/template/bundle/product/edit/bundle.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/bundle/product/edit/bundle.phtml
+++ b/app/design/adminhtml/default/default/template/bundle/product/edit/bundle.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/bundle/product/edit/bundle/option.phtml
+++ b/app/design/adminhtml/default/default/template/bundle/product/edit/bundle/option.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/bundle/product/edit/bundle/option.phtml
+++ b/app/design/adminhtml/default/default/template/bundle/product/edit/bundle/option.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/bundle/product/edit/bundle/option.phtml
+++ b/app/design/adminhtml/default/default/template/bundle/product/edit/bundle/option.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/bundle/product/edit/bundle/option/search.phtml
+++ b/app/design/adminhtml/default/default/template/bundle/product/edit/bundle/option/search.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/bundle/product/edit/bundle/option/search.phtml
+++ b/app/design/adminhtml/default/default/template/bundle/product/edit/bundle/option/search.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/bundle/product/edit/bundle/option/search.phtml
+++ b/app/design/adminhtml/default/default/template/bundle/product/edit/bundle/option/search.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/bundle/product/edit/bundle/option/selection.phtml
+++ b/app/design/adminhtml/default/default/template/bundle/product/edit/bundle/option/selection.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/bundle/product/edit/bundle/option/selection.phtml
+++ b/app/design/adminhtml/default/default/template/bundle/product/edit/bundle/option/selection.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/bundle/product/edit/bundle/option/selection.phtml
+++ b/app/design/adminhtml/default/default/template/bundle/product/edit/bundle/option/selection.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/bundle/sales/creditmemo/create/items/renderer.phtml
+++ b/app/design/adminhtml/default/default/template/bundle/sales/creditmemo/create/items/renderer.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/bundle/sales/creditmemo/create/items/renderer.phtml
+++ b/app/design/adminhtml/default/default/template/bundle/sales/creditmemo/create/items/renderer.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/bundle/sales/creditmemo/create/items/renderer.phtml
+++ b/app/design/adminhtml/default/default/template/bundle/sales/creditmemo/create/items/renderer.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/bundle/sales/creditmemo/view/items/renderer.phtml
+++ b/app/design/adminhtml/default/default/template/bundle/sales/creditmemo/view/items/renderer.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/bundle/sales/creditmemo/view/items/renderer.phtml
+++ b/app/design/adminhtml/default/default/template/bundle/sales/creditmemo/view/items/renderer.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/bundle/sales/creditmemo/view/items/renderer.phtml
+++ b/app/design/adminhtml/default/default/template/bundle/sales/creditmemo/view/items/renderer.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/bundle/sales/invoice/create/items/renderer.phtml
+++ b/app/design/adminhtml/default/default/template/bundle/sales/invoice/create/items/renderer.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/bundle/sales/invoice/create/items/renderer.phtml
+++ b/app/design/adminhtml/default/default/template/bundle/sales/invoice/create/items/renderer.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/bundle/sales/invoice/create/items/renderer.phtml
+++ b/app/design/adminhtml/default/default/template/bundle/sales/invoice/create/items/renderer.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/bundle/sales/invoice/view/items/renderer.phtml
+++ b/app/design/adminhtml/default/default/template/bundle/sales/invoice/view/items/renderer.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/bundle/sales/invoice/view/items/renderer.phtml
+++ b/app/design/adminhtml/default/default/template/bundle/sales/invoice/view/items/renderer.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/bundle/sales/invoice/view/items/renderer.phtml
+++ b/app/design/adminhtml/default/default/template/bundle/sales/invoice/view/items/renderer.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/bundle/sales/order/view/items/renderer.phtml
+++ b/app/design/adminhtml/default/default/template/bundle/sales/order/view/items/renderer.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/bundle/sales/order/view/items/renderer.phtml
+++ b/app/design/adminhtml/default/default/template/bundle/sales/order/view/items/renderer.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/bundle/sales/order/view/items/renderer.phtml
+++ b/app/design/adminhtml/default/default/template/bundle/sales/order/view/items/renderer.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/bundle/sales/shipment/create/items/renderer.phtml
+++ b/app/design/adminhtml/default/default/template/bundle/sales/shipment/create/items/renderer.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/bundle/sales/shipment/create/items/renderer.phtml
+++ b/app/design/adminhtml/default/default/template/bundle/sales/shipment/create/items/renderer.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/bundle/sales/shipment/create/items/renderer.phtml
+++ b/app/design/adminhtml/default/default/template/bundle/sales/shipment/create/items/renderer.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/bundle/sales/shipment/view/items/renderer.phtml
+++ b/app/design/adminhtml/default/default/template/bundle/sales/shipment/view/items/renderer.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/bundle/sales/shipment/view/items/renderer.phtml
+++ b/app/design/adminhtml/default/default/template/bundle/sales/shipment/view/items/renderer.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/bundle/sales/shipment/view/items/renderer.phtml
+++ b/app/design/adminhtml/default/default/template/bundle/sales/shipment/view/items/renderer.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/captcha/zend.phtml
+++ b/app/design/adminhtml/default/default/template/captcha/zend.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/captcha/zend.phtml
+++ b/app/design/adminhtml/default/default/template/captcha/zend.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/captcha/zend.phtml
+++ b/app/design/adminhtml/default/default/template/captcha/zend.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/category/checkboxes/tree.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/category/checkboxes/tree.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/catalog/category/checkboxes/tree.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/category/checkboxes/tree.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/category/checkboxes/tree.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/category/checkboxes/tree.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/category/edit.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/category/edit.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/catalog/category/edit.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/category/edit.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/category/edit.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/category/edit.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/category/edit/form.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/category/edit/form.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/catalog/category/edit/form.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/category/edit/form.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/category/edit/form.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/category/edit/form.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/category/tree.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/category/tree.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/catalog/category/tree.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/category/tree.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/category/tree.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/category/tree.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/category/widget/tree.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/category/widget/tree.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/catalog/category/widget/tree.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/category/widget/tree.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/category/widget/tree.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/category/widget/tree.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/form/renderer/fieldset/element.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/form/renderer/fieldset/element.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/catalog/form/renderer/fieldset/element.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/form/renderer/fieldset/element.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/form/renderer/fieldset/element.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/form/renderer/fieldset/element.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/product.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/catalog/product.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/product.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/product/attribute/js.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/attribute/js.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/catalog/product/attribute/js.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/attribute/js.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/product/attribute/js.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/attribute/js.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/product/attribute/new/created.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/attribute/new/created.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/catalog/product/attribute/new/created.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/attribute/new/created.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/product/attribute/new/created.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/attribute/new/created.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/product/attribute/options.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/attribute/options.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/catalog/product/attribute/options.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/attribute/options.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/product/attribute/options.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/attribute/options.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/product/attribute/set/main.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/attribute/set/main.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/catalog/product/attribute/set/main.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/attribute/set/main.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/product/attribute/set/main.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/attribute/set/main.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/product/attribute/set/main/tree/attribute.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/attribute/set/main/tree/attribute.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/catalog/product/attribute/set/main/tree/attribute.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/attribute/set/main/tree/attribute.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/product/attribute/set/main/tree/attribute.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/attribute/set/main/tree/attribute.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/product/attribute/set/main/tree/group.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/attribute/set/main/tree/group.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/catalog/product/attribute/set/main/tree/group.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/attribute/set/main/tree/group.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/product/attribute/set/main/tree/group.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/attribute/set/main/tree/group.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/product/attribute/set/toolbar/add.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/attribute/set/toolbar/add.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/catalog/product/attribute/set/toolbar/add.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/attribute/set/toolbar/add.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/product/attribute/set/toolbar/add.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/attribute/set/toolbar/add.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/product/attribute/set/toolbar/main.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/attribute/set/toolbar/main.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/catalog/product/attribute/set/toolbar/main.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/attribute/set/toolbar/main.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/product/attribute/set/toolbar/main.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/attribute/set/toolbar/main.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/product/composite/configure.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/composite/configure.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/catalog/product/composite/configure.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/composite/configure.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/product/composite/configure.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/composite/configure.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/product/composite/fieldset/configurable.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/composite/fieldset/configurable.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/catalog/product/composite/fieldset/configurable.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/composite/fieldset/configurable.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/product/composite/fieldset/configurable.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/composite/fieldset/configurable.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/product/composite/fieldset/grouped.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/composite/fieldset/grouped.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/catalog/product/composite/fieldset/grouped.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/composite/fieldset/grouped.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/product/composite/fieldset/grouped.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/composite/fieldset/grouped.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/product/composite/fieldset/options.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/composite/fieldset/options.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/catalog/product/composite/fieldset/options.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/composite/fieldset/options.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/product/composite/fieldset/options.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/composite/fieldset/options.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/product/composite/fieldset/options/js.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/composite/fieldset/options/js.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/catalog/product/composite/fieldset/options/js.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/composite/fieldset/options/js.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/product/composite/fieldset/options/js.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/composite/fieldset/options/js.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/product/composite/fieldset/options/type/date.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/composite/fieldset/options/type/date.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/catalog/product/composite/fieldset/options/type/date.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/composite/fieldset/options/type/date.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/product/composite/fieldset/options/type/date.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/composite/fieldset/options/type/date.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/product/composite/fieldset/options/type/default.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/composite/fieldset/options/type/default.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/catalog/product/composite/fieldset/options/type/default.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/composite/fieldset/options/type/default.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/product/composite/fieldset/options/type/default.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/composite/fieldset/options/type/default.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/product/composite/fieldset/options/type/file.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/composite/fieldset/options/type/file.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/catalog/product/composite/fieldset/options/type/file.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/composite/fieldset/options/type/file.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/product/composite/fieldset/options/type/file.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/composite/fieldset/options/type/file.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/product/composite/fieldset/options/type/select.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/composite/fieldset/options/type/select.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/catalog/product/composite/fieldset/options/type/select.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/composite/fieldset/options/type/select.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/product/composite/fieldset/options/type/select.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/composite/fieldset/options/type/select.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/product/composite/fieldset/options/type/text.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/composite/fieldset/options/type/text.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/catalog/product/composite/fieldset/options/type/text.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/composite/fieldset/options/type/text.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/product/composite/fieldset/options/type/text.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/composite/fieldset/options/type/text.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/product/composite/fieldset/qty.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/composite/fieldset/qty.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/catalog/product/composite/fieldset/qty.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/composite/fieldset/qty.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/product/composite/fieldset/qty.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/composite/fieldset/qty.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/product/created.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/created.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/catalog/product/created.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/created.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/product/created.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/created.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/product/edit.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/edit.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/catalog/product/edit.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/edit.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/product/edit.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/edit.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/product/edit/action/attribute.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/edit/action/attribute.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/catalog/product/edit/action/attribute.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/edit/action/attribute.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/product/edit/action/attribute.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/edit/action/attribute.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/product/edit/action/inventory.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/edit/action/inventory.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/catalog/product/edit/action/inventory.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/edit/action/inventory.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/product/edit/action/inventory.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/edit/action/inventory.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/product/edit/action/websites.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/edit/action/websites.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/catalog/product/edit/action/websites.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/edit/action/websites.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/product/edit/action/websites.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/edit/action/websites.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/product/edit/categories.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/edit/categories.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/catalog/product/edit/categories.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/edit/categories.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/product/edit/categories.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/edit/categories.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/product/edit/options.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/edit/options.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/catalog/product/edit/options.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/edit/options.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/product/edit/options.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/edit/options.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/product/edit/options/option.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/edit/options/option.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/catalog/product/edit/options/option.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/edit/options/option.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/product/edit/options/option.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/edit/options/option.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/product/edit/options/type/date.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/edit/options/type/date.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/catalog/product/edit/options/type/date.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/edit/options/type/date.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/product/edit/options/type/date.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/edit/options/type/date.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/product/edit/options/type/file.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/edit/options/type/file.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/catalog/product/edit/options/type/file.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/edit/options/type/file.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/product/edit/options/type/file.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/edit/options/type/file.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/product/edit/options/type/select.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/edit/options/type/select.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/catalog/product/edit/options/type/select.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/edit/options/type/select.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/product/edit/options/type/select.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/edit/options/type/select.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/product/edit/options/type/text.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/edit/options/type/text.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/catalog/product/edit/options/type/text.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/edit/options/type/text.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/product/edit/options/type/text.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/edit/options/type/text.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/product/edit/price/group.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/edit/price/group.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/catalog/product/edit/price/group.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/edit/price/group.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/product/edit/price/group.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/edit/price/group.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/product/edit/price/tier.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/edit/price/tier.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/catalog/product/edit/price/tier.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/edit/price/tier.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/product/edit/price/tier.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/edit/price/tier.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/product/edit/serializer.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/edit/serializer.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/catalog/product/edit/serializer.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/edit/serializer.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/product/edit/serializer.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/edit/serializer.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/product/edit/super/config.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/edit/super/config.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/catalog/product/edit/super/config.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/edit/super/config.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/product/edit/super/config.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/edit/super/config.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/product/edit/websites.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/edit/websites.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/catalog/product/edit/websites.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/edit/websites.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/product/edit/websites.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/edit/websites.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/product/helper/gallery.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/helper/gallery.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/catalog/product/helper/gallery.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/helper/gallery.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/product/helper/gallery.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/helper/gallery.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/product/js.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/js.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/catalog/product/js.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/js.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/product/js.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/js.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/product/price.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/price.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/catalog/product/price.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/price.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/product/price.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/price.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/product/tab/alert.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/tab/alert.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/catalog/product/tab/alert.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/tab/alert.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/product/tab/alert.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/tab/alert.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/product/tab/inventory.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/tab/inventory.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/catalog/product/tab/inventory.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/tab/inventory.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/product/tab/inventory.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/tab/inventory.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/product/widget/chooser/container.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/widget/chooser/container.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/catalog/product/widget/chooser/container.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/widget/chooser/container.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/product/widget/chooser/container.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/widget/chooser/container.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/wysiwyg/js.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/wysiwyg/js.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/catalog/wysiwyg/js.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/wysiwyg/js.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/catalog/wysiwyg/js.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/wysiwyg/js.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/centinel/authentication/complete.phtml
+++ b/app/design/adminhtml/default/default/template/centinel/authentication/complete.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/centinel/authentication/complete.phtml
+++ b/app/design/adminhtml/default/default/template/centinel/authentication/complete.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/centinel/authentication/complete.phtml
+++ b/app/design/adminhtml/default/default/template/centinel/authentication/complete.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/centinel/authentication/start.phtml
+++ b/app/design/adminhtml/default/default/template/centinel/authentication/start.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/centinel/authentication/start.phtml
+++ b/app/design/adminhtml/default/default/template/centinel/authentication/start.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/centinel/authentication/start.phtml
+++ b/app/design/adminhtml/default/default/template/centinel/authentication/start.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/centinel/validation/form.phtml
+++ b/app/design/adminhtml/default/default/template/centinel/validation/form.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/centinel/validation/form.phtml
+++ b/app/design/adminhtml/default/default/template/centinel/validation/form.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/centinel/validation/form.phtml
+++ b/app/design/adminhtml/default/default/template/centinel/validation/form.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/cms/browser/content.phtml
+++ b/app/design/adminhtml/default/default/template/cms/browser/content.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/cms/browser/content.phtml
+++ b/app/design/adminhtml/default/default/template/cms/browser/content.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/cms/browser/content.phtml
+++ b/app/design/adminhtml/default/default/template/cms/browser/content.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/cms/browser/content/files.phtml
+++ b/app/design/adminhtml/default/default/template/cms/browser/content/files.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/cms/browser/content/files.phtml
+++ b/app/design/adminhtml/default/default/template/cms/browser/content/files.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/cms/browser/content/files.phtml
+++ b/app/design/adminhtml/default/default/template/cms/browser/content/files.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/cms/browser/content/newfolder.phtml
+++ b/app/design/adminhtml/default/default/template/cms/browser/content/newfolder.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/cms/browser/content/newfolder.phtml
+++ b/app/design/adminhtml/default/default/template/cms/browser/content/newfolder.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/cms/browser/content/newfolder.phtml
+++ b/app/design/adminhtml/default/default/template/cms/browser/content/newfolder.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/cms/browser/content/uploader.phtml
+++ b/app/design/adminhtml/default/default/template/cms/browser/content/uploader.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/cms/browser/content/uploader.phtml
+++ b/app/design/adminhtml/default/default/template/cms/browser/content/uploader.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/cms/browser/content/uploader.phtml
+++ b/app/design/adminhtml/default/default/template/cms/browser/content/uploader.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/cms/browser/js.phtml
+++ b/app/design/adminhtml/default/default/template/cms/browser/js.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/cms/browser/js.phtml
+++ b/app/design/adminhtml/default/default/template/cms/browser/js.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/cms/browser/js.phtml
+++ b/app/design/adminhtml/default/default/template/cms/browser/js.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/cms/browser/tree.phtml
+++ b/app/design/adminhtml/default/default/template/cms/browser/tree.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/cms/browser/tree.phtml
+++ b/app/design/adminhtml/default/default/template/cms/browser/tree.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/cms/browser/tree.phtml
+++ b/app/design/adminhtml/default/default/template/cms/browser/tree.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/cms/page/edit/form/renderer/content.phtml
+++ b/app/design/adminhtml/default/default/template/cms/page/edit/form/renderer/content.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/cms/page/edit/form/renderer/content.phtml
+++ b/app/design/adminhtml/default/default/template/cms/page/edit/form/renderer/content.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/cms/page/edit/form/renderer/content.phtml
+++ b/app/design/adminhtml/default/default/template/cms/page/edit/form/renderer/content.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/coming.phtml
+++ b/app/design/adminhtml/default/default/template/coming.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/coming.phtml
+++ b/app/design/adminhtml/default/default/template/coming.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/coming.phtml
+++ b/app/design/adminhtml/default/default/template/coming.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/currencysymbol/grid.phtml
+++ b/app/design/adminhtml/default/default/template/currencysymbol/grid.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/currencysymbol/grid.phtml
+++ b/app/design/adminhtml/default/default/template/currencysymbol/grid.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/currencysymbol/grid.phtml
+++ b/app/design/adminhtml/default/default/template/currencysymbol/grid.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/customer/edit/js.phtml
+++ b/app/design/adminhtml/default/default/template/customer/edit/js.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/customer/edit/js.phtml
+++ b/app/design/adminhtml/default/default/template/customer/edit/js.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/customer/edit/js.phtml
+++ b/app/design/adminhtml/default/default/template/customer/edit/js.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/customer/edit/tab/account/form/renderer/group.phtml
+++ b/app/design/adminhtml/default/default/template/customer/edit/tab/account/form/renderer/group.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/customer/edit/tab/account/form/renderer/group.phtml
+++ b/app/design/adminhtml/default/default/template/customer/edit/tab/account/form/renderer/group.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/customer/edit/tab/account/form/renderer/group.phtml
+++ b/app/design/adminhtml/default/default/template/customer/edit/tab/account/form/renderer/group.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/customer/edit/tab/view/grid/item.phtml
+++ b/app/design/adminhtml/default/default/template/customer/edit/tab/view/grid/item.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/customer/edit/tab/view/grid/item.phtml
+++ b/app/design/adminhtml/default/default/template/customer/edit/tab/view/grid/item.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/customer/edit/tab/view/grid/item.phtml
+++ b/app/design/adminhtml/default/default/template/customer/edit/tab/view/grid/item.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/customer/online.phtml
+++ b/app/design/adminhtml/default/default/template/customer/online.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/customer/online.phtml
+++ b/app/design/adminhtml/default/default/template/customer/online.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/customer/online.phtml
+++ b/app/design/adminhtml/default/default/template/customer/online.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/customer/sales/order/create/address/form/renderer/vat.phtml
+++ b/app/design/adminhtml/default/default/template/customer/sales/order/create/address/form/renderer/vat.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/customer/sales/order/create/address/form/renderer/vat.phtml
+++ b/app/design/adminhtml/default/default/template/customer/sales/order/create/address/form/renderer/vat.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/customer/sales/order/create/address/form/renderer/vat.phtml
+++ b/app/design/adminhtml/default/default/template/customer/sales/order/create/address/form/renderer/vat.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/customer/system/config/validatevat.phtml
+++ b/app/design/adminhtml/default/default/template/customer/system/config/validatevat.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/customer/system/config/validatevat.phtml
+++ b/app/design/adminhtml/default/default/template/customer/system/config/validatevat.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/customer/system/config/validatevat.phtml
+++ b/app/design/adminhtml/default/default/template/customer/system/config/validatevat.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/customer/tab/addresses.phtml
+++ b/app/design/adminhtml/default/default/template/customer/tab/addresses.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/customer/tab/addresses.phtml
+++ b/app/design/adminhtml/default/default/template/customer/tab/addresses.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/customer/tab/addresses.phtml
+++ b/app/design/adminhtml/default/default/template/customer/tab/addresses.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/customer/tab/cart.phtml
+++ b/app/design/adminhtml/default/default/template/customer/tab/cart.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/customer/tab/cart.phtml
+++ b/app/design/adminhtml/default/default/template/customer/tab/cart.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/customer/tab/cart.phtml
+++ b/app/design/adminhtml/default/default/template/customer/tab/cart.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/customer/tab/newsletter.phtml
+++ b/app/design/adminhtml/default/default/template/customer/tab/newsletter.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/customer/tab/newsletter.phtml
+++ b/app/design/adminhtml/default/default/template/customer/tab/newsletter.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/customer/tab/newsletter.phtml
+++ b/app/design/adminhtml/default/default/template/customer/tab/newsletter.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/customer/tab/view.phtml
+++ b/app/design/adminhtml/default/default/template/customer/tab/view.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/customer/tab/view.phtml
+++ b/app/design/adminhtml/default/default/template/customer/tab/view.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/customer/tab/view.phtml
+++ b/app/design/adminhtml/default/default/template/customer/tab/view.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/customer/tab/view/sales.phtml
+++ b/app/design/adminhtml/default/default/template/customer/tab/view/sales.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/customer/tab/view/sales.phtml
+++ b/app/design/adminhtml/default/default/template/customer/tab/view/sales.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/customer/tab/view/sales.phtml
+++ b/app/design/adminhtml/default/default/template/customer/tab/view/sales.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/customer/tab/wishlist.phtml
+++ b/app/design/adminhtml/default/default/template/customer/tab/wishlist.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/customer/tab/wishlist.phtml
+++ b/app/design/adminhtml/default/default/template/customer/tab/wishlist.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/customer/tab/wishlist.phtml
+++ b/app/design/adminhtml/default/default/template/customer/tab/wishlist.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/dashboard/graph.phtml
+++ b/app/design/adminhtml/default/default/template/dashboard/graph.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/dashboard/graph.phtml
+++ b/app/design/adminhtml/default/default/template/dashboard/graph.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/dashboard/graph.phtml
+++ b/app/design/adminhtml/default/default/template/dashboard/graph.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/dashboard/graph/disabled.phtml
+++ b/app/design/adminhtml/default/default/template/dashboard/graph/disabled.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/dashboard/graph/disabled.phtml
+++ b/app/design/adminhtml/default/default/template/dashboard/graph/disabled.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/dashboard/graph/disabled.phtml
+++ b/app/design/adminhtml/default/default/template/dashboard/graph/disabled.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/dashboard/grid.phtml
+++ b/app/design/adminhtml/default/default/template/dashboard/grid.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/dashboard/grid.phtml
+++ b/app/design/adminhtml/default/default/template/dashboard/grid.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/dashboard/grid.phtml
+++ b/app/design/adminhtml/default/default/template/dashboard/grid.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/dashboard/index.phtml
+++ b/app/design/adminhtml/default/default/template/dashboard/index.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/dashboard/index.phtml
+++ b/app/design/adminhtml/default/default/template/dashboard/index.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/dashboard/index.phtml
+++ b/app/design/adminhtml/default/default/template/dashboard/index.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/dashboard/salebar.phtml
+++ b/app/design/adminhtml/default/default/template/dashboard/salebar.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/dashboard/salebar.phtml
+++ b/app/design/adminhtml/default/default/template/dashboard/salebar.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/dashboard/salebar.phtml
+++ b/app/design/adminhtml/default/default/template/dashboard/salebar.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/dashboard/searches.phtml
+++ b/app/design/adminhtml/default/default/template/dashboard/searches.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/dashboard/searches.phtml
+++ b/app/design/adminhtml/default/default/template/dashboard/searches.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/dashboard/searches.phtml
+++ b/app/design/adminhtml/default/default/template/dashboard/searches.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/dashboard/store/switcher.phtml
+++ b/app/design/adminhtml/default/default/template/dashboard/store/switcher.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/dashboard/store/switcher.phtml
+++ b/app/design/adminhtml/default/default/template/dashboard/store/switcher.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/dashboard/store/switcher.phtml
+++ b/app/design/adminhtml/default/default/template/dashboard/store/switcher.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/dashboard/totalbar.phtml
+++ b/app/design/adminhtml/default/default/template/dashboard/totalbar.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/dashboard/totalbar.phtml
+++ b/app/design/adminhtml/default/default/template/dashboard/totalbar.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/dashboard/totalbar.phtml
+++ b/app/design/adminhtml/default/default/template/dashboard/totalbar.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/directory/js/optional_zip_countries.phtml
+++ b/app/design/adminhtml/default/default/template/directory/js/optional_zip_countries.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/directory/js/optional_zip_countries.phtml
+++ b/app/design/adminhtml/default/default/template/directory/js/optional_zip_countries.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/directory/js/optional_zip_countries.phtml
+++ b/app/design/adminhtml/default/default/template/directory/js/optional_zip_countries.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/downloadable/product/composite/fieldset/downloadable.phtml
+++ b/app/design/adminhtml/default/default/template/downloadable/product/composite/fieldset/downloadable.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/downloadable/product/composite/fieldset/downloadable.phtml
+++ b/app/design/adminhtml/default/default/template/downloadable/product/composite/fieldset/downloadable.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/downloadable/product/composite/fieldset/downloadable.phtml
+++ b/app/design/adminhtml/default/default/template/downloadable/product/composite/fieldset/downloadable.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/downloadable/product/edit/downloadable.phtml
+++ b/app/design/adminhtml/default/default/template/downloadable/product/edit/downloadable.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/downloadable/product/edit/downloadable.phtml
+++ b/app/design/adminhtml/default/default/template/downloadable/product/edit/downloadable.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/downloadable/product/edit/downloadable.phtml
+++ b/app/design/adminhtml/default/default/template/downloadable/product/edit/downloadable.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/downloadable/product/edit/downloadable/links.phtml
+++ b/app/design/adminhtml/default/default/template/downloadable/product/edit/downloadable/links.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/downloadable/product/edit/downloadable/links.phtml
+++ b/app/design/adminhtml/default/default/template/downloadable/product/edit/downloadable/links.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/downloadable/product/edit/downloadable/links.phtml
+++ b/app/design/adminhtml/default/default/template/downloadable/product/edit/downloadable/links.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/downloadable/product/edit/downloadable/samples.phtml
+++ b/app/design/adminhtml/default/default/template/downloadable/product/edit/downloadable/samples.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/downloadable/product/edit/downloadable/samples.phtml
+++ b/app/design/adminhtml/default/default/template/downloadable/product/edit/downloadable/samples.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/downloadable/product/edit/downloadable/samples.phtml
+++ b/app/design/adminhtml/default/default/template/downloadable/product/edit/downloadable/samples.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/downloadable/sales/items/column/downloadable/creditmemo/name.phtml
+++ b/app/design/adminhtml/default/default/template/downloadable/sales/items/column/downloadable/creditmemo/name.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/downloadable/sales/items/column/downloadable/creditmemo/name.phtml
+++ b/app/design/adminhtml/default/default/template/downloadable/sales/items/column/downloadable/creditmemo/name.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/downloadable/sales/items/column/downloadable/creditmemo/name.phtml
+++ b/app/design/adminhtml/default/default/template/downloadable/sales/items/column/downloadable/creditmemo/name.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/downloadable/sales/items/column/downloadable/invoice/name.phtml
+++ b/app/design/adminhtml/default/default/template/downloadable/sales/items/column/downloadable/invoice/name.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/downloadable/sales/items/column/downloadable/invoice/name.phtml
+++ b/app/design/adminhtml/default/default/template/downloadable/sales/items/column/downloadable/invoice/name.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/downloadable/sales/items/column/downloadable/invoice/name.phtml
+++ b/app/design/adminhtml/default/default/template/downloadable/sales/items/column/downloadable/invoice/name.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/downloadable/sales/items/column/downloadable/name.phtml
+++ b/app/design/adminhtml/default/default/template/downloadable/sales/items/column/downloadable/name.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/downloadable/sales/items/column/downloadable/name.phtml
+++ b/app/design/adminhtml/default/default/template/downloadable/sales/items/column/downloadable/name.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/downloadable/sales/items/column/downloadable/name.phtml
+++ b/app/design/adminhtml/default/default/template/downloadable/sales/items/column/downloadable/name.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/downloadable/sales/order/creditmemo/create/items/renderer/downloadable.phtml
+++ b/app/design/adminhtml/default/default/template/downloadable/sales/order/creditmemo/create/items/renderer/downloadable.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/downloadable/sales/order/creditmemo/create/items/renderer/downloadable.phtml
+++ b/app/design/adminhtml/default/default/template/downloadable/sales/order/creditmemo/create/items/renderer/downloadable.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/downloadable/sales/order/creditmemo/create/items/renderer/downloadable.phtml
+++ b/app/design/adminhtml/default/default/template/downloadable/sales/order/creditmemo/create/items/renderer/downloadable.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/downloadable/sales/order/creditmemo/view/items/renderer/downloadable.phtml
+++ b/app/design/adminhtml/default/default/template/downloadable/sales/order/creditmemo/view/items/renderer/downloadable.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/downloadable/sales/order/creditmemo/view/items/renderer/downloadable.phtml
+++ b/app/design/adminhtml/default/default/template/downloadable/sales/order/creditmemo/view/items/renderer/downloadable.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/downloadable/sales/order/creditmemo/view/items/renderer/downloadable.phtml
+++ b/app/design/adminhtml/default/default/template/downloadable/sales/order/creditmemo/view/items/renderer/downloadable.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/downloadable/sales/order/invoice/create/items/renderer/downloadable.phtml
+++ b/app/design/adminhtml/default/default/template/downloadable/sales/order/invoice/create/items/renderer/downloadable.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/downloadable/sales/order/invoice/create/items/renderer/downloadable.phtml
+++ b/app/design/adminhtml/default/default/template/downloadable/sales/order/invoice/create/items/renderer/downloadable.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/downloadable/sales/order/invoice/create/items/renderer/downloadable.phtml
+++ b/app/design/adminhtml/default/default/template/downloadable/sales/order/invoice/create/items/renderer/downloadable.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/downloadable/sales/order/invoice/view/items/renderer/downloadable.phtml
+++ b/app/design/adminhtml/default/default/template/downloadable/sales/order/invoice/view/items/renderer/downloadable.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/downloadable/sales/order/invoice/view/items/renderer/downloadable.phtml
+++ b/app/design/adminhtml/default/default/template/downloadable/sales/order/invoice/view/items/renderer/downloadable.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/downloadable/sales/order/invoice/view/items/renderer/downloadable.phtml
+++ b/app/design/adminhtml/default/default/template/downloadable/sales/order/invoice/view/items/renderer/downloadable.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/downloadable/sales/order/view/items/renderer/downloadable.phtml
+++ b/app/design/adminhtml/default/default/template/downloadable/sales/order/view/items/renderer/downloadable.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/downloadable/sales/order/view/items/renderer/downloadable.phtml
+++ b/app/design/adminhtml/default/default/template/downloadable/sales/order/view/items/renderer/downloadable.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/downloadable/sales/order/view/items/renderer/downloadable.phtml
+++ b/app/design/adminhtml/default/default/template/downloadable/sales/order/view/items/renderer/downloadable.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/eav/attribute/edit/js.phtml
+++ b/app/design/adminhtml/default/default/template/eav/attribute/edit/js.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/eav/attribute/edit/js.phtml
+++ b/app/design/adminhtml/default/default/template/eav/attribute/edit/js.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/eav/attribute/edit/js.phtml
+++ b/app/design/adminhtml/default/default/template/eav/attribute/edit/js.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/eav/attribute/options.phtml
+++ b/app/design/adminhtml/default/default/template/eav/attribute/options.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/eav/attribute/options.phtml
+++ b/app/design/adminhtml/default/default/template/eav/attribute/options.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/eav/attribute/options.phtml
+++ b/app/design/adminhtml/default/default/template/eav/attribute/options.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/email/order/items.phtml
+++ b/app/design/adminhtml/default/default/template/email/order/items.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/email/order/items.phtml
+++ b/app/design/adminhtml/default/default/template/email/order/items.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/email/order/items.phtml
+++ b/app/design/adminhtml/default/default/template/email/order/items.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/empty.phtml
+++ b/app/design/adminhtml/default/default/template/empty.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/empty.phtml
+++ b/app/design/adminhtml/default/default/template/empty.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/empty.phtml
+++ b/app/design/adminhtml/default/default/template/empty.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/forgotpassword.phtml
+++ b/app/design/adminhtml/default/default/template/forgotpassword.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/forgotpassword.phtml
+++ b/app/design/adminhtml/default/default/template/forgotpassword.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/forgotpassword.phtml
+++ b/app/design/adminhtml/default/default/template/forgotpassword.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/formkey.phtml
+++ b/app/design/adminhtml/default/default/template/formkey.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/formkey.phtml
+++ b/app/design/adminhtml/default/default/template/formkey.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/formkey.phtml
+++ b/app/design/adminhtml/default/default/template/formkey.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/giftmessage/form.phtml
+++ b/app/design/adminhtml/default/default/template/giftmessage/form.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/giftmessage/form.phtml
+++ b/app/design/adminhtml/default/default/template/giftmessage/form.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/giftmessage/form.phtml
+++ b/app/design/adminhtml/default/default/template/giftmessage/form.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/giftmessage/giftoptionsform.phtml
+++ b/app/design/adminhtml/default/default/template/giftmessage/giftoptionsform.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/giftmessage/giftoptionsform.phtml
+++ b/app/design/adminhtml/default/default/template/giftmessage/giftoptionsform.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/giftmessage/giftoptionsform.phtml
+++ b/app/design/adminhtml/default/default/template/giftmessage/giftoptionsform.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/giftmessage/helper.phtml
+++ b/app/design/adminhtml/default/default/template/giftmessage/helper.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/giftmessage/helper.phtml
+++ b/app/design/adminhtml/default/default/template/giftmessage/helper.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/giftmessage/helper.phtml
+++ b/app/design/adminhtml/default/default/template/giftmessage/helper.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/giftmessage/popup.phtml
+++ b/app/design/adminhtml/default/default/template/giftmessage/popup.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/giftmessage/popup.phtml
+++ b/app/design/adminhtml/default/default/template/giftmessage/popup.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/giftmessage/popup.phtml
+++ b/app/design/adminhtml/default/default/template/giftmessage/popup.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/giftmessage/sales/order/create/giftoptions.phtml
+++ b/app/design/adminhtml/default/default/template/giftmessage/sales/order/create/giftoptions.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/giftmessage/sales/order/create/giftoptions.phtml
+++ b/app/design/adminhtml/default/default/template/giftmessage/sales/order/create/giftoptions.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/giftmessage/sales/order/create/giftoptions.phtml
+++ b/app/design/adminhtml/default/default/template/giftmessage/sales/order/create/giftoptions.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/giftmessage/sales/order/create/items.phtml
+++ b/app/design/adminhtml/default/default/template/giftmessage/sales/order/create/items.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/giftmessage/sales/order/create/items.phtml
+++ b/app/design/adminhtml/default/default/template/giftmessage/sales/order/create/items.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/giftmessage/sales/order/create/items.phtml
+++ b/app/design/adminhtml/default/default/template/giftmessage/sales/order/create/items.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/giftmessage/sales/order/view/giftoptions.phtml
+++ b/app/design/adminhtml/default/default/template/giftmessage/sales/order/view/giftoptions.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/giftmessage/sales/order/view/giftoptions.phtml
+++ b/app/design/adminhtml/default/default/template/giftmessage/sales/order/view/giftoptions.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/giftmessage/sales/order/view/giftoptions.phtml
+++ b/app/design/adminhtml/default/default/template/giftmessage/sales/order/view/giftoptions.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/giftmessage/sales/order/view/items.phtml
+++ b/app/design/adminhtml/default/default/template/giftmessage/sales/order/view/items.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/giftmessage/sales/order/view/items.phtml
+++ b/app/design/adminhtml/default/default/template/giftmessage/sales/order/view/items.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/giftmessage/sales/order/view/items.phtml
+++ b/app/design/adminhtml/default/default/template/giftmessage/sales/order/view/items.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/importexport/busy.phtml
+++ b/app/design/adminhtml/default/default/template/importexport/busy.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/importexport/busy.phtml
+++ b/app/design/adminhtml/default/default/template/importexport/busy.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/importexport/busy.phtml
+++ b/app/design/adminhtml/default/default/template/importexport/busy.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/importexport/export/form/after.phtml
+++ b/app/design/adminhtml/default/default/template/importexport/export/form/after.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/importexport/export/form/after.phtml
+++ b/app/design/adminhtml/default/default/template/importexport/export/form/after.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/importexport/export/form/after.phtml
+++ b/app/design/adminhtml/default/default/template/importexport/export/form/after.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/importexport/export/form/before.phtml
+++ b/app/design/adminhtml/default/default/template/importexport/export/form/before.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/importexport/export/form/before.phtml
+++ b/app/design/adminhtml/default/default/template/importexport/export/form/before.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/importexport/export/form/before.phtml
+++ b/app/design/adminhtml/default/default/template/importexport/export/form/before.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/importexport/import/form/after.phtml
+++ b/app/design/adminhtml/default/default/template/importexport/import/form/after.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/importexport/import/form/after.phtml
+++ b/app/design/adminhtml/default/default/template/importexport/import/form/after.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/importexport/import/form/after.phtml
+++ b/app/design/adminhtml/default/default/template/importexport/import/form/after.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/importexport/import/form/before.phtml
+++ b/app/design/adminhtml/default/default/template/importexport/import/form/before.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/importexport/import/form/before.phtml
+++ b/app/design/adminhtml/default/default/template/importexport/import/form/before.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/importexport/import/form/before.phtml
+++ b/app/design/adminhtml/default/default/template/importexport/import/form/before.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/importexport/import/frame/result.phtml
+++ b/app/design/adminhtml/default/default/template/importexport/import/frame/result.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/importexport/import/frame/result.phtml
+++ b/app/design/adminhtml/default/default/template/importexport/import/frame/result.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/importexport/import/frame/result.phtml
+++ b/app/design/adminhtml/default/default/template/importexport/import/frame/result.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/index/notifications.phtml
+++ b/app/design/adminhtml/default/default/template/index/notifications.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/index/notifications.phtml
+++ b/app/design/adminhtml/default/default/template/index/notifications.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/index/notifications.phtml
+++ b/app/design/adminhtml/default/default/template/index/notifications.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/login.phtml
+++ b/app/design/adminhtml/default/default/template/login.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/login.phtml
+++ b/app/design/adminhtml/default/default/template/login.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/login.phtml
+++ b/app/design/adminhtml/default/default/template/login.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/media/editor.phtml
+++ b/app/design/adminhtml/default/default/template/media/editor.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/media/editor.phtml
+++ b/app/design/adminhtml/default/default/template/media/editor.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/media/editor.phtml
+++ b/app/design/adminhtml/default/default/template/media/editor.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/media/uploader.phtml
+++ b/app/design/adminhtml/default/default/template/media/uploader.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/media/uploader.phtml
+++ b/app/design/adminhtml/default/default/template/media/uploader.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/media/uploader.phtml
+++ b/app/design/adminhtml/default/default/template/media/uploader.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/newsletter/preview/iframeswitcher.phtml
+++ b/app/design/adminhtml/default/default/template/newsletter/preview/iframeswitcher.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/newsletter/preview/iframeswitcher.phtml
+++ b/app/design/adminhtml/default/default/template/newsletter/preview/iframeswitcher.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/newsletter/preview/iframeswitcher.phtml
+++ b/app/design/adminhtml/default/default/template/newsletter/preview/iframeswitcher.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/newsletter/preview/store.phtml
+++ b/app/design/adminhtml/default/default/template/newsletter/preview/store.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/newsletter/preview/store.phtml
+++ b/app/design/adminhtml/default/default/template/newsletter/preview/store.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/newsletter/preview/store.phtml
+++ b/app/design/adminhtml/default/default/template/newsletter/preview/store.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/newsletter/problem/list.phtml
+++ b/app/design/adminhtml/default/default/template/newsletter/problem/list.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/newsletter/problem/list.phtml
+++ b/app/design/adminhtml/default/default/template/newsletter/problem/list.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/newsletter/problem/list.phtml
+++ b/app/design/adminhtml/default/default/template/newsletter/problem/list.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/newsletter/queue/edit.phtml
+++ b/app/design/adminhtml/default/default/template/newsletter/queue/edit.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/newsletter/queue/edit.phtml
+++ b/app/design/adminhtml/default/default/template/newsletter/queue/edit.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/newsletter/queue/edit.phtml
+++ b/app/design/adminhtml/default/default/template/newsletter/queue/edit.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/newsletter/queue/list.phtml
+++ b/app/design/adminhtml/default/default/template/newsletter/queue/list.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/newsletter/queue/list.phtml
+++ b/app/design/adminhtml/default/default/template/newsletter/queue/list.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/newsletter/queue/list.phtml
+++ b/app/design/adminhtml/default/default/template/newsletter/queue/list.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/newsletter/queue/preview.phtml
+++ b/app/design/adminhtml/default/default/template/newsletter/queue/preview.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/newsletter/queue/preview.phtml
+++ b/app/design/adminhtml/default/default/template/newsletter/queue/preview.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/newsletter/queue/preview.phtml
+++ b/app/design/adminhtml/default/default/template/newsletter/queue/preview.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/newsletter/subscriber/list.phtml
+++ b/app/design/adminhtml/default/default/template/newsletter/subscriber/list.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/newsletter/subscriber/list.phtml
+++ b/app/design/adminhtml/default/default/template/newsletter/subscriber/list.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/newsletter/subscriber/list.phtml
+++ b/app/design/adminhtml/default/default/template/newsletter/subscriber/list.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/newsletter/template/edit.phtml
+++ b/app/design/adminhtml/default/default/template/newsletter/template/edit.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/newsletter/template/edit.phtml
+++ b/app/design/adminhtml/default/default/template/newsletter/template/edit.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/newsletter/template/edit.phtml
+++ b/app/design/adminhtml/default/default/template/newsletter/template/edit.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/newsletter/template/list.phtml
+++ b/app/design/adminhtml/default/default/template/newsletter/template/list.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/newsletter/template/list.phtml
+++ b/app/design/adminhtml/default/default/template/newsletter/template/list.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/newsletter/template/list.phtml
+++ b/app/design/adminhtml/default/default/template/newsletter/template/list.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/newsletter/template/preview.phtml
+++ b/app/design/adminhtml/default/default/template/newsletter/template/preview.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/newsletter/template/preview.phtml
+++ b/app/design/adminhtml/default/default/template/newsletter/template/preview.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/newsletter/template/preview.phtml
+++ b/app/design/adminhtml/default/default/template/newsletter/template/preview.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/notification/baseurl.phtml
+++ b/app/design/adminhtml/default/default/template/notification/baseurl.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/notification/baseurl.phtml
+++ b/app/design/adminhtml/default/default/template/notification/baseurl.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/notification/baseurl.phtml
+++ b/app/design/adminhtml/default/default/template/notification/baseurl.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/notification/curl.phtml
+++ b/app/design/adminhtml/default/default/template/notification/curl.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/notification/curl.phtml
+++ b/app/design/adminhtml/default/default/template/notification/curl.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/notification/curl.phtml
+++ b/app/design/adminhtml/default/default/template/notification/curl.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/notification/formkey.phtml
+++ b/app/design/adminhtml/default/default/template/notification/formkey.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/notification/formkey.phtml
+++ b/app/design/adminhtml/default/default/template/notification/formkey.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/notification/formkey.phtml
+++ b/app/design/adminhtml/default/default/template/notification/formkey.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/notification/security.phtml
+++ b/app/design/adminhtml/default/default/template/notification/security.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/notification/security.phtml
+++ b/app/design/adminhtml/default/default/template/notification/security.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/notification/security.phtml
+++ b/app/design/adminhtml/default/default/template/notification/security.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/notification/toolbar.phtml
+++ b/app/design/adminhtml/default/default/template/notification/toolbar.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/notification/toolbar.phtml
+++ b/app/design/adminhtml/default/default/template/notification/toolbar.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/notification/toolbar.phtml
+++ b/app/design/adminhtml/default/default/template/notification/toolbar.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/notification/window.phtml
+++ b/app/design/adminhtml/default/default/template/notification/window.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/notification/window.phtml
+++ b/app/design/adminhtml/default/default/template/notification/window.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/notification/window.phtml
+++ b/app/design/adminhtml/default/default/template/notification/window.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/oauth/authorize/button-simple.phtml
+++ b/app/design/adminhtml/default/default/template/oauth/authorize/button-simple.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/oauth/authorize/button-simple.phtml
+++ b/app/design/adminhtml/default/default/template/oauth/authorize/button-simple.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/oauth/authorize/button-simple.phtml
+++ b/app/design/adminhtml/default/default/template/oauth/authorize/button-simple.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/oauth/authorize/button.phtml
+++ b/app/design/adminhtml/default/default/template/oauth/authorize/button.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/oauth/authorize/button.phtml
+++ b/app/design/adminhtml/default/default/template/oauth/authorize/button.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/oauth/authorize/button.phtml
+++ b/app/design/adminhtml/default/default/template/oauth/authorize/button.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/oauth/authorize/confirm-simple.phtml
+++ b/app/design/adminhtml/default/default/template/oauth/authorize/confirm-simple.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/oauth/authorize/confirm-simple.phtml
+++ b/app/design/adminhtml/default/default/template/oauth/authorize/confirm-simple.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/oauth/authorize/confirm-simple.phtml
+++ b/app/design/adminhtml/default/default/template/oauth/authorize/confirm-simple.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/oauth/authorize/confirm.phtml
+++ b/app/design/adminhtml/default/default/template/oauth/authorize/confirm.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/oauth/authorize/confirm.phtml
+++ b/app/design/adminhtml/default/default/template/oauth/authorize/confirm.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/oauth/authorize/confirm.phtml
+++ b/app/design/adminhtml/default/default/template/oauth/authorize/confirm.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/oauth/authorize/form/login-simple.phtml
+++ b/app/design/adminhtml/default/default/template/oauth/authorize/form/login-simple.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/oauth/authorize/form/login-simple.phtml
+++ b/app/design/adminhtml/default/default/template/oauth/authorize/form/login-simple.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/oauth/authorize/form/login-simple.phtml
+++ b/app/design/adminhtml/default/default/template/oauth/authorize/form/login-simple.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/oauth/authorize/form/login.phtml
+++ b/app/design/adminhtml/default/default/template/oauth/authorize/form/login.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/oauth/authorize/form/login.phtml
+++ b/app/design/adminhtml/default/default/template/oauth/authorize/form/login.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/oauth/authorize/form/login.phtml
+++ b/app/design/adminhtml/default/default/template/oauth/authorize/form/login.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/oauth/authorize/head-simple.phtml
+++ b/app/design/adminhtml/default/default/template/oauth/authorize/head-simple.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/oauth/authorize/head-simple.phtml
+++ b/app/design/adminhtml/default/default/template/oauth/authorize/head-simple.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/oauth/authorize/head-simple.phtml
+++ b/app/design/adminhtml/default/default/template/oauth/authorize/head-simple.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/oauth/authorize/reject-simple.phtml
+++ b/app/design/adminhtml/default/default/template/oauth/authorize/reject-simple.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/oauth/authorize/reject-simple.phtml
+++ b/app/design/adminhtml/default/default/template/oauth/authorize/reject-simple.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/oauth/authorize/reject-simple.phtml
+++ b/app/design/adminhtml/default/default/template/oauth/authorize/reject-simple.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/oauth/authorize/reject.phtml
+++ b/app/design/adminhtml/default/default/template/oauth/authorize/reject.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/oauth/authorize/reject.phtml
+++ b/app/design/adminhtml/default/default/template/oauth/authorize/reject.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/oauth/authorize/reject.phtml
+++ b/app/design/adminhtml/default/default/template/oauth/authorize/reject.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/overlay_popup.phtml
+++ b/app/design/adminhtml/default/default/template/overlay_popup.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/overlay_popup.phtml
+++ b/app/design/adminhtml/default/default/template/overlay_popup.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/overlay_popup.phtml
+++ b/app/design/adminhtml/default/default/template/overlay_popup.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/page.phtml
+++ b/app/design/adminhtml/default/default/template/page.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/page.phtml
+++ b/app/design/adminhtml/default/default/template/page.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/page.phtml
+++ b/app/design/adminhtml/default/default/template/page.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/page/footer.phtml
+++ b/app/design/adminhtml/default/default/template/page/footer.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/page/footer.phtml
+++ b/app/design/adminhtml/default/default/template/page/footer.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/page/footer.phtml
+++ b/app/design/adminhtml/default/default/template/page/footer.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/page/head.phtml
+++ b/app/design/adminhtml/default/default/template/page/head.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/page/head.phtml
+++ b/app/design/adminhtml/default/default/template/page/head.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/page/head.phtml
+++ b/app/design/adminhtml/default/default/template/page/head.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/page/header.phtml
+++ b/app/design/adminhtml/default/default/template/page/header.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/page/header.phtml
+++ b/app/design/adminhtml/default/default/template/page/header.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/page/header.phtml
+++ b/app/design/adminhtml/default/default/template/page/header.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/page/js/calendar.phtml
+++ b/app/design/adminhtml/default/default/template/page/js/calendar.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/page/js/calendar.phtml
+++ b/app/design/adminhtml/default/default/template/page/js/calendar.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/page/js/calendar.phtml
+++ b/app/design/adminhtml/default/default/template/page/js/calendar.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/page/js/translate.phtml
+++ b/app/design/adminhtml/default/default/template/page/js/translate.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/page/js/translate.phtml
+++ b/app/design/adminhtml/default/default/template/page/js/translate.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/page/js/translate.phtml
+++ b/app/design/adminhtml/default/default/template/page/js/translate.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/page/menu.phtml
+++ b/app/design/adminhtml/default/default/template/page/menu.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/page/menu.phtml
+++ b/app/design/adminhtml/default/default/template/page/menu.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/page/menu.phtml
+++ b/app/design/adminhtml/default/default/template/page/menu.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/page/notices.phtml
+++ b/app/design/adminhtml/default/default/template/page/notices.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/page/notices.phtml
+++ b/app/design/adminhtml/default/default/template/page/notices.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/page/notices.phtml
+++ b/app/design/adminhtml/default/default/template/page/notices.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/paygate/form/cc.phtml
+++ b/app/design/adminhtml/default/default/template/paygate/form/cc.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/paygate/form/cc.phtml
+++ b/app/design/adminhtml/default/default/template/paygate/form/cc.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/paygate/form/cc.phtml
+++ b/app/design/adminhtml/default/default/template/paygate/form/cc.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/paygate/info/cc.phtml
+++ b/app/design/adminhtml/default/default/template/paygate/info/cc.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/paygate/info/cc.phtml
+++ b/app/design/adminhtml/default/default/template/paygate/info/cc.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/paygate/info/cc.phtml
+++ b/app/design/adminhtml/default/default/template/paygate/info/cc.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/paygate/info/pdf.phtml
+++ b/app/design/adminhtml/default/default/template/paygate/info/pdf.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/paygate/info/pdf.phtml
+++ b/app/design/adminhtml/default/default/template/paygate/info/pdf.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/paygate/info/pdf.phtml
+++ b/app/design/adminhtml/default/default/template/paygate/info/pdf.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/payment/form/banktransfer.phtml
+++ b/app/design/adminhtml/default/default/template/payment/form/banktransfer.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/payment/form/banktransfer.phtml
+++ b/app/design/adminhtml/default/default/template/payment/form/banktransfer.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/payment/form/banktransfer.phtml
+++ b/app/design/adminhtml/default/default/template/payment/form/banktransfer.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/payment/form/cashondelivery.phtml
+++ b/app/design/adminhtml/default/default/template/payment/form/cashondelivery.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/payment/form/cashondelivery.phtml
+++ b/app/design/adminhtml/default/default/template/payment/form/cashondelivery.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/payment/form/cashondelivery.phtml
+++ b/app/design/adminhtml/default/default/template/payment/form/cashondelivery.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/payment/form/cc.phtml
+++ b/app/design/adminhtml/default/default/template/payment/form/cc.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/payment/form/cc.phtml
+++ b/app/design/adminhtml/default/default/template/payment/form/cc.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/payment/form/cc.phtml
+++ b/app/design/adminhtml/default/default/template/payment/form/cc.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/payment/form/ccsave.phtml
+++ b/app/design/adminhtml/default/default/template/payment/form/ccsave.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/payment/form/ccsave.phtml
+++ b/app/design/adminhtml/default/default/template/payment/form/ccsave.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/payment/form/ccsave.phtml
+++ b/app/design/adminhtml/default/default/template/payment/form/ccsave.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/payment/form/checkmo.phtml
+++ b/app/design/adminhtml/default/default/template/payment/form/checkmo.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/payment/form/checkmo.phtml
+++ b/app/design/adminhtml/default/default/template/payment/form/checkmo.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/payment/form/checkmo.phtml
+++ b/app/design/adminhtml/default/default/template/payment/form/checkmo.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/payment/form/purchaseorder.phtml
+++ b/app/design/adminhtml/default/default/template/payment/form/purchaseorder.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/payment/form/purchaseorder.phtml
+++ b/app/design/adminhtml/default/default/template/payment/form/purchaseorder.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/payment/form/purchaseorder.phtml
+++ b/app/design/adminhtml/default/default/template/payment/form/purchaseorder.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/payment/info/banktransfer.phtml
+++ b/app/design/adminhtml/default/default/template/payment/info/banktransfer.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/payment/info/banktransfer.phtml
+++ b/app/design/adminhtml/default/default/template/payment/info/banktransfer.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/payment/info/banktransfer.phtml
+++ b/app/design/adminhtml/default/default/template/payment/info/banktransfer.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/payment/info/checkmo.phtml
+++ b/app/design/adminhtml/default/default/template/payment/info/checkmo.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/payment/info/checkmo.phtml
+++ b/app/design/adminhtml/default/default/template/payment/info/checkmo.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/payment/info/checkmo.phtml
+++ b/app/design/adminhtml/default/default/template/payment/info/checkmo.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/payment/info/default.phtml
+++ b/app/design/adminhtml/default/default/template/payment/info/default.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/payment/info/default.phtml
+++ b/app/design/adminhtml/default/default/template/payment/info/default.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/payment/info/default.phtml
+++ b/app/design/adminhtml/default/default/template/payment/info/default.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/payment/info/pdf/checkmo.phtml
+++ b/app/design/adminhtml/default/default/template/payment/info/pdf/checkmo.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/payment/info/pdf/checkmo.phtml
+++ b/app/design/adminhtml/default/default/template/payment/info/pdf/checkmo.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/payment/info/pdf/checkmo.phtml
+++ b/app/design/adminhtml/default/default/template/payment/info/pdf/checkmo.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/payment/info/pdf/default.phtml
+++ b/app/design/adminhtml/default/default/template/payment/info/pdf/default.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/payment/info/pdf/default.phtml
+++ b/app/design/adminhtml/default/default/template/payment/info/pdf/default.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/payment/info/pdf/default.phtml
+++ b/app/design/adminhtml/default/default/template/payment/info/pdf/default.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/payment/info/pdf/purchaseorder.phtml
+++ b/app/design/adminhtml/default/default/template/payment/info/pdf/purchaseorder.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/payment/info/pdf/purchaseorder.phtml
+++ b/app/design/adminhtml/default/default/template/payment/info/pdf/purchaseorder.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/payment/info/pdf/purchaseorder.phtml
+++ b/app/design/adminhtml/default/default/template/payment/info/pdf/purchaseorder.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/payment/info/purchaseorder.phtml
+++ b/app/design/adminhtml/default/default/template/payment/info/purchaseorder.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/payment/info/purchaseorder.phtml
+++ b/app/design/adminhtml/default/default/template/payment/info/purchaseorder.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/payment/info/purchaseorder.phtml
+++ b/app/design/adminhtml/default/default/template/payment/info/purchaseorder.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/paypal/system/config/api_wizard.phtml
+++ b/app/design/adminhtml/default/default/template/paypal/system/config/api_wizard.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/paypal/system/config/api_wizard.phtml
+++ b/app/design/adminhtml/default/default/template/paypal/system/config/api_wizard.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/paypal/system/config/api_wizard.phtml
+++ b/app/design/adminhtml/default/default/template/paypal/system/config/api_wizard.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/paypal/system/config/bml_api_wizard.phtml
+++ b/app/design/adminhtml/default/default/template/paypal/system/config/bml_api_wizard.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/paypal/system/config/bml_api_wizard.phtml
+++ b/app/design/adminhtml/default/default/template/paypal/system/config/bml_api_wizard.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/paypal/system/config/bml_api_wizard.phtml
+++ b/app/design/adminhtml/default/default/template/paypal/system/config/bml_api_wizard.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/paypal/system/config/fieldset/global.phtml
+++ b/app/design/adminhtml/default/default/template/paypal/system/config/fieldset/global.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/paypal/system/config/fieldset/global.phtml
+++ b/app/design/adminhtml/default/default/template/paypal/system/config/fieldset/global.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/paypal/system/config/fieldset/global.phtml
+++ b/app/design/adminhtml/default/default/template/paypal/system/config/fieldset/global.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/paypal/system/config/fieldset/hint.phtml
+++ b/app/design/adminhtml/default/default/template/paypal/system/config/fieldset/hint.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/paypal/system/config/fieldset/hint.phtml
+++ b/app/design/adminhtml/default/default/template/paypal/system/config/fieldset/hint.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/paypal/system/config/fieldset/hint.phtml
+++ b/app/design/adminhtml/default/default/template/paypal/system/config/fieldset/hint.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/paypal/system/config/fieldset/store.phtml
+++ b/app/design/adminhtml/default/default/template/paypal/system/config/fieldset/store.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/paypal/system/config/fieldset/store.phtml
+++ b/app/design/adminhtml/default/default/template/paypal/system/config/fieldset/store.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/paypal/system/config/fieldset/store.phtml
+++ b/app/design/adminhtml/default/default/template/paypal/system/config/fieldset/store.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/paypal/system/config/payflowlink/advanced.phtml
+++ b/app/design/adminhtml/default/default/template/paypal/system/config/payflowlink/advanced.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/paypal/system/config/payflowlink/advanced.phtml
+++ b/app/design/adminhtml/default/default/template/paypal/system/config/payflowlink/advanced.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/paypal/system/config/payflowlink/advanced.phtml
+++ b/app/design/adminhtml/default/default/template/paypal/system/config/payflowlink/advanced.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/paypal/system/config/payflowlink/info.phtml
+++ b/app/design/adminhtml/default/default/template/paypal/system/config/payflowlink/info.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/paypal/system/config/payflowlink/info.phtml
+++ b/app/design/adminhtml/default/default/template/paypal/system/config/payflowlink/info.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/paypal/system/config/payflowlink/info.phtml
+++ b/app/design/adminhtml/default/default/template/paypal/system/config/payflowlink/info.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/permissions/role_users_grid_js.phtml
+++ b/app/design/adminhtml/default/default/template/permissions/role_users_grid_js.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/permissions/role_users_grid_js.phtml
+++ b/app/design/adminhtml/default/default/template/permissions/role_users_grid_js.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/permissions/role_users_grid_js.phtml
+++ b/app/design/adminhtml/default/default/template/permissions/role_users_grid_js.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/permissions/roleinfo.phtml
+++ b/app/design/adminhtml/default/default/template/permissions/roleinfo.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/permissions/roleinfo.phtml
+++ b/app/design/adminhtml/default/default/template/permissions/roleinfo.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/permissions/roleinfo.phtml
+++ b/app/design/adminhtml/default/default/template/permissions/roleinfo.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/permissions/roles.phtml
+++ b/app/design/adminhtml/default/default/template/permissions/roles.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/permissions/roles.phtml
+++ b/app/design/adminhtml/default/default/template/permissions/roles.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/permissions/roles.phtml
+++ b/app/design/adminhtml/default/default/template/permissions/roles.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/permissions/rolesedit.phtml
+++ b/app/design/adminhtml/default/default/template/permissions/rolesedit.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/permissions/rolesedit.phtml
+++ b/app/design/adminhtml/default/default/template/permissions/rolesedit.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/permissions/rolesedit.phtml
+++ b/app/design/adminhtml/default/default/template/permissions/rolesedit.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/permissions/rolesusers.phtml
+++ b/app/design/adminhtml/default/default/template/permissions/rolesusers.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/permissions/rolesusers.phtml
+++ b/app/design/adminhtml/default/default/template/permissions/rolesusers.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/permissions/rolesusers.phtml
+++ b/app/design/adminhtml/default/default/template/permissions/rolesusers.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/permissions/user_roles_grid_js.phtml
+++ b/app/design/adminhtml/default/default/template/permissions/user_roles_grid_js.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/permissions/user_roles_grid_js.phtml
+++ b/app/design/adminhtml/default/default/template/permissions/user_roles_grid_js.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/permissions/user_roles_grid_js.phtml
+++ b/app/design/adminhtml/default/default/template/permissions/user_roles_grid_js.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/permissions/userinfo.phtml
+++ b/app/design/adminhtml/default/default/template/permissions/userinfo.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/permissions/userinfo.phtml
+++ b/app/design/adminhtml/default/default/template/permissions/userinfo.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/permissions/userinfo.phtml
+++ b/app/design/adminhtml/default/default/template/permissions/userinfo.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/permissions/usernroles.phtml
+++ b/app/design/adminhtml/default/default/template/permissions/usernroles.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/permissions/usernroles.phtml
+++ b/app/design/adminhtml/default/default/template/permissions/usernroles.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/permissions/usernroles.phtml
+++ b/app/design/adminhtml/default/default/template/permissions/usernroles.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/permissions/userroles.phtml
+++ b/app/design/adminhtml/default/default/template/permissions/userroles.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/permissions/userroles.phtml
+++ b/app/design/adminhtml/default/default/template/permissions/userroles.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/permissions/userroles.phtml
+++ b/app/design/adminhtml/default/default/template/permissions/userroles.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/permissions/users.phtml
+++ b/app/design/adminhtml/default/default/template/permissions/users.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/permissions/users.phtml
+++ b/app/design/adminhtml/default/default/template/permissions/users.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/permissions/users.phtml
+++ b/app/design/adminhtml/default/default/template/permissions/users.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/poll/answers/list.phtml
+++ b/app/design/adminhtml/default/default/template/poll/answers/list.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/poll/answers/list.phtml
+++ b/app/design/adminhtml/default/default/template/poll/answers/list.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/poll/answers/list.phtml
+++ b/app/design/adminhtml/default/default/template/poll/answers/list.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/popup.phtml
+++ b/app/design/adminhtml/default/default/template/popup.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/popup.phtml
+++ b/app/design/adminhtml/default/default/template/popup.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/popup.phtml
+++ b/app/design/adminhtml/default/default/template/popup.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/promo/fieldset.phtml
+++ b/app/design/adminhtml/default/default/template/promo/fieldset.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/promo/fieldset.phtml
+++ b/app/design/adminhtml/default/default/template/promo/fieldset.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/promo/fieldset.phtml
+++ b/app/design/adminhtml/default/default/template/promo/fieldset.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/promo/form.phtml
+++ b/app/design/adminhtml/default/default/template/promo/form.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/promo/form.phtml
+++ b/app/design/adminhtml/default/default/template/promo/form.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/promo/form.phtml
+++ b/app/design/adminhtml/default/default/template/promo/form.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/promo/js.phtml
+++ b/app/design/adminhtml/default/default/template/promo/js.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/promo/js.phtml
+++ b/app/design/adminhtml/default/default/template/promo/js.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/promo/js.phtml
+++ b/app/design/adminhtml/default/default/template/promo/js.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/promo/salesrulejs.phtml
+++ b/app/design/adminhtml/default/default/template/promo/salesrulejs.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/promo/salesrulejs.phtml
+++ b/app/design/adminhtml/default/default/template/promo/salesrulejs.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/promo/salesrulejs.phtml
+++ b/app/design/adminhtml/default/default/template/promo/salesrulejs.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/rating/detailed.phtml
+++ b/app/design/adminhtml/default/default/template/rating/detailed.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/rating/detailed.phtml
+++ b/app/design/adminhtml/default/default/template/rating/detailed.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/rating/detailed.phtml
+++ b/app/design/adminhtml/default/default/template/rating/detailed.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/rating/options.phtml
+++ b/app/design/adminhtml/default/default/template/rating/options.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/rating/options.phtml
+++ b/app/design/adminhtml/default/default/template/rating/options.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/rating/options.phtml
+++ b/app/design/adminhtml/default/default/template/rating/options.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/rating/stars/detailed.phtml
+++ b/app/design/adminhtml/default/default/template/rating/stars/detailed.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/rating/stars/detailed.phtml
+++ b/app/design/adminhtml/default/default/template/rating/stars/detailed.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/rating/stars/detailed.phtml
+++ b/app/design/adminhtml/default/default/template/rating/stars/detailed.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/rating/stars/summary.phtml
+++ b/app/design/adminhtml/default/default/template/rating/stars/summary.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/rating/stars/summary.phtml
+++ b/app/design/adminhtml/default/default/template/rating/stars/summary.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/rating/stars/summary.phtml
+++ b/app/design/adminhtml/default/default/template/rating/stars/summary.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/report/grid.phtml
+++ b/app/design/adminhtml/default/default/template/report/grid.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/report/grid.phtml
+++ b/app/design/adminhtml/default/default/template/report/grid.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/report/grid.phtml
+++ b/app/design/adminhtml/default/default/template/report/grid.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/report/grid/container.phtml
+++ b/app/design/adminhtml/default/default/template/report/grid/container.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/report/grid/container.phtml
+++ b/app/design/adminhtml/default/default/template/report/grid/container.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/report/grid/container.phtml
+++ b/app/design/adminhtml/default/default/template/report/grid/container.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/report/refresh/statistics.phtml
+++ b/app/design/adminhtml/default/default/template/report/refresh/statistics.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/report/refresh/statistics.phtml
+++ b/app/design/adminhtml/default/default/template/report/refresh/statistics.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/report/refresh/statistics.phtml
+++ b/app/design/adminhtml/default/default/template/report/refresh/statistics.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/report/store/switcher.phtml
+++ b/app/design/adminhtml/default/default/template/report/store/switcher.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/report/store/switcher.phtml
+++ b/app/design/adminhtml/default/default/template/report/store/switcher.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/report/store/switcher.phtml
+++ b/app/design/adminhtml/default/default/template/report/store/switcher.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/report/store/switcher/enhanced.phtml
+++ b/app/design/adminhtml/default/default/template/report/store/switcher/enhanced.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/report/store/switcher/enhanced.phtml
+++ b/app/design/adminhtml/default/default/template/report/store/switcher/enhanced.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/report/store/switcher/enhanced.phtml
+++ b/app/design/adminhtml/default/default/template/report/store/switcher/enhanced.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/report/wishlist.phtml
+++ b/app/design/adminhtml/default/default/template/report/wishlist.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/report/wishlist.phtml
+++ b/app/design/adminhtml/default/default/template/report/wishlist.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/report/wishlist.phtml
+++ b/app/design/adminhtml/default/default/template/report/wishlist.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/resetforgottenpassword.phtml
+++ b/app/design/adminhtml/default/default/template/resetforgottenpassword.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/resetforgottenpassword.phtml
+++ b/app/design/adminhtml/default/default/template/resetforgottenpassword.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/resetforgottenpassword.phtml
+++ b/app/design/adminhtml/default/default/template/resetforgottenpassword.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/review/add.phtml
+++ b/app/design/adminhtml/default/default/template/review/add.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/review/add.phtml
+++ b/app/design/adminhtml/default/default/template/review/add.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/review/add.phtml
+++ b/app/design/adminhtml/default/default/template/review/add.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/billing/agreement/form.phtml
+++ b/app/design/adminhtml/default/default/template/sales/billing/agreement/form.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/sales/billing/agreement/form.phtml
+++ b/app/design/adminhtml/default/default/template/sales/billing/agreement/form.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/billing/agreement/form.phtml
+++ b/app/design/adminhtml/default/default/template/sales/billing/agreement/form.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/billing/agreement/view/form.phtml
+++ b/app/design/adminhtml/default/default/template/sales/billing/agreement/view/form.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/sales/billing/agreement/view/form.phtml
+++ b/app/design/adminhtml/default/default/template/sales/billing/agreement/view/form.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/billing/agreement/view/form.phtml
+++ b/app/design/adminhtml/default/default/template/sales/billing/agreement/view/form.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/billing/agreement/view/tab/info.phtml
+++ b/app/design/adminhtml/default/default/template/sales/billing/agreement/view/tab/info.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/sales/billing/agreement/view/tab/info.phtml
+++ b/app/design/adminhtml/default/default/template/sales/billing/agreement/view/tab/info.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/billing/agreement/view/tab/info.phtml
+++ b/app/design/adminhtml/default/default/template/sales/billing/agreement/view/tab/info.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/items/column/name.phtml
+++ b/app/design/adminhtml/default/default/template/sales/items/column/name.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/sales/items/column/name.phtml
+++ b/app/design/adminhtml/default/default/template/sales/items/column/name.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/items/column/name.phtml
+++ b/app/design/adminhtml/default/default/template/sales/items/column/name.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/items/column/qty.phtml
+++ b/app/design/adminhtml/default/default/template/sales/items/column/qty.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/sales/items/column/qty.phtml
+++ b/app/design/adminhtml/default/default/template/sales/items/column/qty.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/items/column/qty.phtml
+++ b/app/design/adminhtml/default/default/template/sales/items/column/qty.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/items/renderer/default.phtml
+++ b/app/design/adminhtml/default/default/template/sales/items/renderer/default.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/sales/items/renderer/default.phtml
+++ b/app/design/adminhtml/default/default/template/sales/items/renderer/default.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/items/renderer/default.phtml
+++ b/app/design/adminhtml/default/default/template/sales/items/renderer/default.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/address/form.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/address/form.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/sales/order/address/form.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/address/form.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/address/form.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/address/form.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/comments/view.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/comments/view.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/sales/order/comments/view.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/comments/view.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/comments/view.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/comments/view.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/create/abstract.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/create/abstract.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/sales/order/create/abstract.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/create/abstract.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/create/abstract.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/create/abstract.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/create/billing/method/form.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/create/billing/method/form.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/sales/order/create/billing/method/form.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/create/billing/method/form.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/create/billing/method/form.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/create/billing/method/form.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/create/comment.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/create/comment.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/sales/order/create/comment.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/create/comment.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/create/comment.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/create/comment.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/create/coupons/form.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/create/coupons/form.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/sales/order/create/coupons/form.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/create/coupons/form.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/create/coupons/form.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/create/coupons/form.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/create/data.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/create/data.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/sales/order/create/data.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/create/data.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/create/data.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/create/data.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/create/form.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/create/form.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/sales/order/create/form.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/create/form.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/create/form.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/create/form.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/create/form/account.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/create/form/account.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/sales/order/create/form/account.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/create/form/account.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/create/form/account.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/create/form/account.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/create/form/address.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/create/form/address.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/sales/order/create/form/address.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/create/form/address.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/create/form/address.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/create/form/address.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/create/giftmessage.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/create/giftmessage.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/sales/order/create/giftmessage.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/create/giftmessage.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/create/giftmessage.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/create/giftmessage.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/create/items.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/create/items.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/sales/order/create/items.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/create/items.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/create/items.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/create/items.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/create/items/grid.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/create/items/grid.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/sales/order/create/items/grid.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/create/items/grid.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/create/items/grid.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/create/items/grid.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/create/js.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/create/js.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/sales/order/create/js.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/create/js.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/create/js.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/create/js.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/create/newsletter/form.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/create/newsletter/form.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/sales/order/create/newsletter/form.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/create/newsletter/form.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/create/newsletter/form.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/create/newsletter/form.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/create/shipping/method/form.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/create/shipping/method/form.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/sales/order/create/shipping/method/form.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/create/shipping/method/form.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/create/shipping/method/form.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/create/shipping/method/form.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/create/sidebar.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/create/sidebar.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/sales/order/create/sidebar.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/create/sidebar.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/create/sidebar.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/create/sidebar.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/create/sidebar/items.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/create/sidebar/items.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/sales/order/create/sidebar/items.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/create/sidebar/items.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/create/sidebar/items.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/create/sidebar/items.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/create/store/select.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/create/store/select.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/sales/order/create/store/select.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/create/store/select.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/create/store/select.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/create/store/select.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/create/totals.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/create/totals.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/sales/order/create/totals.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/create/totals.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/create/totals.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/create/totals.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/create/totals/default.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/create/totals/default.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/sales/order/create/totals/default.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/create/totals/default.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/create/totals/default.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/create/totals/default.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/create/totals/grandtotal.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/create/totals/grandtotal.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/sales/order/create/totals/grandtotal.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/create/totals/grandtotal.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/create/totals/grandtotal.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/create/totals/grandtotal.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/create/totals/shipping.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/create/totals/shipping.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/sales/order/create/totals/shipping.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/create/totals/shipping.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/create/totals/shipping.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/create/totals/shipping.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/create/totals/subtotal.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/create/totals/subtotal.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/sales/order/create/totals/subtotal.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/create/totals/subtotal.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/create/totals/subtotal.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/create/totals/subtotal.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/create/totals/tax.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/create/totals/tax.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/sales/order/create/totals/tax.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/create/totals/tax.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/create/totals/tax.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/create/totals/tax.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/creditmemo/create/form.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/creditmemo/create/form.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/sales/order/creditmemo/create/form.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/creditmemo/create/form.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/creditmemo/create/form.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/creditmemo/create/form.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/creditmemo/create/items.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/creditmemo/create/items.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/sales/order/creditmemo/create/items.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/creditmemo/create/items.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/creditmemo/create/items.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/creditmemo/create/items.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/creditmemo/create/items/renderer/configurable.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/creditmemo/create/items/renderer/configurable.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/sales/order/creditmemo/create/items/renderer/configurable.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/creditmemo/create/items/renderer/configurable.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/creditmemo/create/items/renderer/configurable.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/creditmemo/create/items/renderer/configurable.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/creditmemo/create/items/renderer/default.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/creditmemo/create/items/renderer/default.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/sales/order/creditmemo/create/items/renderer/default.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/creditmemo/create/items/renderer/default.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/creditmemo/create/items/renderer/default.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/creditmemo/create/items/renderer/default.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/creditmemo/create/totals/adjustments.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/creditmemo/create/totals/adjustments.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/sales/order/creditmemo/create/totals/adjustments.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/creditmemo/create/totals/adjustments.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/creditmemo/create/totals/adjustments.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/creditmemo/create/totals/adjustments.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/creditmemo/view/form.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/creditmemo/view/form.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/sales/order/creditmemo/view/form.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/creditmemo/view/form.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/creditmemo/view/form.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/creditmemo/view/form.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/creditmemo/view/items.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/creditmemo/view/items.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/sales/order/creditmemo/view/items.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/creditmemo/view/items.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/creditmemo/view/items.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/creditmemo/view/items.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/creditmemo/view/items/renderer/configurable.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/creditmemo/view/items/renderer/configurable.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/sales/order/creditmemo/view/items/renderer/configurable.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/creditmemo/view/items/renderer/configurable.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/creditmemo/view/items/renderer/configurable.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/creditmemo/view/items/renderer/configurable.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/creditmemo/view/items/renderer/default.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/creditmemo/view/items/renderer/default.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/sales/order/creditmemo/view/items/renderer/default.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/creditmemo/view/items/renderer/default.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/creditmemo/view/items/renderer/default.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/creditmemo/view/items/renderer/default.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/giftoptions.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/giftoptions.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/sales/order/giftoptions.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/giftoptions.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/giftoptions.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/giftoptions.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/invoice/create/form.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/invoice/create/form.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/sales/order/invoice/create/form.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/invoice/create/form.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/invoice/create/form.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/invoice/create/form.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/invoice/create/items.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/invoice/create/items.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/sales/order/invoice/create/items.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/invoice/create/items.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/invoice/create/items.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/invoice/create/items.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/invoice/create/items/renderer/configurable.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/invoice/create/items/renderer/configurable.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/sales/order/invoice/create/items/renderer/configurable.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/invoice/create/items/renderer/configurable.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/invoice/create/items/renderer/configurable.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/invoice/create/items/renderer/configurable.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/invoice/create/items/renderer/default.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/invoice/create/items/renderer/default.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/sales/order/invoice/create/items/renderer/default.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/invoice/create/items/renderer/default.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/invoice/create/items/renderer/default.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/invoice/create/items/renderer/default.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/invoice/create/tracking.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/invoice/create/tracking.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/sales/order/invoice/create/tracking.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/invoice/create/tracking.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/invoice/create/tracking.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/invoice/create/tracking.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/invoice/view/form.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/invoice/view/form.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/sales/order/invoice/view/form.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/invoice/view/form.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/invoice/view/form.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/invoice/view/form.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/invoice/view/items.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/invoice/view/items.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/sales/order/invoice/view/items.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/invoice/view/items.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/invoice/view/items.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/invoice/view/items.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/invoice/view/items/renderer/configurable.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/invoice/view/items/renderer/configurable.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/sales/order/invoice/view/items/renderer/configurable.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/invoice/view/items/renderer/configurable.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/invoice/view/items/renderer/configurable.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/invoice/view/items/renderer/configurable.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/invoice/view/items/renderer/default.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/invoice/view/items/renderer/default.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/sales/order/invoice/view/items/renderer/default.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/invoice/view/items/renderer/default.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/invoice/view/items/renderer/default.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/invoice/view/items/renderer/default.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/shipment/create/form.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/shipment/create/form.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/sales/order/shipment/create/form.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/shipment/create/form.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/shipment/create/form.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/shipment/create/form.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/shipment/create/items.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/shipment/create/items.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/sales/order/shipment/create/items.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/shipment/create/items.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/shipment/create/items.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/shipment/create/items.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/shipment/create/items/renderer/configurable.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/shipment/create/items/renderer/configurable.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/sales/order/shipment/create/items/renderer/configurable.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/shipment/create/items/renderer/configurable.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/shipment/create/items/renderer/configurable.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/shipment/create/items/renderer/configurable.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/shipment/create/items/renderer/default.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/shipment/create/items/renderer/default.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/sales/order/shipment/create/items/renderer/default.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/shipment/create/items/renderer/default.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/shipment/create/items/renderer/default.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/shipment/create/items/renderer/default.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/shipment/create/tracking.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/shipment/create/tracking.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/sales/order/shipment/create/tracking.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/shipment/create/tracking.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/shipment/create/tracking.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/shipment/create/tracking.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/shipment/packaging/grid.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/shipment/packaging/grid.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/sales/order/shipment/packaging/grid.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/shipment/packaging/grid.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/shipment/packaging/grid.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/shipment/packaging/grid.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/shipment/packaging/packed.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/shipment/packaging/packed.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/sales/order/shipment/packaging/packed.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/shipment/packaging/packed.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/shipment/packaging/packed.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/shipment/packaging/packed.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/shipment/packaging/popup.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/shipment/packaging/popup.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/sales/order/shipment/packaging/popup.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/shipment/packaging/popup.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/shipment/packaging/popup.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/shipment/packaging/popup.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/shipment/tracking/info.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/shipment/tracking/info.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/sales/order/shipment/tracking/info.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/shipment/tracking/info.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/shipment/tracking/info.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/shipment/tracking/info.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/shipment/view/form.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/shipment/view/form.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/sales/order/shipment/view/form.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/shipment/view/form.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/shipment/view/form.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/shipment/view/form.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/shipment/view/items.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/shipment/view/items.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/sales/order/shipment/view/items.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/shipment/view/items.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/shipment/view/items.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/shipment/view/items.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/shipment/view/items/renderer/configurable.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/shipment/view/items/renderer/configurable.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/sales/order/shipment/view/items/renderer/configurable.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/shipment/view/items/renderer/configurable.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/shipment/view/items/renderer/configurable.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/shipment/view/items/renderer/configurable.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/shipment/view/items/renderer/default.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/shipment/view/items/renderer/default.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/sales/order/shipment/view/items/renderer/default.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/shipment/view/items/renderer/default.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/shipment/view/items/renderer/default.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/shipment/view/items/renderer/default.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/shipment/view/tracking.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/shipment/view/tracking.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/sales/order/shipment/view/tracking.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/shipment/view/tracking.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/shipment/view/tracking.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/shipment/view/tracking.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/totalbar.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/totalbar.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/sales/order/totalbar.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/totalbar.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/totalbar.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/totalbar.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/totals.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/totals.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/sales/order/totals.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/totals.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/totals.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/totals.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/totals/discount.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/totals/discount.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/sales/order/totals/discount.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/totals/discount.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/totals/discount.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/totals/discount.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/totals/due.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/totals/due.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/sales/order/totals/due.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/totals/due.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/totals/due.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/totals/due.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/totals/footer.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/totals/footer.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/sales/order/totals/footer.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/totals/footer.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/totals/footer.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/totals/footer.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/totals/grand.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/totals/grand.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/sales/order/totals/grand.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/totals/grand.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/totals/grand.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/totals/grand.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/totals/item.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/totals/item.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/sales/order/totals/item.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/totals/item.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/totals/item.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/totals/item.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/totals/main.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/totals/main.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/sales/order/totals/main.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/totals/main.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/totals/main.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/totals/main.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/totals/paid.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/totals/paid.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/sales/order/totals/paid.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/totals/paid.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/totals/paid.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/totals/paid.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/totals/refunded.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/totals/refunded.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/sales/order/totals/refunded.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/totals/refunded.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/totals/refunded.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/totals/refunded.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/totals/shipping.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/totals/shipping.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/sales/order/totals/shipping.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/totals/shipping.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/totals/shipping.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/totals/shipping.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/totals/subtotal.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/totals/subtotal.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/sales/order/totals/subtotal.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/totals/subtotal.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/totals/subtotal.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/totals/subtotal.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/totals/tax.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/totals/tax.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/sales/order/totals/tax.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/totals/tax.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/totals/tax.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/totals/tax.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/view/form.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/view/form.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/sales/order/view/form.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/view/form.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/view/form.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/view/form.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/view/giftmessage.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/view/giftmessage.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/sales/order/view/giftmessage.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/view/giftmessage.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/view/giftmessage.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/view/giftmessage.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/view/history.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/view/history.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/sales/order/view/history.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/view/history.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/view/history.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/view/history.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/view/info.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/view/info.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/sales/order/view/info.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/view/info.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/view/info.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/view/info.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/view/items.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/view/items.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/sales/order/view/items.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/view/items.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/view/items.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/view/items.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/view/items/renderer/default.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/view/items/renderer/default.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/sales/order/view/items/renderer/default.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/view/items/renderer/default.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/view/items/renderer/default.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/view/items/renderer/default.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/view/tab/history.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/view/tab/history.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/sales/order/view/tab/history.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/view/tab/history.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/view/tab/history.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/view/tab/history.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/view/tab/info.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/view/tab/info.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/sales/order/view/tab/info.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/view/tab/info.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/view/tab/info.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/view/tab/info.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/view/tracking.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/view/tracking.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/sales/order/view/tracking.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/view/tracking.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/order/view/tracking.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/view/tracking.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/payment/form/billing/agreement.phtml
+++ b/app/design/adminhtml/default/default/template/sales/payment/form/billing/agreement.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/sales/payment/form/billing/agreement.phtml
+++ b/app/design/adminhtml/default/default/template/sales/payment/form/billing/agreement.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/payment/form/billing/agreement.phtml
+++ b/app/design/adminhtml/default/default/template/sales/payment/form/billing/agreement.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/recurring/profile/view.phtml
+++ b/app/design/adminhtml/default/default/template/sales/recurring/profile/view.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/sales/recurring/profile/view.phtml
+++ b/app/design/adminhtml/default/default/template/sales/recurring/profile/view.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/recurring/profile/view.phtml
+++ b/app/design/adminhtml/default/default/template/sales/recurring/profile/view.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/recurring/profile/view/info.phtml
+++ b/app/design/adminhtml/default/default/template/sales/recurring/profile/view/info.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/sales/recurring/profile/view/info.phtml
+++ b/app/design/adminhtml/default/default/template/sales/recurring/profile/view/info.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/recurring/profile/view/info.phtml
+++ b/app/design/adminhtml/default/default/template/sales/recurring/profile/view/info.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/transactions/detail.phtml
+++ b/app/design/adminhtml/default/default/template/sales/transactions/detail.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/sales/transactions/detail.phtml
+++ b/app/design/adminhtml/default/default/template/sales/transactions/detail.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/sales/transactions/detail.phtml
+++ b/app/design/adminhtml/default/default/template/sales/transactions/detail.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/store/switcher.phtml
+++ b/app/design/adminhtml/default/default/template/store/switcher.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/store/switcher.phtml
+++ b/app/design/adminhtml/default/default/template/store/switcher.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/store/switcher.phtml
+++ b/app/design/adminhtml/default/default/template/store/switcher.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/store/switcher/enhanced.phtml
+++ b/app/design/adminhtml/default/default/template/store/switcher/enhanced.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/store/switcher/enhanced.phtml
+++ b/app/design/adminhtml/default/default/template/store/switcher/enhanced.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/store/switcher/enhanced.phtml
+++ b/app/design/adminhtml/default/default/template/store/switcher/enhanced.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/store/switcher/form/renderer/fieldset.phtml
+++ b/app/design/adminhtml/default/default/template/store/switcher/form/renderer/fieldset.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/store/switcher/form/renderer/fieldset.phtml
+++ b/app/design/adminhtml/default/default/template/store/switcher/form/renderer/fieldset.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/store/switcher/form/renderer/fieldset.phtml
+++ b/app/design/adminhtml/default/default/template/store/switcher/form/renderer/fieldset.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/store/switcher/form/renderer/fieldset/element.phtml
+++ b/app/design/adminhtml/default/default/template/store/switcher/form/renderer/fieldset/element.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/store/switcher/form/renderer/fieldset/element.phtml
+++ b/app/design/adminhtml/default/default/template/store/switcher/form/renderer/fieldset/element.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/store/switcher/form/renderer/fieldset/element.phtml
+++ b/app/design/adminhtml/default/default/template/store/switcher/form/renderer/fieldset/element.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/system/autocomplete.phtml
+++ b/app/design/adminhtml/default/default/template/system/autocomplete.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/system/autocomplete.phtml
+++ b/app/design/adminhtml/default/default/template/system/autocomplete.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/system/autocomplete.phtml
+++ b/app/design/adminhtml/default/default/template/system/autocomplete.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/system/cache/additional.phtml
+++ b/app/design/adminhtml/default/default/template/system/cache/additional.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/system/cache/additional.phtml
+++ b/app/design/adminhtml/default/default/template/system/cache/additional.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/system/cache/additional.phtml
+++ b/app/design/adminhtml/default/default/template/system/cache/additional.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/system/cache/edit.phtml
+++ b/app/design/adminhtml/default/default/template/system/cache/edit.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/system/cache/edit.phtml
+++ b/app/design/adminhtml/default/default/template/system/cache/edit.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/system/cache/edit.phtml
+++ b/app/design/adminhtml/default/default/template/system/cache/edit.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/system/cache/notifications.phtml
+++ b/app/design/adminhtml/default/default/template/system/cache/notifications.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/system/cache/notifications.phtml
+++ b/app/design/adminhtml/default/default/template/system/cache/notifications.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/system/cache/notifications.phtml
+++ b/app/design/adminhtml/default/default/template/system/cache/notifications.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/system/config/edit.phtml
+++ b/app/design/adminhtml/default/default/template/system/config/edit.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/system/config/edit.phtml
+++ b/app/design/adminhtml/default/default/template/system/config/edit.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/system/config/edit.phtml
+++ b/app/design/adminhtml/default/default/template/system/config/edit.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/system/config/form/field/array.phtml
+++ b/app/design/adminhtml/default/default/template/system/config/form/field/array.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/system/config/form/field/array.phtml
+++ b/app/design/adminhtml/default/default/template/system/config/form/field/array.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/system/config/form/field/array.phtml
+++ b/app/design/adminhtml/default/default/template/system/config/form/field/array.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/system/config/js.phtml
+++ b/app/design/adminhtml/default/default/template/system/config/js.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/system/config/js.phtml
+++ b/app/design/adminhtml/default/default/template/system/config/js.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/system/config/js.phtml
+++ b/app/design/adminhtml/default/default/template/system/config/js.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/system/config/switcher.phtml
+++ b/app/design/adminhtml/default/default/template/system/config/switcher.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/system/config/switcher.phtml
+++ b/app/design/adminhtml/default/default/template/system/config/switcher.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/system/config/switcher.phtml
+++ b/app/design/adminhtml/default/default/template/system/config/switcher.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/system/config/system/storage/media/synchronize.phtml
+++ b/app/design/adminhtml/default/default/template/system/config/system/storage/media/synchronize.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/system/config/system/storage/media/synchronize.phtml
+++ b/app/design/adminhtml/default/default/template/system/config/system/storage/media/synchronize.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/system/config/system/storage/media/synchronize.phtml
+++ b/app/design/adminhtml/default/default/template/system/config/system/storage/media/synchronize.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/system/config/tabs.phtml
+++ b/app/design/adminhtml/default/default/template/system/config/tabs.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/system/config/tabs.phtml
+++ b/app/design/adminhtml/default/default/template/system/config/tabs.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/system/config/tabs.phtml
+++ b/app/design/adminhtml/default/default/template/system/config/tabs.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/system/convert/profile/process.phtml
+++ b/app/design/adminhtml/default/default/template/system/convert/profile/process.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/system/convert/profile/process.phtml
+++ b/app/design/adminhtml/default/default/template/system/convert/profile/process.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/system/convert/profile/process.phtml
+++ b/app/design/adminhtml/default/default/template/system/convert/profile/process.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/system/convert/profile/run.phtml
+++ b/app/design/adminhtml/default/default/template/system/convert/profile/run.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/system/convert/profile/run.phtml
+++ b/app/design/adminhtml/default/default/template/system/convert/profile/run.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/system/convert/profile/run.phtml
+++ b/app/design/adminhtml/default/default/template/system/convert/profile/run.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/system/convert/profile/upload.phtml
+++ b/app/design/adminhtml/default/default/template/system/convert/profile/upload.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/system/convert/profile/upload.phtml
+++ b/app/design/adminhtml/default/default/template/system/convert/profile/upload.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/system/convert/profile/upload.phtml
+++ b/app/design/adminhtml/default/default/template/system/convert/profile/upload.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/system/convert/profile/wizard.phtml
+++ b/app/design/adminhtml/default/default/template/system/convert/profile/wizard.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/system/convert/profile/wizard.phtml
+++ b/app/design/adminhtml/default/default/template/system/convert/profile/wizard.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/system/convert/profile/wizard.phtml
+++ b/app/design/adminhtml/default/default/template/system/convert/profile/wizard.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/system/currency/rate/matrix.phtml
+++ b/app/design/adminhtml/default/default/template/system/currency/rate/matrix.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/system/currency/rate/matrix.phtml
+++ b/app/design/adminhtml/default/default/template/system/currency/rate/matrix.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/system/currency/rate/matrix.phtml
+++ b/app/design/adminhtml/default/default/template/system/currency/rate/matrix.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/system/currency/rate/services.phtml
+++ b/app/design/adminhtml/default/default/template/system/currency/rate/services.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/system/currency/rate/services.phtml
+++ b/app/design/adminhtml/default/default/template/system/currency/rate/services.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/system/currency/rate/services.phtml
+++ b/app/design/adminhtml/default/default/template/system/currency/rate/services.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/system/currency/rates.phtml
+++ b/app/design/adminhtml/default/default/template/system/currency/rates.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/system/currency/rates.phtml
+++ b/app/design/adminhtml/default/default/template/system/currency/rates.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/system/currency/rates.phtml
+++ b/app/design/adminhtml/default/default/template/system/currency/rates.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/system/design/edit.phtml
+++ b/app/design/adminhtml/default/default/template/system/design/edit.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/system/design/edit.phtml
+++ b/app/design/adminhtml/default/default/template/system/design/edit.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/system/design/edit.phtml
+++ b/app/design/adminhtml/default/default/template/system/design/edit.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/system/design/index.phtml
+++ b/app/design/adminhtml/default/default/template/system/design/index.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/system/design/index.phtml
+++ b/app/design/adminhtml/default/default/template/system/design/index.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/system/design/index.phtml
+++ b/app/design/adminhtml/default/default/template/system/design/index.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/system/email/template/edit.phtml
+++ b/app/design/adminhtml/default/default/template/system/email/template/edit.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/system/email/template/edit.phtml
+++ b/app/design/adminhtml/default/default/template/system/email/template/edit.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/system/email/template/edit.phtml
+++ b/app/design/adminhtml/default/default/template/system/email/template/edit.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/system/email/template/list.phtml
+++ b/app/design/adminhtml/default/default/template/system/email/template/list.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/system/email/template/list.phtml
+++ b/app/design/adminhtml/default/default/template/system/email/template/list.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/system/email/template/list.phtml
+++ b/app/design/adminhtml/default/default/template/system/email/template/list.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/system/email/template/preview.phtml
+++ b/app/design/adminhtml/default/default/template/system/email/template/preview.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/system/email/template/preview.phtml
+++ b/app/design/adminhtml/default/default/template/system/email/template/preview.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/system/email/template/preview.phtml
+++ b/app/design/adminhtml/default/default/template/system/email/template/preview.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/system/info.phtml
+++ b/app/design/adminhtml/default/default/template/system/info.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/system/info.phtml
+++ b/app/design/adminhtml/default/default/template/system/info.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/system/info.phtml
+++ b/app/design/adminhtml/default/default/template/system/info.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/system/shipping/applicable_country.phtml
+++ b/app/design/adminhtml/default/default/template/system/shipping/applicable_country.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/system/shipping/applicable_country.phtml
+++ b/app/design/adminhtml/default/default/template/system/shipping/applicable_country.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/system/shipping/applicable_country.phtml
+++ b/app/design/adminhtml/default/default/template/system/shipping/applicable_country.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/system/shipping/ups.phtml
+++ b/app/design/adminhtml/default/default/template/system/shipping/ups.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/system/shipping/ups.phtml
+++ b/app/design/adminhtml/default/default/template/system/shipping/ups.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/system/shipping/ups.phtml
+++ b/app/design/adminhtml/default/default/template/system/shipping/ups.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/system/store/cell.phtml
+++ b/app/design/adminhtml/default/default/template/system/store/cell.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/system/store/cell.phtml
+++ b/app/design/adminhtml/default/default/template/system/store/cell.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/system/store/cell.phtml
+++ b/app/design/adminhtml/default/default/template/system/store/cell.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/system/store/container.phtml
+++ b/app/design/adminhtml/default/default/template/system/store/container.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/system/store/container.phtml
+++ b/app/design/adminhtml/default/default/template/system/store/container.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/system/store/container.phtml
+++ b/app/design/adminhtml/default/default/template/system/store/container.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/system/store/tree.phtml
+++ b/app/design/adminhtml/default/default/template/system/store/tree.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/system/store/tree.phtml
+++ b/app/design/adminhtml/default/default/template/system/store/tree.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/system/store/tree.phtml
+++ b/app/design/adminhtml/default/default/template/system/store/tree.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/system/variable/js.phtml
+++ b/app/design/adminhtml/default/default/template/system/variable/js.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/system/variable/js.phtml
+++ b/app/design/adminhtml/default/default/template/system/variable/js.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/system/variable/js.phtml
+++ b/app/design/adminhtml/default/default/template/system/variable/js.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/tag/edit/container.phtml
+++ b/app/design/adminhtml/default/default/template/tag/edit/container.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/tag/edit/container.phtml
+++ b/app/design/adminhtml/default/default/template/tag/edit/container.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/tag/edit/container.phtml
+++ b/app/design/adminhtml/default/default/template/tag/edit/container.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/tag/index.phtml
+++ b/app/design/adminhtml/default/default/template/tag/index.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/tag/index.phtml
+++ b/app/design/adminhtml/default/default/template/tag/index.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/tag/index.phtml
+++ b/app/design/adminhtml/default/default/template/tag/index.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/tax/class/page/edit.phtml
+++ b/app/design/adminhtml/default/default/template/tax/class/page/edit.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/tax/class/page/edit.phtml
+++ b/app/design/adminhtml/default/default/template/tax/class/page/edit.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/tax/class/page/edit.phtml
+++ b/app/design/adminhtml/default/default/template/tax/class/page/edit.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/tax/importExport.phtml
+++ b/app/design/adminhtml/default/default/template/tax/importExport.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/tax/importExport.phtml
+++ b/app/design/adminhtml/default/default/template/tax/importExport.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/tax/importExport.phtml
+++ b/app/design/adminhtml/default/default/template/tax/importExport.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/tax/notifications.phtml
+++ b/app/design/adminhtml/default/default/template/tax/notifications.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/tax/notifications.phtml
+++ b/app/design/adminhtml/default/default/template/tax/notifications.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/tax/notifications.phtml
+++ b/app/design/adminhtml/default/default/template/tax/notifications.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/tax/rate/form.phtml
+++ b/app/design/adminhtml/default/default/template/tax/rate/form.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/tax/rate/form.phtml
+++ b/app/design/adminhtml/default/default/template/tax/rate/form.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/tax/rate/form.phtml
+++ b/app/design/adminhtml/default/default/template/tax/rate/form.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/tax/rate/title.phtml
+++ b/app/design/adminhtml/default/default/template/tax/rate/title.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/tax/rate/title.phtml
+++ b/app/design/adminhtml/default/default/template/tax/rate/title.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/tax/rate/title.phtml
+++ b/app/design/adminhtml/default/default/template/tax/rate/title.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/tax/toolbar/class/add.phtml
+++ b/app/design/adminhtml/default/default/template/tax/toolbar/class/add.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/tax/toolbar/class/add.phtml
+++ b/app/design/adminhtml/default/default/template/tax/toolbar/class/add.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/tax/toolbar/class/add.phtml
+++ b/app/design/adminhtml/default/default/template/tax/toolbar/class/add.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/tax/toolbar/class/save.phtml
+++ b/app/design/adminhtml/default/default/template/tax/toolbar/class/save.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/tax/toolbar/class/save.phtml
+++ b/app/design/adminhtml/default/default/template/tax/toolbar/class/save.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/tax/toolbar/class/save.phtml
+++ b/app/design/adminhtml/default/default/template/tax/toolbar/class/save.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/tax/toolbar/rate/add.phtml
+++ b/app/design/adminhtml/default/default/template/tax/toolbar/rate/add.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/tax/toolbar/rate/add.phtml
+++ b/app/design/adminhtml/default/default/template/tax/toolbar/rate/add.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/tax/toolbar/rate/add.phtml
+++ b/app/design/adminhtml/default/default/template/tax/toolbar/rate/add.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/tax/toolbar/rate/save.phtml
+++ b/app/design/adminhtml/default/default/template/tax/toolbar/rate/save.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/tax/toolbar/rate/save.phtml
+++ b/app/design/adminhtml/default/default/template/tax/toolbar/rate/save.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/tax/toolbar/rate/save.phtml
+++ b/app/design/adminhtml/default/default/template/tax/toolbar/rate/save.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/tax/toolbar/rule/add.phtml
+++ b/app/design/adminhtml/default/default/template/tax/toolbar/rule/add.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/tax/toolbar/rule/add.phtml
+++ b/app/design/adminhtml/default/default/template/tax/toolbar/rule/add.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/tax/toolbar/rule/add.phtml
+++ b/app/design/adminhtml/default/default/template/tax/toolbar/rule/add.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/tax/toolbar/rule/save.phtml
+++ b/app/design/adminhtml/default/default/template/tax/toolbar/rule/save.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/tax/toolbar/rule/save.phtml
+++ b/app/design/adminhtml/default/default/template/tax/toolbar/rule/save.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/tax/toolbar/rule/save.phtml
+++ b/app/design/adminhtml/default/default/template/tax/toolbar/rule/save.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/urlrewrite/categories.phtml
+++ b/app/design/adminhtml/default/default/template/urlrewrite/categories.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/urlrewrite/categories.phtml
+++ b/app/design/adminhtml/default/default/template/urlrewrite/categories.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/urlrewrite/categories.phtml
+++ b/app/design/adminhtml/default/default/template/urlrewrite/categories.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/urlrewrite/edit.phtml
+++ b/app/design/adminhtml/default/default/template/urlrewrite/edit.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/urlrewrite/edit.phtml
+++ b/app/design/adminhtml/default/default/template/urlrewrite/edit.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/urlrewrite/edit.phtml
+++ b/app/design/adminhtml/default/default/template/urlrewrite/edit.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/urlrewrite/selector.phtml
+++ b/app/design/adminhtml/default/default/template/urlrewrite/selector.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/urlrewrite/selector.phtml
+++ b/app/design/adminhtml/default/default/template/urlrewrite/selector.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/urlrewrite/selector.phtml
+++ b/app/design/adminhtml/default/default/template/urlrewrite/selector.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/usa/dhl/unitofmeasure.phtml
+++ b/app/design/adminhtml/default/default/template/usa/dhl/unitofmeasure.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/usa/dhl/unitofmeasure.phtml
+++ b/app/design/adminhtml/default/default/template/usa/dhl/unitofmeasure.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/usa/dhl/unitofmeasure.phtml
+++ b/app/design/adminhtml/default/default/template/usa/dhl/unitofmeasure.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/weee/renderer/tax.phtml
+++ b/app/design/adminhtml/default/default/template/weee/renderer/tax.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/weee/renderer/tax.phtml
+++ b/app/design/adminhtml/default/default/template/weee/renderer/tax.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/weee/renderer/tax.phtml
+++ b/app/design/adminhtml/default/default/template/weee/renderer/tax.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/widget/accordion.phtml
+++ b/app/design/adminhtml/default/default/template/widget/accordion.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/widget/accordion.phtml
+++ b/app/design/adminhtml/default/default/template/widget/accordion.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/widget/accordion.phtml
+++ b/app/design/adminhtml/default/default/template/widget/accordion.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/widget/breadcrumbs.phtml
+++ b/app/design/adminhtml/default/default/template/widget/breadcrumbs.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/widget/breadcrumbs.phtml
+++ b/app/design/adminhtml/default/default/template/widget/breadcrumbs.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/widget/breadcrumbs.phtml
+++ b/app/design/adminhtml/default/default/template/widget/breadcrumbs.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/widget/form.phtml
+++ b/app/design/adminhtml/default/default/template/widget/form.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/widget/form.phtml
+++ b/app/design/adminhtml/default/default/template/widget/form.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/widget/form.phtml
+++ b/app/design/adminhtml/default/default/template/widget/form.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/widget/form/container.phtml
+++ b/app/design/adminhtml/default/default/template/widget/form/container.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/widget/form/container.phtml
+++ b/app/design/adminhtml/default/default/template/widget/form/container.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/widget/form/container.phtml
+++ b/app/design/adminhtml/default/default/template/widget/form/container.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/widget/form/element.phtml
+++ b/app/design/adminhtml/default/default/template/widget/form/element.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/widget/form/element.phtml
+++ b/app/design/adminhtml/default/default/template/widget/form/element.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/widget/form/element.phtml
+++ b/app/design/adminhtml/default/default/template/widget/form/element.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/widget/form/element/gallery.phtml
+++ b/app/design/adminhtml/default/default/template/widget/form/element/gallery.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/widget/form/element/gallery.phtml
+++ b/app/design/adminhtml/default/default/template/widget/form/element/gallery.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/widget/form/element/gallery.phtml
+++ b/app/design/adminhtml/default/default/template/widget/form/element/gallery.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/widget/form/renderer/element.phtml
+++ b/app/design/adminhtml/default/default/template/widget/form/renderer/element.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/widget/form/renderer/element.phtml
+++ b/app/design/adminhtml/default/default/template/widget/form/renderer/element.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/widget/form/renderer/element.phtml
+++ b/app/design/adminhtml/default/default/template/widget/form/renderer/element.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/widget/form/renderer/fieldset.phtml
+++ b/app/design/adminhtml/default/default/template/widget/form/renderer/fieldset.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/widget/form/renderer/fieldset.phtml
+++ b/app/design/adminhtml/default/default/template/widget/form/renderer/fieldset.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/widget/form/renderer/fieldset.phtml
+++ b/app/design/adminhtml/default/default/template/widget/form/renderer/fieldset.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/widget/form/renderer/fieldset/element.phtml
+++ b/app/design/adminhtml/default/default/template/widget/form/renderer/fieldset/element.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/widget/form/renderer/fieldset/element.phtml
+++ b/app/design/adminhtml/default/default/template/widget/form/renderer/fieldset/element.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/widget/form/renderer/fieldset/element.phtml
+++ b/app/design/adminhtml/default/default/template/widget/form/renderer/fieldset/element.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/widget/grid.phtml
+++ b/app/design/adminhtml/default/default/template/widget/grid.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/widget/grid.phtml
+++ b/app/design/adminhtml/default/default/template/widget/grid.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/widget/grid.phtml
+++ b/app/design/adminhtml/default/default/template/widget/grid.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/widget/grid/container.phtml
+++ b/app/design/adminhtml/default/default/template/widget/grid/container.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/widget/grid/container.phtml
+++ b/app/design/adminhtml/default/default/template/widget/grid/container.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/widget/grid/container.phtml
+++ b/app/design/adminhtml/default/default/template/widget/grid/container.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/widget/grid/massaction.phtml
+++ b/app/design/adminhtml/default/default/template/widget/grid/massaction.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/widget/grid/massaction.phtml
+++ b/app/design/adminhtml/default/default/template/widget/grid/massaction.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/widget/grid/massaction.phtml
+++ b/app/design/adminhtml/default/default/template/widget/grid/massaction.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/widget/grid/serializer.phtml
+++ b/app/design/adminhtml/default/default/template/widget/grid/serializer.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/widget/grid/serializer.phtml
+++ b/app/design/adminhtml/default/default/template/widget/grid/serializer.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/widget/grid/serializer.phtml
+++ b/app/design/adminhtml/default/default/template/widget/grid/serializer.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/widget/instance/edit/layout.phtml
+++ b/app/design/adminhtml/default/default/template/widget/instance/edit/layout.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/widget/instance/edit/layout.phtml
+++ b/app/design/adminhtml/default/default/template/widget/instance/edit/layout.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/widget/instance/edit/layout.phtml
+++ b/app/design/adminhtml/default/default/template/widget/instance/edit/layout.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/widget/instance/js.phtml
+++ b/app/design/adminhtml/default/default/template/widget/instance/js.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/widget/instance/js.phtml
+++ b/app/design/adminhtml/default/default/template/widget/instance/js.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/widget/instance/js.phtml
+++ b/app/design/adminhtml/default/default/template/widget/instance/js.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/widget/tabs.phtml
+++ b/app/design/adminhtml/default/default/template/widget/tabs.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/widget/tabs.phtml
+++ b/app/design/adminhtml/default/default/template/widget/tabs.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/widget/tabs.phtml
+++ b/app/design/adminhtml/default/default/template/widget/tabs.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/widget/tabshoriz.phtml
+++ b/app/design/adminhtml/default/default/template/widget/tabshoriz.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/widget/tabshoriz.phtml
+++ b/app/design/adminhtml/default/default/template/widget/tabshoriz.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/widget/tabshoriz.phtml
+++ b/app/design/adminhtml/default/default/template/widget/tabshoriz.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/widget/tabsleft.phtml
+++ b/app/design/adminhtml/default/default/template/widget/tabsleft.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/widget/tabsleft.phtml
+++ b/app/design/adminhtml/default/default/template/widget/tabsleft.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/widget/tabsleft.phtml
+++ b/app/design/adminhtml/default/default/template/widget/tabsleft.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/widget/view/container.phtml
+++ b/app/design/adminhtml/default/default/template/widget/view/container.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/default/template/widget/view/container.phtml
+++ b/app/design/adminhtml/default/default/template/widget/view/container.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/default/template/widget/view/container.phtml
+++ b/app/design/adminhtml/default/default/template/widget/view/container.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/openmage/template/forgotpassword.phtml
+++ b/app/design/adminhtml/default/openmage/template/forgotpassword.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/openmage/template/forgotpassword.phtml
+++ b/app/design/adminhtml/default/openmage/template/forgotpassword.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/openmage/template/forgotpassword.phtml
+++ b/app/design/adminhtml/default/openmage/template/forgotpassword.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/openmage/template/login.phtml
+++ b/app/design/adminhtml/default/openmage/template/login.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/openmage/template/login.phtml
+++ b/app/design/adminhtml/default/openmage/template/login.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/openmage/template/login.phtml
+++ b/app/design/adminhtml/default/openmage/template/login.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/openmage/template/page/header.phtml
+++ b/app/design/adminhtml/default/openmage/template/page/header.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/openmage/template/page/header.phtml
+++ b/app/design/adminhtml/default/openmage/template/page/header.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/openmage/template/page/header.phtml
+++ b/app/design/adminhtml/default/openmage/template/page/header.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/openmage/template/resetforgottenpassword.phtml
+++ b/app/design/adminhtml/default/openmage/template/resetforgottenpassword.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/adminhtml/default/openmage/template/resetforgottenpassword.phtml
+++ b/app/design/adminhtml/default/openmage/template/resetforgottenpassword.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/adminhtml/default/openmage/template/resetforgottenpassword.phtml
+++ b/app/design/adminhtml/default/openmage/template/resetforgottenpassword.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/frontend/base/default/etc/theme.xml
+++ b/app/design/frontend/base/default/etc/theme.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/etc/theme.xml
+++ b/app/design/frontend/base/default/etc/theme.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/etc/theme.xml
+++ b/app/design/frontend/base/default/etc/theme.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/etc/widget.xml
+++ b/app/design/frontend/base/default/etc/widget.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/etc/widget.xml
+++ b/app/design/frontend/base/default/etc/widget.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/etc/widget.xml
+++ b/app/design/frontend/base/default/etc/widget.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/layout/authorizenet.xml
+++ b/app/design/frontend/base/default/layout/authorizenet.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/layout/authorizenet.xml
+++ b/app/design/frontend/base/default/layout/authorizenet.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/layout/authorizenet.xml
+++ b/app/design/frontend/base/default/layout/authorizenet.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/layout/bml.xml
+++ b/app/design/frontend/base/default/layout/bml.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/layout/bml.xml
+++ b/app/design/frontend/base/default/layout/bml.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/layout/bml.xml
+++ b/app/design/frontend/base/default/layout/bml.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/layout/bundle.xml
+++ b/app/design/frontend/base/default/layout/bundle.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/layout/bundle.xml
+++ b/app/design/frontend/base/default/layout/bundle.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/layout/bundle.xml
+++ b/app/design/frontend/base/default/layout/bundle.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/layout/captcha.xml
+++ b/app/design/frontend/base/default/layout/captcha.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/layout/captcha.xml
+++ b/app/design/frontend/base/default/layout/captcha.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/layout/captcha.xml
+++ b/app/design/frontend/base/default/layout/captcha.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/layout/catalog.xml
+++ b/app/design/frontend/base/default/layout/catalog.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/layout/catalog.xml
+++ b/app/design/frontend/base/default/layout/catalog.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/layout/catalog.xml
+++ b/app/design/frontend/base/default/layout/catalog.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/layout/catalog_msrp.xml
+++ b/app/design/frontend/base/default/layout/catalog_msrp.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/layout/catalog_msrp.xml
+++ b/app/design/frontend/base/default/layout/catalog_msrp.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/layout/catalog_msrp.xml
+++ b/app/design/frontend/base/default/layout/catalog_msrp.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/layout/cataloginventory.xml
+++ b/app/design/frontend/base/default/layout/cataloginventory.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/layout/cataloginventory.xml
+++ b/app/design/frontend/base/default/layout/cataloginventory.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/layout/cataloginventory.xml
+++ b/app/design/frontend/base/default/layout/cataloginventory.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/layout/catalogsearch.xml
+++ b/app/design/frontend/base/default/layout/catalogsearch.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/layout/catalogsearch.xml
+++ b/app/design/frontend/base/default/layout/catalogsearch.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/layout/catalogsearch.xml
+++ b/app/design/frontend/base/default/layout/catalogsearch.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/layout/centinel.xml
+++ b/app/design/frontend/base/default/layout/centinel.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/layout/centinel.xml
+++ b/app/design/frontend/base/default/layout/centinel.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/layout/centinel.xml
+++ b/app/design/frontend/base/default/layout/centinel.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/layout/checkout.xml
+++ b/app/design/frontend/base/default/layout/checkout.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/layout/checkout.xml
+++ b/app/design/frontend/base/default/layout/checkout.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/layout/checkout.xml
+++ b/app/design/frontend/base/default/layout/checkout.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/layout/cms.xml
+++ b/app/design/frontend/base/default/layout/cms.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/layout/cms.xml
+++ b/app/design/frontend/base/default/layout/cms.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/layout/cms.xml
+++ b/app/design/frontend/base/default/layout/cms.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/layout/contacts.xml
+++ b/app/design/frontend/base/default/layout/contacts.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/layout/contacts.xml
+++ b/app/design/frontend/base/default/layout/contacts.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/layout/contacts.xml
+++ b/app/design/frontend/base/default/layout/contacts.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/layout/core.xml
+++ b/app/design/frontend/base/default/layout/core.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/layout/core.xml
+++ b/app/design/frontend/base/default/layout/core.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/layout/core.xml
+++ b/app/design/frontend/base/default/layout/core.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/layout/customer.xml
+++ b/app/design/frontend/base/default/layout/customer.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/layout/customer.xml
+++ b/app/design/frontend/base/default/layout/customer.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/layout/customer.xml
+++ b/app/design/frontend/base/default/layout/customer.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/layout/directory.xml
+++ b/app/design/frontend/base/default/layout/directory.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/layout/directory.xml
+++ b/app/design/frontend/base/default/layout/directory.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/layout/directory.xml
+++ b/app/design/frontend/base/default/layout/directory.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/layout/downloadable.xml
+++ b/app/design/frontend/base/default/layout/downloadable.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/layout/downloadable.xml
+++ b/app/design/frontend/base/default/layout/downloadable.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/layout/downloadable.xml
+++ b/app/design/frontend/base/default/layout/downloadable.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/layout/googleanalytics.xml
+++ b/app/design/frontend/base/default/layout/googleanalytics.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/layout/googleanalytics.xml
+++ b/app/design/frontend/base/default/layout/googleanalytics.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/layout/googleanalytics.xml
+++ b/app/design/frontend/base/default/layout/googleanalytics.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/layout/newsletter.xml
+++ b/app/design/frontend/base/default/layout/newsletter.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/layout/newsletter.xml
+++ b/app/design/frontend/base/default/layout/newsletter.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/layout/newsletter.xml
+++ b/app/design/frontend/base/default/layout/newsletter.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/layout/oauth.xml
+++ b/app/design/frontend/base/default/layout/oauth.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/layout/oauth.xml
+++ b/app/design/frontend/base/default/layout/oauth.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/layout/oauth.xml
+++ b/app/design/frontend/base/default/layout/oauth.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/layout/page.xml
+++ b/app/design/frontend/base/default/layout/page.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/layout/page.xml
+++ b/app/design/frontend/base/default/layout/page.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/layout/page.xml
+++ b/app/design/frontend/base/default/layout/page.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/layout/payment.xml
+++ b/app/design/frontend/base/default/layout/payment.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/layout/payment.xml
+++ b/app/design/frontend/base/default/layout/payment.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/layout/payment.xml
+++ b/app/design/frontend/base/default/layout/payment.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/layout/paypal.xml
+++ b/app/design/frontend/base/default/layout/paypal.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/layout/paypal.xml
+++ b/app/design/frontend/base/default/layout/paypal.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/layout/paypal.xml
+++ b/app/design/frontend/base/default/layout/paypal.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/layout/paypaluk.xml
+++ b/app/design/frontend/base/default/layout/paypaluk.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/layout/paypaluk.xml
+++ b/app/design/frontend/base/default/layout/paypaluk.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/layout/paypaluk.xml
+++ b/app/design/frontend/base/default/layout/paypaluk.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/layout/persistent.xml
+++ b/app/design/frontend/base/default/layout/persistent.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/layout/persistent.xml
+++ b/app/design/frontend/base/default/layout/persistent.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/layout/persistent.xml
+++ b/app/design/frontend/base/default/layout/persistent.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/layout/poll.xml
+++ b/app/design/frontend/base/default/layout/poll.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/layout/poll.xml
+++ b/app/design/frontend/base/default/layout/poll.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/layout/poll.xml
+++ b/app/design/frontend/base/default/layout/poll.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/layout/productalert.xml
+++ b/app/design/frontend/base/default/layout/productalert.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/layout/productalert.xml
+++ b/app/design/frontend/base/default/layout/productalert.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/layout/productalert.xml
+++ b/app/design/frontend/base/default/layout/productalert.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/layout/reports.xml
+++ b/app/design/frontend/base/default/layout/reports.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/layout/reports.xml
+++ b/app/design/frontend/base/default/layout/reports.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/layout/reports.xml
+++ b/app/design/frontend/base/default/layout/reports.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/layout/review.xml
+++ b/app/design/frontend/base/default/layout/review.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/layout/review.xml
+++ b/app/design/frontend/base/default/layout/review.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/layout/review.xml
+++ b/app/design/frontend/base/default/layout/review.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/layout/rss.xml
+++ b/app/design/frontend/base/default/layout/rss.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/layout/rss.xml
+++ b/app/design/frontend/base/default/layout/rss.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/layout/rss.xml
+++ b/app/design/frontend/base/default/layout/rss.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/layout/sales.xml
+++ b/app/design/frontend/base/default/layout/sales.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/layout/sales.xml
+++ b/app/design/frontend/base/default/layout/sales.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/layout/sales.xml
+++ b/app/design/frontend/base/default/layout/sales.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/layout/sales/billing_agreement.xml
+++ b/app/design/frontend/base/default/layout/sales/billing_agreement.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/layout/sales/billing_agreement.xml
+++ b/app/design/frontend/base/default/layout/sales/billing_agreement.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/layout/sales/billing_agreement.xml
+++ b/app/design/frontend/base/default/layout/sales/billing_agreement.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/layout/sales/recurring_profile.xml
+++ b/app/design/frontend/base/default/layout/sales/recurring_profile.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/layout/sales/recurring_profile.xml
+++ b/app/design/frontend/base/default/layout/sales/recurring_profile.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/layout/sales/recurring_profile.xml
+++ b/app/design/frontend/base/default/layout/sales/recurring_profile.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/layout/sendfriend.xml
+++ b/app/design/frontend/base/default/layout/sendfriend.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/layout/sendfriend.xml
+++ b/app/design/frontend/base/default/layout/sendfriend.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/layout/sendfriend.xml
+++ b/app/design/frontend/base/default/layout/sendfriend.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/layout/shipping.xml
+++ b/app/design/frontend/base/default/layout/shipping.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/layout/shipping.xml
+++ b/app/design/frontend/base/default/layout/shipping.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/layout/shipping.xml
+++ b/app/design/frontend/base/default/layout/shipping.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/layout/tag.xml
+++ b/app/design/frontend/base/default/layout/tag.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/layout/tag.xml
+++ b/app/design/frontend/base/default/layout/tag.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/layout/tag.xml
+++ b/app/design/frontend/base/default/layout/tag.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/layout/weee.xml
+++ b/app/design/frontend/base/default/layout/weee.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/layout/weee.xml
+++ b/app/design/frontend/base/default/layout/weee.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/layout/weee.xml
+++ b/app/design/frontend/base/default/layout/weee.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/layout/wishlist.xml
+++ b/app/design/frontend/base/default/layout/wishlist.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/layout/wishlist.xml
+++ b/app/design/frontend/base/default/layout/wishlist.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/layout/wishlist.xml
+++ b/app/design/frontend/base/default/layout/wishlist.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/authorizenet/directpost/form.phtml
+++ b/app/design/frontend/base/default/template/authorizenet/directpost/form.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/authorizenet/directpost/form.phtml
+++ b/app/design/frontend/base/default/template/authorizenet/directpost/form.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/authorizenet/directpost/form.phtml
+++ b/app/design/frontend/base/default/template/authorizenet/directpost/form.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/authorizenet/directpost/iframe.phtml
+++ b/app/design/frontend/base/default/template/authorizenet/directpost/iframe.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/authorizenet/directpost/iframe.phtml
+++ b/app/design/frontend/base/default/template/authorizenet/directpost/iframe.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/authorizenet/directpost/iframe.phtml
+++ b/app/design/frontend/base/default/template/authorizenet/directpost/iframe.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/authorizenet/directpost/info.phtml
+++ b/app/design/frontend/base/default/template/authorizenet/directpost/info.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/authorizenet/directpost/info.phtml
+++ b/app/design/frontend/base/default/template/authorizenet/directpost/info.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/authorizenet/directpost/info.phtml
+++ b/app/design/frontend/base/default/template/authorizenet/directpost/info.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/bundle/catalog/product/list/partof.phtml
+++ b/app/design/frontend/base/default/template/bundle/catalog/product/list/partof.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/bundle/catalog/product/list/partof.phtml
+++ b/app/design/frontend/base/default/template/bundle/catalog/product/list/partof.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/bundle/catalog/product/list/partof.phtml
+++ b/app/design/frontend/base/default/template/bundle/catalog/product/list/partof.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/bundle/catalog/product/price.phtml
+++ b/app/design/frontend/base/default/template/bundle/catalog/product/price.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/bundle/catalog/product/price.phtml
+++ b/app/design/frontend/base/default/template/bundle/catalog/product/price.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/bundle/catalog/product/price.phtml
+++ b/app/design/frontend/base/default/template/bundle/catalog/product/price.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/bundle/catalog/product/view/option_tierprices.phtml
+++ b/app/design/frontend/base/default/template/bundle/catalog/product/view/option_tierprices.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/bundle/catalog/product/view/option_tierprices.phtml
+++ b/app/design/frontend/base/default/template/bundle/catalog/product/view/option_tierprices.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/bundle/catalog/product/view/option_tierprices.phtml
+++ b/app/design/frontend/base/default/template/bundle/catalog/product/view/option_tierprices.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/bundle/catalog/product/view/options/notice.phtml
+++ b/app/design/frontend/base/default/template/bundle/catalog/product/view/options/notice.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/bundle/catalog/product/view/options/notice.phtml
+++ b/app/design/frontend/base/default/template/bundle/catalog/product/view/options/notice.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/bundle/catalog/product/view/options/notice.phtml
+++ b/app/design/frontend/base/default/template/bundle/catalog/product/view/options/notice.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/bundle/catalog/product/view/price.phtml
+++ b/app/design/frontend/base/default/template/bundle/catalog/product/view/price.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/bundle/catalog/product/view/price.phtml
+++ b/app/design/frontend/base/default/template/bundle/catalog/product/view/price.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/bundle/catalog/product/view/price.phtml
+++ b/app/design/frontend/base/default/template/bundle/catalog/product/view/price.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/bundle/catalog/product/view/tierprices.phtml
+++ b/app/design/frontend/base/default/template/bundle/catalog/product/view/tierprices.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/bundle/catalog/product/view/tierprices.phtml
+++ b/app/design/frontend/base/default/template/bundle/catalog/product/view/tierprices.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/bundle/catalog/product/view/tierprices.phtml
+++ b/app/design/frontend/base/default/template/bundle/catalog/product/view/tierprices.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/bundle/catalog/product/view/type/bundle.phtml
+++ b/app/design/frontend/base/default/template/bundle/catalog/product/view/type/bundle.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/bundle/catalog/product/view/type/bundle.phtml
+++ b/app/design/frontend/base/default/template/bundle/catalog/product/view/type/bundle.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/bundle/catalog/product/view/type/bundle.phtml
+++ b/app/design/frontend/base/default/template/bundle/catalog/product/view/type/bundle.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/bundle/catalog/product/view/type/bundle/option/checkbox.phtml
+++ b/app/design/frontend/base/default/template/bundle/catalog/product/view/type/bundle/option/checkbox.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/bundle/catalog/product/view/type/bundle/option/checkbox.phtml
+++ b/app/design/frontend/base/default/template/bundle/catalog/product/view/type/bundle/option/checkbox.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/bundle/catalog/product/view/type/bundle/option/checkbox.phtml
+++ b/app/design/frontend/base/default/template/bundle/catalog/product/view/type/bundle/option/checkbox.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/bundle/catalog/product/view/type/bundle/option/multi.phtml
+++ b/app/design/frontend/base/default/template/bundle/catalog/product/view/type/bundle/option/multi.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/bundle/catalog/product/view/type/bundle/option/multi.phtml
+++ b/app/design/frontend/base/default/template/bundle/catalog/product/view/type/bundle/option/multi.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/bundle/catalog/product/view/type/bundle/option/multi.phtml
+++ b/app/design/frontend/base/default/template/bundle/catalog/product/view/type/bundle/option/multi.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/bundle/catalog/product/view/type/bundle/option/radio.phtml
+++ b/app/design/frontend/base/default/template/bundle/catalog/product/view/type/bundle/option/radio.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/bundle/catalog/product/view/type/bundle/option/radio.phtml
+++ b/app/design/frontend/base/default/template/bundle/catalog/product/view/type/bundle/option/radio.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/bundle/catalog/product/view/type/bundle/option/radio.phtml
+++ b/app/design/frontend/base/default/template/bundle/catalog/product/view/type/bundle/option/radio.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/bundle/catalog/product/view/type/bundle/option/select.phtml
+++ b/app/design/frontend/base/default/template/bundle/catalog/product/view/type/bundle/option/select.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/bundle/catalog/product/view/type/bundle/option/select.phtml
+++ b/app/design/frontend/base/default/template/bundle/catalog/product/view/type/bundle/option/select.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/bundle/catalog/product/view/type/bundle/option/select.phtml
+++ b/app/design/frontend/base/default/template/bundle/catalog/product/view/type/bundle/option/select.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/bundle/catalog/product/view/type/bundle/options.phtml
+++ b/app/design/frontend/base/default/template/bundle/catalog/product/view/type/bundle/options.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/bundle/catalog/product/view/type/bundle/options.phtml
+++ b/app/design/frontend/base/default/template/bundle/catalog/product/view/type/bundle/options.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/bundle/catalog/product/view/type/bundle/options.phtml
+++ b/app/design/frontend/base/default/template/bundle/catalog/product/view/type/bundle/options.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/bundle/email/order/items/creditmemo/default.phtml
+++ b/app/design/frontend/base/default/template/bundle/email/order/items/creditmemo/default.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/bundle/email/order/items/creditmemo/default.phtml
+++ b/app/design/frontend/base/default/template/bundle/email/order/items/creditmemo/default.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/bundle/email/order/items/creditmemo/default.phtml
+++ b/app/design/frontend/base/default/template/bundle/email/order/items/creditmemo/default.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/bundle/email/order/items/invoice/default.phtml
+++ b/app/design/frontend/base/default/template/bundle/email/order/items/invoice/default.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/bundle/email/order/items/invoice/default.phtml
+++ b/app/design/frontend/base/default/template/bundle/email/order/items/invoice/default.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/bundle/email/order/items/invoice/default.phtml
+++ b/app/design/frontend/base/default/template/bundle/email/order/items/invoice/default.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/bundle/email/order/items/order/default.phtml
+++ b/app/design/frontend/base/default/template/bundle/email/order/items/order/default.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/bundle/email/order/items/order/default.phtml
+++ b/app/design/frontend/base/default/template/bundle/email/order/items/order/default.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/bundle/email/order/items/order/default.phtml
+++ b/app/design/frontend/base/default/template/bundle/email/order/items/order/default.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/bundle/email/order/items/shipment/default.phtml
+++ b/app/design/frontend/base/default/template/bundle/email/order/items/shipment/default.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/bundle/email/order/items/shipment/default.phtml
+++ b/app/design/frontend/base/default/template/bundle/email/order/items/shipment/default.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/bundle/email/order/items/shipment/default.phtml
+++ b/app/design/frontend/base/default/template/bundle/email/order/items/shipment/default.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/bundle/rss/catalog/product/price.phtml
+++ b/app/design/frontend/base/default/template/bundle/rss/catalog/product/price.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/bundle/rss/catalog/product/price.phtml
+++ b/app/design/frontend/base/default/template/bundle/rss/catalog/product/price.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/bundle/rss/catalog/product/price.phtml
+++ b/app/design/frontend/base/default/template/bundle/rss/catalog/product/price.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/bundle/sales/order/creditmemo/items/renderer.phtml
+++ b/app/design/frontend/base/default/template/bundle/sales/order/creditmemo/items/renderer.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/bundle/sales/order/creditmemo/items/renderer.phtml
+++ b/app/design/frontend/base/default/template/bundle/sales/order/creditmemo/items/renderer.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/bundle/sales/order/creditmemo/items/renderer.phtml
+++ b/app/design/frontend/base/default/template/bundle/sales/order/creditmemo/items/renderer.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/bundle/sales/order/invoice/items/renderer.phtml
+++ b/app/design/frontend/base/default/template/bundle/sales/order/invoice/items/renderer.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/bundle/sales/order/invoice/items/renderer.phtml
+++ b/app/design/frontend/base/default/template/bundle/sales/order/invoice/items/renderer.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/bundle/sales/order/invoice/items/renderer.phtml
+++ b/app/design/frontend/base/default/template/bundle/sales/order/invoice/items/renderer.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/bundle/sales/order/items/renderer.phtml
+++ b/app/design/frontend/base/default/template/bundle/sales/order/items/renderer.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/bundle/sales/order/items/renderer.phtml
+++ b/app/design/frontend/base/default/template/bundle/sales/order/items/renderer.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/bundle/sales/order/items/renderer.phtml
+++ b/app/design/frontend/base/default/template/bundle/sales/order/items/renderer.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/bundle/sales/order/shipment/items/renderer.phtml
+++ b/app/design/frontend/base/default/template/bundle/sales/order/shipment/items/renderer.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/bundle/sales/order/shipment/items/renderer.phtml
+++ b/app/design/frontend/base/default/template/bundle/sales/order/shipment/items/renderer.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/bundle/sales/order/shipment/items/renderer.phtml
+++ b/app/design/frontend/base/default/template/bundle/sales/order/shipment/items/renderer.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/callouts/left_col.phtml
+++ b/app/design/frontend/base/default/template/callouts/left_col.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/callouts/left_col.phtml
+++ b/app/design/frontend/base/default/template/callouts/left_col.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/callouts/left_col.phtml
+++ b/app/design/frontend/base/default/template/callouts/left_col.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/callouts/right_col.phtml
+++ b/app/design/frontend/base/default/template/callouts/right_col.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/callouts/right_col.phtml
+++ b/app/design/frontend/base/default/template/callouts/right_col.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/callouts/right_col.phtml
+++ b/app/design/frontend/base/default/template/callouts/right_col.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/captcha/zend.phtml
+++ b/app/design/frontend/base/default/template/captcha/zend.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/captcha/zend.phtml
+++ b/app/design/frontend/base/default/template/captcha/zend.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/captcha/zend.phtml
+++ b/app/design/frontend/base/default/template/captcha/zend.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/category/page.phtml
+++ b/app/design/frontend/base/default/template/catalog/category/page.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/catalog/category/page.phtml
+++ b/app/design/frontend/base/default/template/catalog/category/page.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/category/page.phtml
+++ b/app/design/frontend/base/default/template/catalog/category/page.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/category/view.phtml
+++ b/app/design/frontend/base/default/template/catalog/category/view.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/catalog/category/view.phtml
+++ b/app/design/frontend/base/default/template/catalog/category/view.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/category/view.phtml
+++ b/app/design/frontend/base/default/template/catalog/category/view.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/category/widget/link/link_block.phtml
+++ b/app/design/frontend/base/default/template/catalog/category/widget/link/link_block.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/catalog/category/widget/link/link_block.phtml
+++ b/app/design/frontend/base/default/template/catalog/category/widget/link/link_block.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/category/widget/link/link_block.phtml
+++ b/app/design/frontend/base/default/template/catalog/category/widget/link/link_block.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/category/widget/link/link_inline.phtml
+++ b/app/design/frontend/base/default/template/catalog/category/widget/link/link_inline.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/catalog/category/widget/link/link_inline.phtml
+++ b/app/design/frontend/base/default/template/catalog/category/widget/link/link_inline.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/category/widget/link/link_inline.phtml
+++ b/app/design/frontend/base/default/template/catalog/category/widget/link/link_inline.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/layer/filter.phtml
+++ b/app/design/frontend/base/default/template/catalog/layer/filter.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/catalog/layer/filter.phtml
+++ b/app/design/frontend/base/default/template/catalog/layer/filter.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/layer/filter.phtml
+++ b/app/design/frontend/base/default/template/catalog/layer/filter.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/layer/state.phtml
+++ b/app/design/frontend/base/default/template/catalog/layer/state.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/catalog/layer/state.phtml
+++ b/app/design/frontend/base/default/template/catalog/layer/state.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/layer/state.phtml
+++ b/app/design/frontend/base/default/template/catalog/layer/state.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/layer/view.phtml
+++ b/app/design/frontend/base/default/template/catalog/layer/view.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/catalog/layer/view.phtml
+++ b/app/design/frontend/base/default/template/catalog/layer/view.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/layer/view.phtml
+++ b/app/design/frontend/base/default/template/catalog/layer/view.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/msrp/popup.phtml
+++ b/app/design/frontend/base/default/template/catalog/msrp/popup.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/catalog/msrp/popup.phtml
+++ b/app/design/frontend/base/default/template/catalog/msrp/popup.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/msrp/popup.phtml
+++ b/app/design/frontend/base/default/template/catalog/msrp/popup.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/navigation/left.phtml
+++ b/app/design/frontend/base/default/template/catalog/navigation/left.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/catalog/navigation/left.phtml
+++ b/app/design/frontend/base/default/template/catalog/navigation/left.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/navigation/left.phtml
+++ b/app/design/frontend/base/default/template/catalog/navigation/left.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/navigation/top.phtml
+++ b/app/design/frontend/base/default/template/catalog/navigation/top.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/catalog/navigation/top.phtml
+++ b/app/design/frontend/base/default/template/catalog/navigation/top.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/navigation/top.phtml
+++ b/app/design/frontend/base/default/template/catalog/navigation/top.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/product/compare/list.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/compare/list.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/catalog/product/compare/list.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/compare/list.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/product/compare/list.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/compare/list.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/product/compare/sidebar.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/compare/sidebar.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/catalog/product/compare/sidebar.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/compare/sidebar.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/product/compare/sidebar.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/compare/sidebar.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/product/gallery.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/gallery.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/catalog/product/gallery.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/gallery.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/product/gallery.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/gallery.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/product/list.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/list.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/catalog/product/list.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/list.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/product/list.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/list.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/product/list/related.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/list/related.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/catalog/product/list/related.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/list/related.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/product/list/related.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/list/related.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/product/list/toolbar.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/list/toolbar.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/catalog/product/list/toolbar.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/list/toolbar.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/product/list/toolbar.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/list/toolbar.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/product/list/upsell.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/list/upsell.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/catalog/product/list/upsell.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/list/upsell.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/product/list/upsell.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/list/upsell.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/product/new.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/new.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/catalog/product/new.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/new.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/product/new.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/new.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/product/price.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/price.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/catalog/product/price.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/price.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/product/price.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/price.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/product/price_msrp.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/price_msrp.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/catalog/product/price_msrp.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/price_msrp.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/product/price_msrp.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/price_msrp.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/product/price_msrp_item.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/price_msrp_item.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/catalog/product/price_msrp_item.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/price_msrp_item.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/product/price_msrp_item.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/price_msrp_item.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/product/price_msrp_noform.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/price_msrp_noform.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/catalog/product/price_msrp_noform.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/price_msrp_noform.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/product/price_msrp_noform.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/price_msrp_noform.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/product/price_msrp_rss.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/price_msrp_rss.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/catalog/product/price_msrp_rss.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/price_msrp_rss.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/product/price_msrp_rss.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/price_msrp_rss.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/product/view.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/view.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/catalog/product/view.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/view.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/product/view.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/view.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/product/view/additional.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/view/additional.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/catalog/product/view/additional.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/view/additional.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/product/view/additional.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/view/additional.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/product/view/addto.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/view/addto.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/catalog/product/view/addto.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/view/addto.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/product/view/addto.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/view/addto.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/product/view/addtocart.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/view/addtocart.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/catalog/product/view/addtocart.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/view/addtocart.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/product/view/addtocart.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/view/addtocart.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/product/view/attributes.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/view/attributes.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/catalog/product/view/attributes.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/view/attributes.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/product/view/attributes.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/view/attributes.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/product/view/description.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/view/description.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/catalog/product/view/description.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/view/description.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/product/view/description.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/view/description.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/product/view/media.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/view/media.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/catalog/product/view/media.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/view/media.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/product/view/media.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/view/media.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/product/view/options.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/view/options.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/catalog/product/view/options.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/view/options.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/product/view/options.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/view/options.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/product/view/options/js.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/view/options/js.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/catalog/product/view/options/js.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/view/options/js.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/product/view/options/js.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/view/options/js.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/product/view/options/type/date.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/view/options/type/date.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/catalog/product/view/options/type/date.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/view/options/type/date.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/product/view/options/type/date.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/view/options/type/date.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/product/view/options/type/default.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/view/options/type/default.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/catalog/product/view/options/type/default.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/view/options/type/default.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/product/view/options/type/default.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/view/options/type/default.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/product/view/options/type/file.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/view/options/type/file.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/catalog/product/view/options/type/file.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/view/options/type/file.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/product/view/options/type/file.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/view/options/type/file.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/product/view/options/type/select.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/view/options/type/select.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/catalog/product/view/options/type/select.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/view/options/type/select.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/product/view/options/type/select.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/view/options/type/select.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/product/view/options/type/text.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/view/options/type/text.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/catalog/product/view/options/type/text.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/view/options/type/text.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/product/view/options/type/text.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/view/options/type/text.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/product/view/options/wrapper.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/view/options/wrapper.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/catalog/product/view/options/wrapper.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/view/options/wrapper.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/product/view/options/wrapper.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/view/options/wrapper.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/product/view/options/wrapper/bottom.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/view/options/wrapper/bottom.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/catalog/product/view/options/wrapper/bottom.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/view/options/wrapper/bottom.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/product/view/options/wrapper/bottom.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/view/options/wrapper/bottom.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/product/view/price.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/view/price.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/catalog/product/view/price.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/view/price.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/product/view/price.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/view/price.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/product/view/price_clone.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/view/price_clone.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/catalog/product/view/price_clone.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/view/price_clone.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/product/view/price_clone.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/view/price_clone.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/product/view/tierprices.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/view/tierprices.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/catalog/product/view/tierprices.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/view/tierprices.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/product/view/tierprices.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/view/tierprices.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/product/view/type/configurable.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/view/type/configurable.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/catalog/product/view/type/configurable.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/view/type/configurable.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/product/view/type/configurable.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/view/type/configurable.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/product/view/type/default.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/view/type/default.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/catalog/product/view/type/default.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/view/type/default.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/product/view/type/default.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/view/type/default.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/product/view/type/grouped.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/view/type/grouped.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/catalog/product/view/type/grouped.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/view/type/grouped.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/product/view/type/grouped.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/view/type/grouped.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/product/view/type/options/configurable.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/view/type/options/configurable.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/catalog/product/view/type/options/configurable.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/view/type/options/configurable.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/product/view/type/options/configurable.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/view/type/options/configurable.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/product/view/type/simple.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/view/type/simple.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/catalog/product/view/type/simple.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/view/type/simple.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/product/view/type/simple.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/view/type/simple.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/product/view/type/virtual.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/view/type/virtual.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/catalog/product/view/type/virtual.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/view/type/virtual.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/product/view/type/virtual.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/view/type/virtual.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/product/widget/link/link_block.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/widget/link/link_block.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/catalog/product/widget/link/link_block.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/widget/link/link_block.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/product/widget/link/link_block.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/widget/link/link_block.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/product/widget/link/link_inline.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/widget/link/link_inline.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/catalog/product/widget/link/link_inline.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/widget/link/link_inline.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/product/widget/link/link_inline.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/widget/link/link_inline.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/product/widget/new/column/new_default_list.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/widget/new/column/new_default_list.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/catalog/product/widget/new/column/new_default_list.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/widget/new/column/new_default_list.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/product/widget/new/column/new_default_list.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/widget/new/column/new_default_list.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/product/widget/new/column/new_images_list.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/widget/new/column/new_images_list.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/catalog/product/widget/new/column/new_images_list.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/widget/new/column/new_images_list.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/product/widget/new/column/new_images_list.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/widget/new/column/new_images_list.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/product/widget/new/column/new_names_list.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/widget/new/column/new_names_list.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/catalog/product/widget/new/column/new_names_list.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/widget/new/column/new_names_list.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/product/widget/new/column/new_names_list.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/widget/new/column/new_names_list.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/product/widget/new/content/new_grid.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/widget/new/content/new_grid.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/catalog/product/widget/new/content/new_grid.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/widget/new/content/new_grid.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/product/widget/new/content/new_grid.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/widget/new/content/new_grid.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/product/widget/new/content/new_list.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/widget/new/content/new_list.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/catalog/product/widget/new/content/new_list.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/widget/new/content/new_list.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/product/widget/new/content/new_list.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/widget/new/content/new_list.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/rss/product/price.phtml
+++ b/app/design/frontend/base/default/template/catalog/rss/product/price.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/catalog/rss/product/price.phtml
+++ b/app/design/frontend/base/default/template/catalog/rss/product/price.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/rss/product/price.phtml
+++ b/app/design/frontend/base/default/template/catalog/rss/product/price.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/seo/sitemap.phtml
+++ b/app/design/frontend/base/default/template/catalog/seo/sitemap.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/catalog/seo/sitemap.phtml
+++ b/app/design/frontend/base/default/template/catalog/seo/sitemap.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/seo/sitemap.phtml
+++ b/app/design/frontend/base/default/template/catalog/seo/sitemap.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/seo/sitemap/container.phtml
+++ b/app/design/frontend/base/default/template/catalog/seo/sitemap/container.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/catalog/seo/sitemap/container.phtml
+++ b/app/design/frontend/base/default/template/catalog/seo/sitemap/container.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/seo/sitemap/container.phtml
+++ b/app/design/frontend/base/default/template/catalog/seo/sitemap/container.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/seo/tree.phtml
+++ b/app/design/frontend/base/default/template/catalog/seo/tree.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/catalog/seo/tree.phtml
+++ b/app/design/frontend/base/default/template/catalog/seo/tree.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalog/seo/tree.phtml
+++ b/app/design/frontend/base/default/template/catalog/seo/tree.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/cataloginventory/qtyincrements.phtml
+++ b/app/design/frontend/base/default/template/cataloginventory/qtyincrements.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/cataloginventory/qtyincrements.phtml
+++ b/app/design/frontend/base/default/template/cataloginventory/qtyincrements.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/cataloginventory/qtyincrements.phtml
+++ b/app/design/frontend/base/default/template/cataloginventory/qtyincrements.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/cataloginventory/stockqty/composite.phtml
+++ b/app/design/frontend/base/default/template/cataloginventory/stockqty/composite.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/cataloginventory/stockqty/composite.phtml
+++ b/app/design/frontend/base/default/template/cataloginventory/stockqty/composite.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/cataloginventory/stockqty/composite.phtml
+++ b/app/design/frontend/base/default/template/cataloginventory/stockqty/composite.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/cataloginventory/stockqty/default.phtml
+++ b/app/design/frontend/base/default/template/cataloginventory/stockqty/default.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/cataloginventory/stockqty/default.phtml
+++ b/app/design/frontend/base/default/template/cataloginventory/stockqty/default.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/cataloginventory/stockqty/default.phtml
+++ b/app/design/frontend/base/default/template/cataloginventory/stockqty/default.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalogsearch/advanced/form.phtml
+++ b/app/design/frontend/base/default/template/catalogsearch/advanced/form.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/catalogsearch/advanced/form.phtml
+++ b/app/design/frontend/base/default/template/catalogsearch/advanced/form.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalogsearch/advanced/form.phtml
+++ b/app/design/frontend/base/default/template/catalogsearch/advanced/form.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalogsearch/advanced/result.phtml
+++ b/app/design/frontend/base/default/template/catalogsearch/advanced/result.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/catalogsearch/advanced/result.phtml
+++ b/app/design/frontend/base/default/template/catalogsearch/advanced/result.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalogsearch/advanced/result.phtml
+++ b/app/design/frontend/base/default/template/catalogsearch/advanced/result.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalogsearch/form.mini.phtml
+++ b/app/design/frontend/base/default/template/catalogsearch/form.mini.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/catalogsearch/form.mini.phtml
+++ b/app/design/frontend/base/default/template/catalogsearch/form.mini.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalogsearch/form.mini.phtml
+++ b/app/design/frontend/base/default/template/catalogsearch/form.mini.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalogsearch/result.phtml
+++ b/app/design/frontend/base/default/template/catalogsearch/result.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/catalogsearch/result.phtml
+++ b/app/design/frontend/base/default/template/catalogsearch/result.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalogsearch/result.phtml
+++ b/app/design/frontend/base/default/template/catalogsearch/result.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalogsearch/term.phtml
+++ b/app/design/frontend/base/default/template/catalogsearch/term.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/catalogsearch/term.phtml
+++ b/app/design/frontend/base/default/template/catalogsearch/term.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/catalogsearch/term.phtml
+++ b/app/design/frontend/base/default/template/catalogsearch/term.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/centinel/authentication.phtml
+++ b/app/design/frontend/base/default/template/centinel/authentication.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/centinel/authentication.phtml
+++ b/app/design/frontend/base/default/template/centinel/authentication.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/centinel/authentication.phtml
+++ b/app/design/frontend/base/default/template/centinel/authentication.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/centinel/authentication/complete.phtml
+++ b/app/design/frontend/base/default/template/centinel/authentication/complete.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/centinel/authentication/complete.phtml
+++ b/app/design/frontend/base/default/template/centinel/authentication/complete.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/centinel/authentication/complete.phtml
+++ b/app/design/frontend/base/default/template/centinel/authentication/complete.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/centinel/authentication/start.phtml
+++ b/app/design/frontend/base/default/template/centinel/authentication/start.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/centinel/authentication/start.phtml
+++ b/app/design/frontend/base/default/template/centinel/authentication/start.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/centinel/authentication/start.phtml
+++ b/app/design/frontend/base/default/template/centinel/authentication/start.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/centinel/logo.phtml
+++ b/app/design/frontend/base/default/template/centinel/logo.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/centinel/logo.phtml
+++ b/app/design/frontend/base/default/template/centinel/logo.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/centinel/logo.phtml
+++ b/app/design/frontend/base/default/template/centinel/logo.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/cart.phtml
+++ b/app/design/frontend/base/default/template/checkout/cart.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/checkout/cart.phtml
+++ b/app/design/frontend/base/default/template/checkout/cart.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/cart.phtml
+++ b/app/design/frontend/base/default/template/checkout/cart.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/cart/coupon.phtml
+++ b/app/design/frontend/base/default/template/checkout/cart/coupon.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/checkout/cart/coupon.phtml
+++ b/app/design/frontend/base/default/template/checkout/cart/coupon.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/cart/coupon.phtml
+++ b/app/design/frontend/base/default/template/checkout/cart/coupon.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/cart/crosssell.phtml
+++ b/app/design/frontend/base/default/template/checkout/cart/crosssell.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/checkout/cart/crosssell.phtml
+++ b/app/design/frontend/base/default/template/checkout/cart/crosssell.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/cart/crosssell.phtml
+++ b/app/design/frontend/base/default/template/checkout/cart/crosssell.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/cart/item/configure/updatecart.phtml
+++ b/app/design/frontend/base/default/template/checkout/cart/item/configure/updatecart.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/checkout/cart/item/configure/updatecart.phtml
+++ b/app/design/frontend/base/default/template/checkout/cart/item/configure/updatecart.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/cart/item/configure/updatecart.phtml
+++ b/app/design/frontend/base/default/template/checkout/cart/item/configure/updatecart.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/cart/item/default.phtml
+++ b/app/design/frontend/base/default/template/checkout/cart/item/default.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/checkout/cart/item/default.phtml
+++ b/app/design/frontend/base/default/template/checkout/cart/item/default.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/cart/item/default.phtml
+++ b/app/design/frontend/base/default/template/checkout/cart/item/default.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/cart/noItems.phtml
+++ b/app/design/frontend/base/default/template/checkout/cart/noItems.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/checkout/cart/noItems.phtml
+++ b/app/design/frontend/base/default/template/checkout/cart/noItems.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/cart/noItems.phtml
+++ b/app/design/frontend/base/default/template/checkout/cart/noItems.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/cart/render/default.phtml
+++ b/app/design/frontend/base/default/template/checkout/cart/render/default.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/checkout/cart/render/default.phtml
+++ b/app/design/frontend/base/default/template/checkout/cart/render/default.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/cart/render/default.phtml
+++ b/app/design/frontend/base/default/template/checkout/cart/render/default.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/cart/render/simple.phtml
+++ b/app/design/frontend/base/default/template/checkout/cart/render/simple.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/checkout/cart/render/simple.phtml
+++ b/app/design/frontend/base/default/template/checkout/cart/render/simple.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/cart/render/simple.phtml
+++ b/app/design/frontend/base/default/template/checkout/cart/render/simple.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/cart/shipping.phtml
+++ b/app/design/frontend/base/default/template/checkout/cart/shipping.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/checkout/cart/shipping.phtml
+++ b/app/design/frontend/base/default/template/checkout/cart/shipping.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/cart/shipping.phtml
+++ b/app/design/frontend/base/default/template/checkout/cart/shipping.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/cart/sidebar.phtml
+++ b/app/design/frontend/base/default/template/checkout/cart/sidebar.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/checkout/cart/sidebar.phtml
+++ b/app/design/frontend/base/default/template/checkout/cart/sidebar.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/cart/sidebar.phtml
+++ b/app/design/frontend/base/default/template/checkout/cart/sidebar.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/cart/sidebar/default.phtml
+++ b/app/design/frontend/base/default/template/checkout/cart/sidebar/default.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/checkout/cart/sidebar/default.phtml
+++ b/app/design/frontend/base/default/template/checkout/cart/sidebar/default.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/cart/sidebar/default.phtml
+++ b/app/design/frontend/base/default/template/checkout/cart/sidebar/default.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/cart/totals.phtml
+++ b/app/design/frontend/base/default/template/checkout/cart/totals.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/checkout/cart/totals.phtml
+++ b/app/design/frontend/base/default/template/checkout/cart/totals.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/cart/totals.phtml
+++ b/app/design/frontend/base/default/template/checkout/cart/totals.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/multishipping/address/select.phtml
+++ b/app/design/frontend/base/default/template/checkout/multishipping/address/select.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/checkout/multishipping/address/select.phtml
+++ b/app/design/frontend/base/default/template/checkout/multishipping/address/select.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/multishipping/address/select.phtml
+++ b/app/design/frontend/base/default/template/checkout/multishipping/address/select.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/multishipping/addresses.phtml
+++ b/app/design/frontend/base/default/template/checkout/multishipping/addresses.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/checkout/multishipping/addresses.phtml
+++ b/app/design/frontend/base/default/template/checkout/multishipping/addresses.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/multishipping/addresses.phtml
+++ b/app/design/frontend/base/default/template/checkout/multishipping/addresses.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/multishipping/agreements.phtml
+++ b/app/design/frontend/base/default/template/checkout/multishipping/agreements.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/checkout/multishipping/agreements.phtml
+++ b/app/design/frontend/base/default/template/checkout/multishipping/agreements.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/multishipping/agreements.phtml
+++ b/app/design/frontend/base/default/template/checkout/multishipping/agreements.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/multishipping/billing.phtml
+++ b/app/design/frontend/base/default/template/checkout/multishipping/billing.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/checkout/multishipping/billing.phtml
+++ b/app/design/frontend/base/default/template/checkout/multishipping/billing.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/multishipping/billing.phtml
+++ b/app/design/frontend/base/default/template/checkout/multishipping/billing.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/multishipping/billing/items.phtml
+++ b/app/design/frontend/base/default/template/checkout/multishipping/billing/items.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/checkout/multishipping/billing/items.phtml
+++ b/app/design/frontend/base/default/template/checkout/multishipping/billing/items.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/multishipping/billing/items.phtml
+++ b/app/design/frontend/base/default/template/checkout/multishipping/billing/items.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/multishipping/item/default.phtml
+++ b/app/design/frontend/base/default/template/checkout/multishipping/item/default.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/checkout/multishipping/item/default.phtml
+++ b/app/design/frontend/base/default/template/checkout/multishipping/item/default.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/multishipping/item/default.phtml
+++ b/app/design/frontend/base/default/template/checkout/multishipping/item/default.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/multishipping/link.phtml
+++ b/app/design/frontend/base/default/template/checkout/multishipping/link.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/checkout/multishipping/link.phtml
+++ b/app/design/frontend/base/default/template/checkout/multishipping/link.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/multishipping/link.phtml
+++ b/app/design/frontend/base/default/template/checkout/multishipping/link.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/multishipping/overview.phtml
+++ b/app/design/frontend/base/default/template/checkout/multishipping/overview.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/checkout/multishipping/overview.phtml
+++ b/app/design/frontend/base/default/template/checkout/multishipping/overview.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/multishipping/overview.phtml
+++ b/app/design/frontend/base/default/template/checkout/multishipping/overview.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/multishipping/overview/item.phtml
+++ b/app/design/frontend/base/default/template/checkout/multishipping/overview/item.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/checkout/multishipping/overview/item.phtml
+++ b/app/design/frontend/base/default/template/checkout/multishipping/overview/item.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/multishipping/overview/item.phtml
+++ b/app/design/frontend/base/default/template/checkout/multishipping/overview/item.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/multishipping/shipping.phtml
+++ b/app/design/frontend/base/default/template/checkout/multishipping/shipping.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/checkout/multishipping/shipping.phtml
+++ b/app/design/frontend/base/default/template/checkout/multishipping/shipping.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/multishipping/shipping.phtml
+++ b/app/design/frontend/base/default/template/checkout/multishipping/shipping.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/multishipping/state.phtml
+++ b/app/design/frontend/base/default/template/checkout/multishipping/state.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/checkout/multishipping/state.phtml
+++ b/app/design/frontend/base/default/template/checkout/multishipping/state.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/multishipping/state.phtml
+++ b/app/design/frontend/base/default/template/checkout/multishipping/state.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/multishipping/success.phtml
+++ b/app/design/frontend/base/default/template/checkout/multishipping/success.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/checkout/multishipping/success.phtml
+++ b/app/design/frontend/base/default/template/checkout/multishipping/success.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/multishipping/success.phtml
+++ b/app/design/frontend/base/default/template/checkout/multishipping/success.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/onepage.phtml
+++ b/app/design/frontend/base/default/template/checkout/onepage.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/checkout/onepage.phtml
+++ b/app/design/frontend/base/default/template/checkout/onepage.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/onepage.phtml
+++ b/app/design/frontend/base/default/template/checkout/onepage.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/onepage/agreements.phtml
+++ b/app/design/frontend/base/default/template/checkout/onepage/agreements.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/checkout/onepage/agreements.phtml
+++ b/app/design/frontend/base/default/template/checkout/onepage/agreements.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/onepage/agreements.phtml
+++ b/app/design/frontend/base/default/template/checkout/onepage/agreements.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/onepage/billing.phtml
+++ b/app/design/frontend/base/default/template/checkout/onepage/billing.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/checkout/onepage/billing.phtml
+++ b/app/design/frontend/base/default/template/checkout/onepage/billing.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/onepage/billing.phtml
+++ b/app/design/frontend/base/default/template/checkout/onepage/billing.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/onepage/failure.phtml
+++ b/app/design/frontend/base/default/template/checkout/onepage/failure.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/checkout/onepage/failure.phtml
+++ b/app/design/frontend/base/default/template/checkout/onepage/failure.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/onepage/failure.phtml
+++ b/app/design/frontend/base/default/template/checkout/onepage/failure.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/onepage/link.phtml
+++ b/app/design/frontend/base/default/template/checkout/onepage/link.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/checkout/onepage/link.phtml
+++ b/app/design/frontend/base/default/template/checkout/onepage/link.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/onepage/link.phtml
+++ b/app/design/frontend/base/default/template/checkout/onepage/link.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/onepage/login.phtml
+++ b/app/design/frontend/base/default/template/checkout/onepage/login.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/checkout/onepage/login.phtml
+++ b/app/design/frontend/base/default/template/checkout/onepage/login.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/onepage/login.phtml
+++ b/app/design/frontend/base/default/template/checkout/onepage/login.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/onepage/payment.phtml
+++ b/app/design/frontend/base/default/template/checkout/onepage/payment.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/checkout/onepage/payment.phtml
+++ b/app/design/frontend/base/default/template/checkout/onepage/payment.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/onepage/payment.phtml
+++ b/app/design/frontend/base/default/template/checkout/onepage/payment.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/onepage/payment/info.phtml
+++ b/app/design/frontend/base/default/template/checkout/onepage/payment/info.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/checkout/onepage/payment/info.phtml
+++ b/app/design/frontend/base/default/template/checkout/onepage/payment/info.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/onepage/payment/info.phtml
+++ b/app/design/frontend/base/default/template/checkout/onepage/payment/info.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/onepage/payment/methods.phtml
+++ b/app/design/frontend/base/default/template/checkout/onepage/payment/methods.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/checkout/onepage/payment/methods.phtml
+++ b/app/design/frontend/base/default/template/checkout/onepage/payment/methods.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/onepage/payment/methods.phtml
+++ b/app/design/frontend/base/default/template/checkout/onepage/payment/methods.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/onepage/progress.phtml
+++ b/app/design/frontend/base/default/template/checkout/onepage/progress.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/checkout/onepage/progress.phtml
+++ b/app/design/frontend/base/default/template/checkout/onepage/progress.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/onepage/progress.phtml
+++ b/app/design/frontend/base/default/template/checkout/onepage/progress.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/onepage/progress/billing.phtml
+++ b/app/design/frontend/base/default/template/checkout/onepage/progress/billing.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/checkout/onepage/progress/billing.phtml
+++ b/app/design/frontend/base/default/template/checkout/onepage/progress/billing.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/onepage/progress/billing.phtml
+++ b/app/design/frontend/base/default/template/checkout/onepage/progress/billing.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/onepage/progress/payment.phtml
+++ b/app/design/frontend/base/default/template/checkout/onepage/progress/payment.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/checkout/onepage/progress/payment.phtml
+++ b/app/design/frontend/base/default/template/checkout/onepage/progress/payment.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/onepage/progress/payment.phtml
+++ b/app/design/frontend/base/default/template/checkout/onepage/progress/payment.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/onepage/progress/shipping.phtml
+++ b/app/design/frontend/base/default/template/checkout/onepage/progress/shipping.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/checkout/onepage/progress/shipping.phtml
+++ b/app/design/frontend/base/default/template/checkout/onepage/progress/shipping.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/onepage/progress/shipping.phtml
+++ b/app/design/frontend/base/default/template/checkout/onepage/progress/shipping.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/onepage/progress/shipping_method.phtml
+++ b/app/design/frontend/base/default/template/checkout/onepage/progress/shipping_method.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/checkout/onepage/progress/shipping_method.phtml
+++ b/app/design/frontend/base/default/template/checkout/onepage/progress/shipping_method.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/onepage/progress/shipping_method.phtml
+++ b/app/design/frontend/base/default/template/checkout/onepage/progress/shipping_method.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/onepage/review.phtml
+++ b/app/design/frontend/base/default/template/checkout/onepage/review.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/checkout/onepage/review.phtml
+++ b/app/design/frontend/base/default/template/checkout/onepage/review.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/onepage/review.phtml
+++ b/app/design/frontend/base/default/template/checkout/onepage/review.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/onepage/review/button.phtml
+++ b/app/design/frontend/base/default/template/checkout/onepage/review/button.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/checkout/onepage/review/button.phtml
+++ b/app/design/frontend/base/default/template/checkout/onepage/review/button.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/onepage/review/button.phtml
+++ b/app/design/frontend/base/default/template/checkout/onepage/review/button.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/onepage/review/info.phtml
+++ b/app/design/frontend/base/default/template/checkout/onepage/review/info.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/checkout/onepage/review/info.phtml
+++ b/app/design/frontend/base/default/template/checkout/onepage/review/info.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/onepage/review/info.phtml
+++ b/app/design/frontend/base/default/template/checkout/onepage/review/info.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/onepage/review/item.phtml
+++ b/app/design/frontend/base/default/template/checkout/onepage/review/item.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/checkout/onepage/review/item.phtml
+++ b/app/design/frontend/base/default/template/checkout/onepage/review/item.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/onepage/review/item.phtml
+++ b/app/design/frontend/base/default/template/checkout/onepage/review/item.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/onepage/review/totals.phtml
+++ b/app/design/frontend/base/default/template/checkout/onepage/review/totals.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/checkout/onepage/review/totals.phtml
+++ b/app/design/frontend/base/default/template/checkout/onepage/review/totals.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/onepage/review/totals.phtml
+++ b/app/design/frontend/base/default/template/checkout/onepage/review/totals.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/onepage/shipping.phtml
+++ b/app/design/frontend/base/default/template/checkout/onepage/shipping.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/checkout/onepage/shipping.phtml
+++ b/app/design/frontend/base/default/template/checkout/onepage/shipping.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/onepage/shipping.phtml
+++ b/app/design/frontend/base/default/template/checkout/onepage/shipping.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/onepage/shipping_method.phtml
+++ b/app/design/frontend/base/default/template/checkout/onepage/shipping_method.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/checkout/onepage/shipping_method.phtml
+++ b/app/design/frontend/base/default/template/checkout/onepage/shipping_method.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/onepage/shipping_method.phtml
+++ b/app/design/frontend/base/default/template/checkout/onepage/shipping_method.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/onepage/shipping_method/additional.phtml
+++ b/app/design/frontend/base/default/template/checkout/onepage/shipping_method/additional.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/checkout/onepage/shipping_method/additional.phtml
+++ b/app/design/frontend/base/default/template/checkout/onepage/shipping_method/additional.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/onepage/shipping_method/additional.phtml
+++ b/app/design/frontend/base/default/template/checkout/onepage/shipping_method/additional.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/onepage/shipping_method/available.phtml
+++ b/app/design/frontend/base/default/template/checkout/onepage/shipping_method/available.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/checkout/onepage/shipping_method/available.phtml
+++ b/app/design/frontend/base/default/template/checkout/onepage/shipping_method/available.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/onepage/shipping_method/available.phtml
+++ b/app/design/frontend/base/default/template/checkout/onepage/shipping_method/available.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/success.phtml
+++ b/app/design/frontend/base/default/template/checkout/success.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/checkout/success.phtml
+++ b/app/design/frontend/base/default/template/checkout/success.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/success.phtml
+++ b/app/design/frontend/base/default/template/checkout/success.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/total/default.phtml
+++ b/app/design/frontend/base/default/template/checkout/total/default.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/checkout/total/default.phtml
+++ b/app/design/frontend/base/default/template/checkout/total/default.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/total/default.phtml
+++ b/app/design/frontend/base/default/template/checkout/total/default.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/total/nominal.phtml
+++ b/app/design/frontend/base/default/template/checkout/total/nominal.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/checkout/total/nominal.phtml
+++ b/app/design/frontend/base/default/template/checkout/total/nominal.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/total/nominal.phtml
+++ b/app/design/frontend/base/default/template/checkout/total/nominal.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/total/tax.phtml
+++ b/app/design/frontend/base/default/template/checkout/total/tax.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/checkout/total/tax.phtml
+++ b/app/design/frontend/base/default/template/checkout/total/tax.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/checkout/total/tax.phtml
+++ b/app/design/frontend/base/default/template/checkout/total/tax.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/cms/content.phtml
+++ b/app/design/frontend/base/default/template/cms/content.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/cms/content.phtml
+++ b/app/design/frontend/base/default/template/cms/content.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/cms/content.phtml
+++ b/app/design/frontend/base/default/template/cms/content.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/cms/content_heading.phtml
+++ b/app/design/frontend/base/default/template/cms/content_heading.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/cms/content_heading.phtml
+++ b/app/design/frontend/base/default/template/cms/content_heading.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/cms/content_heading.phtml
+++ b/app/design/frontend/base/default/template/cms/content_heading.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/cms/default/home.phtml
+++ b/app/design/frontend/base/default/template/cms/default/home.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/cms/default/home.phtml
+++ b/app/design/frontend/base/default/template/cms/default/home.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/cms/default/home.phtml
+++ b/app/design/frontend/base/default/template/cms/default/home.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/cms/default/no-route.phtml
+++ b/app/design/frontend/base/default/template/cms/default/no-route.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/cms/default/no-route.phtml
+++ b/app/design/frontend/base/default/template/cms/default/no-route.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/cms/default/no-route.phtml
+++ b/app/design/frontend/base/default/template/cms/default/no-route.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/cms/meta.phtml
+++ b/app/design/frontend/base/default/template/cms/meta.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/cms/meta.phtml
+++ b/app/design/frontend/base/default/template/cms/meta.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/cms/meta.phtml
+++ b/app/design/frontend/base/default/template/cms/meta.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/cms/widget/link/link_block.phtml
+++ b/app/design/frontend/base/default/template/cms/widget/link/link_block.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/cms/widget/link/link_block.phtml
+++ b/app/design/frontend/base/default/template/cms/widget/link/link_block.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/cms/widget/link/link_block.phtml
+++ b/app/design/frontend/base/default/template/cms/widget/link/link_block.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/cms/widget/link/link_inline.phtml
+++ b/app/design/frontend/base/default/template/cms/widget/link/link_inline.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/cms/widget/link/link_inline.phtml
+++ b/app/design/frontend/base/default/template/cms/widget/link/link_inline.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/cms/widget/link/link_inline.phtml
+++ b/app/design/frontend/base/default/template/cms/widget/link/link_inline.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/cms/widget/static_block/default.phtml
+++ b/app/design/frontend/base/default/template/cms/widget/static_block/default.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/cms/widget/static_block/default.phtml
+++ b/app/design/frontend/base/default/template/cms/widget/static_block/default.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/cms/widget/static_block/default.phtml
+++ b/app/design/frontend/base/default/template/cms/widget/static_block/default.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/contacts/form.phtml
+++ b/app/design/frontend/base/default/template/contacts/form.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/contacts/form.phtml
+++ b/app/design/frontend/base/default/template/contacts/form.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/contacts/form.phtml
+++ b/app/design/frontend/base/default/template/contacts/form.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/core/formkey.phtml
+++ b/app/design/frontend/base/default/template/core/formkey.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/core/formkey.phtml
+++ b/app/design/frontend/base/default/template/core/formkey.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/core/formkey.phtml
+++ b/app/design/frontend/base/default/template/core/formkey.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/core/link.phtml
+++ b/app/design/frontend/base/default/template/core/link.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/core/link.phtml
+++ b/app/design/frontend/base/default/template/core/link.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/core/link.phtml
+++ b/app/design/frontend/base/default/template/core/link.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/core/messages.phtml
+++ b/app/design/frontend/base/default/template/core/messages.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/core/messages.phtml
+++ b/app/design/frontend/base/default/template/core/messages.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/core/messages.phtml
+++ b/app/design/frontend/base/default/template/core/messages.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/customer/account/dashboard.phtml
+++ b/app/design/frontend/base/default/template/customer/account/dashboard.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/customer/account/dashboard.phtml
+++ b/app/design/frontend/base/default/template/customer/account/dashboard.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/customer/account/dashboard.phtml
+++ b/app/design/frontend/base/default/template/customer/account/dashboard.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/customer/account/dashboard/address.phtml
+++ b/app/design/frontend/base/default/template/customer/account/dashboard/address.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/customer/account/dashboard/address.phtml
+++ b/app/design/frontend/base/default/template/customer/account/dashboard/address.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/customer/account/dashboard/address.phtml
+++ b/app/design/frontend/base/default/template/customer/account/dashboard/address.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/customer/account/dashboard/hello.phtml
+++ b/app/design/frontend/base/default/template/customer/account/dashboard/hello.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/customer/account/dashboard/hello.phtml
+++ b/app/design/frontend/base/default/template/customer/account/dashboard/hello.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/customer/account/dashboard/hello.phtml
+++ b/app/design/frontend/base/default/template/customer/account/dashboard/hello.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/customer/account/dashboard/info.phtml
+++ b/app/design/frontend/base/default/template/customer/account/dashboard/info.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/customer/account/dashboard/info.phtml
+++ b/app/design/frontend/base/default/template/customer/account/dashboard/info.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/customer/account/dashboard/info.phtml
+++ b/app/design/frontend/base/default/template/customer/account/dashboard/info.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/customer/account/dashboard/newsletter.phtml
+++ b/app/design/frontend/base/default/template/customer/account/dashboard/newsletter.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/customer/account/dashboard/newsletter.phtml
+++ b/app/design/frontend/base/default/template/customer/account/dashboard/newsletter.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/customer/account/dashboard/newsletter.phtml
+++ b/app/design/frontend/base/default/template/customer/account/dashboard/newsletter.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/customer/account/link/back.phtml
+++ b/app/design/frontend/base/default/template/customer/account/link/back.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/customer/account/link/back.phtml
+++ b/app/design/frontend/base/default/template/customer/account/link/back.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/customer/account/link/back.phtml
+++ b/app/design/frontend/base/default/template/customer/account/link/back.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/customer/account/navigation.phtml
+++ b/app/design/frontend/base/default/template/customer/account/navigation.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/customer/account/navigation.phtml
+++ b/app/design/frontend/base/default/template/customer/account/navigation.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/customer/account/navigation.phtml
+++ b/app/design/frontend/base/default/template/customer/account/navigation.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/customer/address.phtml
+++ b/app/design/frontend/base/default/template/customer/address.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/customer/address.phtml
+++ b/app/design/frontend/base/default/template/customer/address.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/customer/address.phtml
+++ b/app/design/frontend/base/default/template/customer/address.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/customer/address/book.phtml
+++ b/app/design/frontend/base/default/template/customer/address/book.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/customer/address/book.phtml
+++ b/app/design/frontend/base/default/template/customer/address/book.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/customer/address/book.phtml
+++ b/app/design/frontend/base/default/template/customer/address/book.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/customer/address/edit.phtml
+++ b/app/design/frontend/base/default/template/customer/address/edit.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/customer/address/edit.phtml
+++ b/app/design/frontend/base/default/template/customer/address/edit.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/customer/address/edit.phtml
+++ b/app/design/frontend/base/default/template/customer/address/edit.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/customer/balance.phtml
+++ b/app/design/frontend/base/default/template/customer/balance.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/customer/balance.phtml
+++ b/app/design/frontend/base/default/template/customer/balance.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/customer/balance.phtml
+++ b/app/design/frontend/base/default/template/customer/balance.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/customer/form/address.phtml
+++ b/app/design/frontend/base/default/template/customer/form/address.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/customer/form/address.phtml
+++ b/app/design/frontend/base/default/template/customer/form/address.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/customer/form/address.phtml
+++ b/app/design/frontend/base/default/template/customer/form/address.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/customer/form/changepassword.phtml
+++ b/app/design/frontend/base/default/template/customer/form/changepassword.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/customer/form/changepassword.phtml
+++ b/app/design/frontend/base/default/template/customer/form/changepassword.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/customer/form/changepassword.phtml
+++ b/app/design/frontend/base/default/template/customer/form/changepassword.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/customer/form/confirmation.phtml
+++ b/app/design/frontend/base/default/template/customer/form/confirmation.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/customer/form/confirmation.phtml
+++ b/app/design/frontend/base/default/template/customer/form/confirmation.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/customer/form/confirmation.phtml
+++ b/app/design/frontend/base/default/template/customer/form/confirmation.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/customer/form/edit.phtml
+++ b/app/design/frontend/base/default/template/customer/form/edit.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/customer/form/edit.phtml
+++ b/app/design/frontend/base/default/template/customer/form/edit.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/customer/form/edit.phtml
+++ b/app/design/frontend/base/default/template/customer/form/edit.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/customer/form/forgotpassword.phtml
+++ b/app/design/frontend/base/default/template/customer/form/forgotpassword.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/customer/form/forgotpassword.phtml
+++ b/app/design/frontend/base/default/template/customer/form/forgotpassword.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/customer/form/forgotpassword.phtml
+++ b/app/design/frontend/base/default/template/customer/form/forgotpassword.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/customer/form/login.phtml
+++ b/app/design/frontend/base/default/template/customer/form/login.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/customer/form/login.phtml
+++ b/app/design/frontend/base/default/template/customer/form/login.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/customer/form/login.phtml
+++ b/app/design/frontend/base/default/template/customer/form/login.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/customer/form/mini.login.phtml
+++ b/app/design/frontend/base/default/template/customer/form/mini.login.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/customer/form/mini.login.phtml
+++ b/app/design/frontend/base/default/template/customer/form/mini.login.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/customer/form/mini.login.phtml
+++ b/app/design/frontend/base/default/template/customer/form/mini.login.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/customer/form/newsletter.phtml
+++ b/app/design/frontend/base/default/template/customer/form/newsletter.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/customer/form/newsletter.phtml
+++ b/app/design/frontend/base/default/template/customer/form/newsletter.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/customer/form/newsletter.phtml
+++ b/app/design/frontend/base/default/template/customer/form/newsletter.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/customer/form/register.phtml
+++ b/app/design/frontend/base/default/template/customer/form/register.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/customer/form/register.phtml
+++ b/app/design/frontend/base/default/template/customer/form/register.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/customer/form/register.phtml
+++ b/app/design/frontend/base/default/template/customer/form/register.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/customer/form/resetforgottenpassword.phtml
+++ b/app/design/frontend/base/default/template/customer/form/resetforgottenpassword.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/customer/form/resetforgottenpassword.phtml
+++ b/app/design/frontend/base/default/template/customer/form/resetforgottenpassword.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/customer/form/resetforgottenpassword.phtml
+++ b/app/design/frontend/base/default/template/customer/form/resetforgottenpassword.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/customer/logout.phtml
+++ b/app/design/frontend/base/default/template/customer/logout.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/customer/logout.phtml
+++ b/app/design/frontend/base/default/template/customer/logout.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/customer/logout.phtml
+++ b/app/design/frontend/base/default/template/customer/logout.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/customer/orders.phtml
+++ b/app/design/frontend/base/default/template/customer/orders.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/customer/orders.phtml
+++ b/app/design/frontend/base/default/template/customer/orders.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/customer/orders.phtml
+++ b/app/design/frontend/base/default/template/customer/orders.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/customer/widget/dob.phtml
+++ b/app/design/frontend/base/default/template/customer/widget/dob.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/customer/widget/dob.phtml
+++ b/app/design/frontend/base/default/template/customer/widget/dob.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/customer/widget/dob.phtml
+++ b/app/design/frontend/base/default/template/customer/widget/dob.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/customer/widget/gender.phtml
+++ b/app/design/frontend/base/default/template/customer/widget/gender.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/customer/widget/gender.phtml
+++ b/app/design/frontend/base/default/template/customer/widget/gender.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/customer/widget/gender.phtml
+++ b/app/design/frontend/base/default/template/customer/widget/gender.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/customer/widget/name.phtml
+++ b/app/design/frontend/base/default/template/customer/widget/name.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/customer/widget/name.phtml
+++ b/app/design/frontend/base/default/template/customer/widget/name.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/customer/widget/name.phtml
+++ b/app/design/frontend/base/default/template/customer/widget/name.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/customer/widget/taxvat.phtml
+++ b/app/design/frontend/base/default/template/customer/widget/taxvat.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/customer/widget/taxvat.phtml
+++ b/app/design/frontend/base/default/template/customer/widget/taxvat.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/customer/widget/taxvat.phtml
+++ b/app/design/frontend/base/default/template/customer/widget/taxvat.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/customer/wishlist.phtml
+++ b/app/design/frontend/base/default/template/customer/wishlist.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/customer/wishlist.phtml
+++ b/app/design/frontend/base/default/template/customer/wishlist.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/customer/wishlist.phtml
+++ b/app/design/frontend/base/default/template/customer/wishlist.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/directory/currency.phtml
+++ b/app/design/frontend/base/default/template/directory/currency.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/directory/currency.phtml
+++ b/app/design/frontend/base/default/template/directory/currency.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/directory/currency.phtml
+++ b/app/design/frontend/base/default/template/directory/currency.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/directory/currency/switch.phtml
+++ b/app/design/frontend/base/default/template/directory/currency/switch.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/directory/currency/switch.phtml
+++ b/app/design/frontend/base/default/template/directory/currency/switch.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/directory/currency/switch.phtml
+++ b/app/design/frontend/base/default/template/directory/currency/switch.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/directory/js/optional_zip_countries.phtml
+++ b/app/design/frontend/base/default/template/directory/js/optional_zip_countries.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/directory/js/optional_zip_countries.phtml
+++ b/app/design/frontend/base/default/template/directory/js/optional_zip_countries.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/directory/js/optional_zip_countries.phtml
+++ b/app/design/frontend/base/default/template/directory/js/optional_zip_countries.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/downloadable/catalog/product/links.phtml
+++ b/app/design/frontend/base/default/template/downloadable/catalog/product/links.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/downloadable/catalog/product/links.phtml
+++ b/app/design/frontend/base/default/template/downloadable/catalog/product/links.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/downloadable/catalog/product/links.phtml
+++ b/app/design/frontend/base/default/template/downloadable/catalog/product/links.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/downloadable/catalog/product/samples.phtml
+++ b/app/design/frontend/base/default/template/downloadable/catalog/product/samples.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/downloadable/catalog/product/samples.phtml
+++ b/app/design/frontend/base/default/template/downloadable/catalog/product/samples.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/downloadable/catalog/product/samples.phtml
+++ b/app/design/frontend/base/default/template/downloadable/catalog/product/samples.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/downloadable/catalog/product/type.phtml
+++ b/app/design/frontend/base/default/template/downloadable/catalog/product/type.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/downloadable/catalog/product/type.phtml
+++ b/app/design/frontend/base/default/template/downloadable/catalog/product/type.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/downloadable/catalog/product/type.phtml
+++ b/app/design/frontend/base/default/template/downloadable/catalog/product/type.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/downloadable/checkout/cart/item/default.phtml
+++ b/app/design/frontend/base/default/template/downloadable/checkout/cart/item/default.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/downloadable/checkout/cart/item/default.phtml
+++ b/app/design/frontend/base/default/template/downloadable/checkout/cart/item/default.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/downloadable/checkout/cart/item/default.phtml
+++ b/app/design/frontend/base/default/template/downloadable/checkout/cart/item/default.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/downloadable/checkout/multishipping/item/downloadable.phtml
+++ b/app/design/frontend/base/default/template/downloadable/checkout/multishipping/item/downloadable.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/downloadable/checkout/multishipping/item/downloadable.phtml
+++ b/app/design/frontend/base/default/template/downloadable/checkout/multishipping/item/downloadable.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/downloadable/checkout/multishipping/item/downloadable.phtml
+++ b/app/design/frontend/base/default/template/downloadable/checkout/multishipping/item/downloadable.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/downloadable/checkout/onepage/review/item.phtml
+++ b/app/design/frontend/base/default/template/downloadable/checkout/onepage/review/item.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/downloadable/checkout/onepage/review/item.phtml
+++ b/app/design/frontend/base/default/template/downloadable/checkout/onepage/review/item.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/downloadable/checkout/onepage/review/item.phtml
+++ b/app/design/frontend/base/default/template/downloadable/checkout/onepage/review/item.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/downloadable/checkout/success.phtml
+++ b/app/design/frontend/base/default/template/downloadable/checkout/success.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/downloadable/checkout/success.phtml
+++ b/app/design/frontend/base/default/template/downloadable/checkout/success.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/downloadable/checkout/success.phtml
+++ b/app/design/frontend/base/default/template/downloadable/checkout/success.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/downloadable/customer/products/list.phtml
+++ b/app/design/frontend/base/default/template/downloadable/customer/products/list.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/downloadable/customer/products/list.phtml
+++ b/app/design/frontend/base/default/template/downloadable/customer/products/list.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/downloadable/customer/products/list.phtml
+++ b/app/design/frontend/base/default/template/downloadable/customer/products/list.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/downloadable/email/order/items/creditmemo/downloadable.phtml
+++ b/app/design/frontend/base/default/template/downloadable/email/order/items/creditmemo/downloadable.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/downloadable/email/order/items/creditmemo/downloadable.phtml
+++ b/app/design/frontend/base/default/template/downloadable/email/order/items/creditmemo/downloadable.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/downloadable/email/order/items/creditmemo/downloadable.phtml
+++ b/app/design/frontend/base/default/template/downloadable/email/order/items/creditmemo/downloadable.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/downloadable/email/order/items/invoice/downloadable.phtml
+++ b/app/design/frontend/base/default/template/downloadable/email/order/items/invoice/downloadable.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/downloadable/email/order/items/invoice/downloadable.phtml
+++ b/app/design/frontend/base/default/template/downloadable/email/order/items/invoice/downloadable.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/downloadable/email/order/items/invoice/downloadable.phtml
+++ b/app/design/frontend/base/default/template/downloadable/email/order/items/invoice/downloadable.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/downloadable/email/order/items/order/downloadable.phtml
+++ b/app/design/frontend/base/default/template/downloadable/email/order/items/order/downloadable.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/downloadable/email/order/items/order/downloadable.phtml
+++ b/app/design/frontend/base/default/template/downloadable/email/order/items/order/downloadable.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/downloadable/email/order/items/order/downloadable.phtml
+++ b/app/design/frontend/base/default/template/downloadable/email/order/items/order/downloadable.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/downloadable/sales/order/creditmemo/items/renderer/downloadable.phtml
+++ b/app/design/frontend/base/default/template/downloadable/sales/order/creditmemo/items/renderer/downloadable.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/downloadable/sales/order/creditmemo/items/renderer/downloadable.phtml
+++ b/app/design/frontend/base/default/template/downloadable/sales/order/creditmemo/items/renderer/downloadable.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/downloadable/sales/order/creditmemo/items/renderer/downloadable.phtml
+++ b/app/design/frontend/base/default/template/downloadable/sales/order/creditmemo/items/renderer/downloadable.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/downloadable/sales/order/invoice/items/renderer/downloadable.phtml
+++ b/app/design/frontend/base/default/template/downloadable/sales/order/invoice/items/renderer/downloadable.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/downloadable/sales/order/invoice/items/renderer/downloadable.phtml
+++ b/app/design/frontend/base/default/template/downloadable/sales/order/invoice/items/renderer/downloadable.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/downloadable/sales/order/invoice/items/renderer/downloadable.phtml
+++ b/app/design/frontend/base/default/template/downloadable/sales/order/invoice/items/renderer/downloadable.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/downloadable/sales/order/items/renderer/downloadable.phtml
+++ b/app/design/frontend/base/default/template/downloadable/sales/order/items/renderer/downloadable.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/downloadable/sales/order/items/renderer/downloadable.phtml
+++ b/app/design/frontend/base/default/template/downloadable/sales/order/items/renderer/downloadable.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/downloadable/sales/order/items/renderer/downloadable.phtml
+++ b/app/design/frontend/base/default/template/downloadable/sales/order/items/renderer/downloadable.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/email/order/creditmemo/items.phtml
+++ b/app/design/frontend/base/default/template/email/order/creditmemo/items.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/email/order/creditmemo/items.phtml
+++ b/app/design/frontend/base/default/template/email/order/creditmemo/items.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/email/order/creditmemo/items.phtml
+++ b/app/design/frontend/base/default/template/email/order/creditmemo/items.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/email/order/invoice/items.phtml
+++ b/app/design/frontend/base/default/template/email/order/invoice/items.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/email/order/invoice/items.phtml
+++ b/app/design/frontend/base/default/template/email/order/invoice/items.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/email/order/invoice/items.phtml
+++ b/app/design/frontend/base/default/template/email/order/invoice/items.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/email/order/items.phtml
+++ b/app/design/frontend/base/default/template/email/order/items.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/email/order/items.phtml
+++ b/app/design/frontend/base/default/template/email/order/items.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/email/order/items.phtml
+++ b/app/design/frontend/base/default/template/email/order/items.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/email/order/items/creditmemo/default.phtml
+++ b/app/design/frontend/base/default/template/email/order/items/creditmemo/default.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/email/order/items/creditmemo/default.phtml
+++ b/app/design/frontend/base/default/template/email/order/items/creditmemo/default.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/email/order/items/creditmemo/default.phtml
+++ b/app/design/frontend/base/default/template/email/order/items/creditmemo/default.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/email/order/items/invoice/default.phtml
+++ b/app/design/frontend/base/default/template/email/order/items/invoice/default.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/email/order/items/invoice/default.phtml
+++ b/app/design/frontend/base/default/template/email/order/items/invoice/default.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/email/order/items/invoice/default.phtml
+++ b/app/design/frontend/base/default/template/email/order/items/invoice/default.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/email/order/items/order/default.phtml
+++ b/app/design/frontend/base/default/template/email/order/items/order/default.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/email/order/items/order/default.phtml
+++ b/app/design/frontend/base/default/template/email/order/items/order/default.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/email/order/items/order/default.phtml
+++ b/app/design/frontend/base/default/template/email/order/items/order/default.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/email/order/items/shipment/default.phtml
+++ b/app/design/frontend/base/default/template/email/order/items/shipment/default.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/email/order/items/shipment/default.phtml
+++ b/app/design/frontend/base/default/template/email/order/items/shipment/default.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/email/order/items/shipment/default.phtml
+++ b/app/design/frontend/base/default/template/email/order/items/shipment/default.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/email/order/shipment/items.phtml
+++ b/app/design/frontend/base/default/template/email/order/shipment/items.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/email/order/shipment/items.phtml
+++ b/app/design/frontend/base/default/template/email/order/shipment/items.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/email/order/shipment/items.phtml
+++ b/app/design/frontend/base/default/template/email/order/shipment/items.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/email/order/shipment/track.phtml
+++ b/app/design/frontend/base/default/template/email/order/shipment/track.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/email/order/shipment/track.phtml
+++ b/app/design/frontend/base/default/template/email/order/shipment/track.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/email/order/shipment/track.phtml
+++ b/app/design/frontend/base/default/template/email/order/shipment/track.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/email/productalert/price.phtml
+++ b/app/design/frontend/base/default/template/email/productalert/price.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/email/productalert/price.phtml
+++ b/app/design/frontend/base/default/template/email/productalert/price.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/email/productalert/price.phtml
+++ b/app/design/frontend/base/default/template/email/productalert/price.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/email/productalert/stock.phtml
+++ b/app/design/frontend/base/default/template/email/productalert/stock.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/email/productalert/stock.phtml
+++ b/app/design/frontend/base/default/template/email/productalert/stock.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/email/productalert/stock.phtml
+++ b/app/design/frontend/base/default/template/email/productalert/stock.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/giftmessage/inline.phtml
+++ b/app/design/frontend/base/default/template/giftmessage/inline.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/giftmessage/inline.phtml
+++ b/app/design/frontend/base/default/template/giftmessage/inline.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/giftmessage/inline.phtml
+++ b/app/design/frontend/base/default/template/giftmessage/inline.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/googleanalytics/ga.phtml
+++ b/app/design/frontend/base/default/template/googleanalytics/ga.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/googleanalytics/ga.phtml
+++ b/app/design/frontend/base/default/template/googleanalytics/ga.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/googleanalytics/ga.phtml
+++ b/app/design/frontend/base/default/template/googleanalytics/ga.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/newsletter/subscribe.phtml
+++ b/app/design/frontend/base/default/template/newsletter/subscribe.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/newsletter/subscribe.phtml
+++ b/app/design/frontend/base/default/template/newsletter/subscribe.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/newsletter/subscribe.phtml
+++ b/app/design/frontend/base/default/template/newsletter/subscribe.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/oauth/authorize/button-simple.phtml
+++ b/app/design/frontend/base/default/template/oauth/authorize/button-simple.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/oauth/authorize/button-simple.phtml
+++ b/app/design/frontend/base/default/template/oauth/authorize/button-simple.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/oauth/authorize/button-simple.phtml
+++ b/app/design/frontend/base/default/template/oauth/authorize/button-simple.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/oauth/authorize/button.phtml
+++ b/app/design/frontend/base/default/template/oauth/authorize/button.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/oauth/authorize/button.phtml
+++ b/app/design/frontend/base/default/template/oauth/authorize/button.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/oauth/authorize/button.phtml
+++ b/app/design/frontend/base/default/template/oauth/authorize/button.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/oauth/authorize/confirm-simple.phtml
+++ b/app/design/frontend/base/default/template/oauth/authorize/confirm-simple.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/oauth/authorize/confirm-simple.phtml
+++ b/app/design/frontend/base/default/template/oauth/authorize/confirm-simple.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/oauth/authorize/confirm-simple.phtml
+++ b/app/design/frontend/base/default/template/oauth/authorize/confirm-simple.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/oauth/authorize/confirm.phtml
+++ b/app/design/frontend/base/default/template/oauth/authorize/confirm.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/oauth/authorize/confirm.phtml
+++ b/app/design/frontend/base/default/template/oauth/authorize/confirm.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/oauth/authorize/confirm.phtml
+++ b/app/design/frontend/base/default/template/oauth/authorize/confirm.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/oauth/authorize/form/login-simple.phtml
+++ b/app/design/frontend/base/default/template/oauth/authorize/form/login-simple.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/oauth/authorize/form/login-simple.phtml
+++ b/app/design/frontend/base/default/template/oauth/authorize/form/login-simple.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/oauth/authorize/form/login-simple.phtml
+++ b/app/design/frontend/base/default/template/oauth/authorize/form/login-simple.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/oauth/authorize/form/login.phtml
+++ b/app/design/frontend/base/default/template/oauth/authorize/form/login.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/oauth/authorize/form/login.phtml
+++ b/app/design/frontend/base/default/template/oauth/authorize/form/login.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/oauth/authorize/form/login.phtml
+++ b/app/design/frontend/base/default/template/oauth/authorize/form/login.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/oauth/authorize/head-simple.phtml
+++ b/app/design/frontend/base/default/template/oauth/authorize/head-simple.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/oauth/authorize/head-simple.phtml
+++ b/app/design/frontend/base/default/template/oauth/authorize/head-simple.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/oauth/authorize/head-simple.phtml
+++ b/app/design/frontend/base/default/template/oauth/authorize/head-simple.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/oauth/authorize/reject-simple.phtml
+++ b/app/design/frontend/base/default/template/oauth/authorize/reject-simple.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/oauth/authorize/reject-simple.phtml
+++ b/app/design/frontend/base/default/template/oauth/authorize/reject-simple.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/oauth/authorize/reject-simple.phtml
+++ b/app/design/frontend/base/default/template/oauth/authorize/reject-simple.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/oauth/authorize/reject.phtml
+++ b/app/design/frontend/base/default/template/oauth/authorize/reject.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/oauth/authorize/reject.phtml
+++ b/app/design/frontend/base/default/template/oauth/authorize/reject.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/oauth/authorize/reject.phtml
+++ b/app/design/frontend/base/default/template/oauth/authorize/reject.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/oauth/customer/token/list.phtml
+++ b/app/design/frontend/base/default/template/oauth/customer/token/list.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/oauth/customer/token/list.phtml
+++ b/app/design/frontend/base/default/template/oauth/customer/token/list.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/oauth/customer/token/list.phtml
+++ b/app/design/frontend/base/default/template/oauth/customer/token/list.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/page/1column.phtml
+++ b/app/design/frontend/base/default/template/page/1column.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/page/1column.phtml
+++ b/app/design/frontend/base/default/template/page/1column.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/page/1column.phtml
+++ b/app/design/frontend/base/default/template/page/1column.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/page/2columns-left.phtml
+++ b/app/design/frontend/base/default/template/page/2columns-left.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/page/2columns-left.phtml
+++ b/app/design/frontend/base/default/template/page/2columns-left.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/page/2columns-left.phtml
+++ b/app/design/frontend/base/default/template/page/2columns-left.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/page/2columns-right.phtml
+++ b/app/design/frontend/base/default/template/page/2columns-right.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/page/2columns-right.phtml
+++ b/app/design/frontend/base/default/template/page/2columns-right.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/page/2columns-right.phtml
+++ b/app/design/frontend/base/default/template/page/2columns-right.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/page/3columns.phtml
+++ b/app/design/frontend/base/default/template/page/3columns.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/page/3columns.phtml
+++ b/app/design/frontend/base/default/template/page/3columns.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/page/3columns.phtml
+++ b/app/design/frontend/base/default/template/page/3columns.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/page/empty.phtml
+++ b/app/design/frontend/base/default/template/page/empty.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/page/empty.phtml
+++ b/app/design/frontend/base/default/template/page/empty.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/page/empty.phtml
+++ b/app/design/frontend/base/default/template/page/empty.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/page/html/breadcrumbs.phtml
+++ b/app/design/frontend/base/default/template/page/html/breadcrumbs.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/page/html/breadcrumbs.phtml
+++ b/app/design/frontend/base/default/template/page/html/breadcrumbs.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/page/html/breadcrumbs.phtml
+++ b/app/design/frontend/base/default/template/page/html/breadcrumbs.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/page/html/cookienotice.phtml
+++ b/app/design/frontend/base/default/template/page/html/cookienotice.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/page/html/cookienotice.phtml
+++ b/app/design/frontend/base/default/template/page/html/cookienotice.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/page/html/cookienotice.phtml
+++ b/app/design/frontend/base/default/template/page/html/cookienotice.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/page/html/footer.phtml
+++ b/app/design/frontend/base/default/template/page/html/footer.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/page/html/footer.phtml
+++ b/app/design/frontend/base/default/template/page/html/footer.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/page/html/footer.phtml
+++ b/app/design/frontend/base/default/template/page/html/footer.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/page/html/head.phtml
+++ b/app/design/frontend/base/default/template/page/html/head.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/page/html/head.phtml
+++ b/app/design/frontend/base/default/template/page/html/head.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/page/html/head.phtml
+++ b/app/design/frontend/base/default/template/page/html/head.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/page/html/header.phtml
+++ b/app/design/frontend/base/default/template/page/html/header.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/page/html/header.phtml
+++ b/app/design/frontend/base/default/template/page/html/header.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/page/html/header.phtml
+++ b/app/design/frontend/base/default/template/page/html/header.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/page/html/notices.phtml
+++ b/app/design/frontend/base/default/template/page/html/notices.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/page/html/notices.phtml
+++ b/app/design/frontend/base/default/template/page/html/notices.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/page/html/notices.phtml
+++ b/app/design/frontend/base/default/template/page/html/notices.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/page/html/pager.phtml
+++ b/app/design/frontend/base/default/template/page/html/pager.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/page/html/pager.phtml
+++ b/app/design/frontend/base/default/template/page/html/pager.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/page/html/pager.phtml
+++ b/app/design/frontend/base/default/template/page/html/pager.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/page/html/top.links.phtml
+++ b/app/design/frontend/base/default/template/page/html/top.links.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/page/html/top.links.phtml
+++ b/app/design/frontend/base/default/template/page/html/top.links.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/page/html/top.links.phtml
+++ b/app/design/frontend/base/default/template/page/html/top.links.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/page/html/topmenu.phtml
+++ b/app/design/frontend/base/default/template/page/html/topmenu.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/page/html/topmenu.phtml
+++ b/app/design/frontend/base/default/template/page/html/topmenu.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/page/html/topmenu.phtml
+++ b/app/design/frontend/base/default/template/page/html/topmenu.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/page/html/wrapper.phtml
+++ b/app/design/frontend/base/default/template/page/html/wrapper.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/page/html/wrapper.phtml
+++ b/app/design/frontend/base/default/template/page/html/wrapper.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/page/html/wrapper.phtml
+++ b/app/design/frontend/base/default/template/page/html/wrapper.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/page/js/calendar.phtml
+++ b/app/design/frontend/base/default/template/page/js/calendar.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/page/js/calendar.phtml
+++ b/app/design/frontend/base/default/template/page/js/calendar.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/page/js/calendar.phtml
+++ b/app/design/frontend/base/default/template/page/js/calendar.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/page/js/cookie.phtml
+++ b/app/design/frontend/base/default/template/page/js/cookie.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/page/js/cookie.phtml
+++ b/app/design/frontend/base/default/template/page/js/cookie.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/page/js/cookie.phtml
+++ b/app/design/frontend/base/default/template/page/js/cookie.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/page/popup.phtml
+++ b/app/design/frontend/base/default/template/page/popup.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/page/popup.phtml
+++ b/app/design/frontend/base/default/template/page/popup.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/page/popup.phtml
+++ b/app/design/frontend/base/default/template/page/popup.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/page/print.phtml
+++ b/app/design/frontend/base/default/template/page/print.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/page/print.phtml
+++ b/app/design/frontend/base/default/template/page/print.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/page/print.phtml
+++ b/app/design/frontend/base/default/template/page/print.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/page/redirect.phtml
+++ b/app/design/frontend/base/default/template/page/redirect.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/page/redirect.phtml
+++ b/app/design/frontend/base/default/template/page/redirect.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/page/redirect.phtml
+++ b/app/design/frontend/base/default/template/page/redirect.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/page/switch/flags.phtml
+++ b/app/design/frontend/base/default/template/page/switch/flags.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/page/switch/flags.phtml
+++ b/app/design/frontend/base/default/template/page/switch/flags.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/page/switch/flags.phtml
+++ b/app/design/frontend/base/default/template/page/switch/flags.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/page/switch/languages.phtml
+++ b/app/design/frontend/base/default/template/page/switch/languages.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/page/switch/languages.phtml
+++ b/app/design/frontend/base/default/template/page/switch/languages.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/page/switch/languages.phtml
+++ b/app/design/frontend/base/default/template/page/switch/languages.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/page/switch/stores.phtml
+++ b/app/design/frontend/base/default/template/page/switch/stores.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/page/switch/stores.phtml
+++ b/app/design/frontend/base/default/template/page/switch/stores.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/page/switch/stores.phtml
+++ b/app/design/frontend/base/default/template/page/switch/stores.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/page/template/container.phtml
+++ b/app/design/frontend/base/default/template/page/template/container.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/page/template/container.phtml
+++ b/app/design/frontend/base/default/template/page/template/container.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/page/template/container.phtml
+++ b/app/design/frontend/base/default/template/page/template/container.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/page/template/links.phtml
+++ b/app/design/frontend/base/default/template/page/template/links.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/page/template/links.phtml
+++ b/app/design/frontend/base/default/template/page/template/links.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/page/template/links.phtml
+++ b/app/design/frontend/base/default/template/page/template/links.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/page/template/linksblock.phtml
+++ b/app/design/frontend/base/default/template/page/template/linksblock.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/page/template/linksblock.phtml
+++ b/app/design/frontend/base/default/template/page/template/linksblock.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/page/template/linksblock.phtml
+++ b/app/design/frontend/base/default/template/page/template/linksblock.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/paygate/form/cc.phtml
+++ b/app/design/frontend/base/default/template/paygate/form/cc.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/paygate/form/cc.phtml
+++ b/app/design/frontend/base/default/template/paygate/form/cc.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/paygate/form/cc.phtml
+++ b/app/design/frontend/base/default/template/paygate/form/cc.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/paygate/info/cc.phtml
+++ b/app/design/frontend/base/default/template/paygate/info/cc.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/paygate/info/cc.phtml
+++ b/app/design/frontend/base/default/template/paygate/info/cc.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/paygate/info/cc.phtml
+++ b/app/design/frontend/base/default/template/paygate/info/cc.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/payment/catalog/product/view/profile/options.phtml
+++ b/app/design/frontend/base/default/template/payment/catalog/product/view/profile/options.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/payment/catalog/product/view/profile/options.phtml
+++ b/app/design/frontend/base/default/template/payment/catalog/product/view/profile/options.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/payment/catalog/product/view/profile/options.phtml
+++ b/app/design/frontend/base/default/template/payment/catalog/product/view/profile/options.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/payment/catalog/product/view/profile/schedule.phtml
+++ b/app/design/frontend/base/default/template/payment/catalog/product/view/profile/schedule.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/payment/catalog/product/view/profile/schedule.phtml
+++ b/app/design/frontend/base/default/template/payment/catalog/product/view/profile/schedule.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/payment/catalog/product/view/profile/schedule.phtml
+++ b/app/design/frontend/base/default/template/payment/catalog/product/view/profile/schedule.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/payment/form/banktransfer.phtml
+++ b/app/design/frontend/base/default/template/payment/form/banktransfer.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/payment/form/banktransfer.phtml
+++ b/app/design/frontend/base/default/template/payment/form/banktransfer.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/payment/form/banktransfer.phtml
+++ b/app/design/frontend/base/default/template/payment/form/banktransfer.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/payment/form/cashondelivery.phtml
+++ b/app/design/frontend/base/default/template/payment/form/cashondelivery.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/payment/form/cashondelivery.phtml
+++ b/app/design/frontend/base/default/template/payment/form/cashondelivery.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/payment/form/cashondelivery.phtml
+++ b/app/design/frontend/base/default/template/payment/form/cashondelivery.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/payment/form/cc.phtml
+++ b/app/design/frontend/base/default/template/payment/form/cc.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/payment/form/cc.phtml
+++ b/app/design/frontend/base/default/template/payment/form/cc.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/payment/form/cc.phtml
+++ b/app/design/frontend/base/default/template/payment/form/cc.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/payment/form/ccsave.phtml
+++ b/app/design/frontend/base/default/template/payment/form/ccsave.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/payment/form/ccsave.phtml
+++ b/app/design/frontend/base/default/template/payment/form/ccsave.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/payment/form/ccsave.phtml
+++ b/app/design/frontend/base/default/template/payment/form/ccsave.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/payment/form/checkmo.phtml
+++ b/app/design/frontend/base/default/template/payment/form/checkmo.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/payment/form/checkmo.phtml
+++ b/app/design/frontend/base/default/template/payment/form/checkmo.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/payment/form/checkmo.phtml
+++ b/app/design/frontend/base/default/template/payment/form/checkmo.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/payment/form/purchaseorder.phtml
+++ b/app/design/frontend/base/default/template/payment/form/purchaseorder.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/payment/form/purchaseorder.phtml
+++ b/app/design/frontend/base/default/template/payment/form/purchaseorder.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/payment/form/purchaseorder.phtml
+++ b/app/design/frontend/base/default/template/payment/form/purchaseorder.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/payment/info/banktransfer.phtml
+++ b/app/design/frontend/base/default/template/payment/info/banktransfer.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/payment/info/banktransfer.phtml
+++ b/app/design/frontend/base/default/template/payment/info/banktransfer.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/payment/info/banktransfer.phtml
+++ b/app/design/frontend/base/default/template/payment/info/banktransfer.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/payment/info/checkmo.phtml
+++ b/app/design/frontend/base/default/template/payment/info/checkmo.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/payment/info/checkmo.phtml
+++ b/app/design/frontend/base/default/template/payment/info/checkmo.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/payment/info/checkmo.phtml
+++ b/app/design/frontend/base/default/template/payment/info/checkmo.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/payment/info/default.phtml
+++ b/app/design/frontend/base/default/template/payment/info/default.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/payment/info/default.phtml
+++ b/app/design/frontend/base/default/template/payment/info/default.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/payment/info/default.phtml
+++ b/app/design/frontend/base/default/template/payment/info/default.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/payment/info/purchaseorder.phtml
+++ b/app/design/frontend/base/default/template/payment/info/purchaseorder.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/payment/info/purchaseorder.phtml
+++ b/app/design/frontend/base/default/template/payment/info/purchaseorder.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/payment/info/purchaseorder.phtml
+++ b/app/design/frontend/base/default/template/payment/info/purchaseorder.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/paypal/bml.phtml
+++ b/app/design/frontend/base/default/template/paypal/bml.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/paypal/bml.phtml
+++ b/app/design/frontend/base/default/template/paypal/bml.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/paypal/bml.phtml
+++ b/app/design/frontend/base/default/template/paypal/bml.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/paypal/express/review.phtml
+++ b/app/design/frontend/base/default/template/paypal/express/review.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/paypal/express/review.phtml
+++ b/app/design/frontend/base/default/template/paypal/express/review.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/paypal/express/review.phtml
+++ b/app/design/frontend/base/default/template/paypal/express/review.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/paypal/express/review/details.phtml
+++ b/app/design/frontend/base/default/template/paypal/express/review/details.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/paypal/express/review/details.phtml
+++ b/app/design/frontend/base/default/template/paypal/express/review/details.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/paypal/express/review/details.phtml
+++ b/app/design/frontend/base/default/template/paypal/express/review/details.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/paypal/express/review/shipping/method.phtml
+++ b/app/design/frontend/base/default/template/paypal/express/review/shipping/method.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/paypal/express/review/shipping/method.phtml
+++ b/app/design/frontend/base/default/template/paypal/express/review/shipping/method.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/paypal/express/review/shipping/method.phtml
+++ b/app/design/frontend/base/default/template/paypal/express/review/shipping/method.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/paypal/express/shortcut.phtml
+++ b/app/design/frontend/base/default/template/paypal/express/shortcut.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/paypal/express/shortcut.phtml
+++ b/app/design/frontend/base/default/template/paypal/express/shortcut.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/paypal/express/shortcut.phtml
+++ b/app/design/frontend/base/default/template/paypal/express/shortcut.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/paypal/hss/form.phtml
+++ b/app/design/frontend/base/default/template/paypal/hss/form.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/paypal/hss/form.phtml
+++ b/app/design/frontend/base/default/template/paypal/hss/form.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/paypal/hss/form.phtml
+++ b/app/design/frontend/base/default/template/paypal/hss/form.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/paypal/hss/iframe.phtml
+++ b/app/design/frontend/base/default/template/paypal/hss/iframe.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/paypal/hss/iframe.phtml
+++ b/app/design/frontend/base/default/template/paypal/hss/iframe.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/paypal/hss/iframe.phtml
+++ b/app/design/frontend/base/default/template/paypal/hss/iframe.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/paypal/hss/info.phtml
+++ b/app/design/frontend/base/default/template/paypal/hss/info.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/paypal/hss/info.phtml
+++ b/app/design/frontend/base/default/template/paypal/hss/info.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/paypal/hss/info.phtml
+++ b/app/design/frontend/base/default/template/paypal/hss/info.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/paypal/hss/js.phtml
+++ b/app/design/frontend/base/default/template/paypal/hss/js.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/paypal/hss/js.phtml
+++ b/app/design/frontend/base/default/template/paypal/hss/js.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/paypal/hss/js.phtml
+++ b/app/design/frontend/base/default/template/paypal/hss/js.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/paypal/hss/redirect.phtml
+++ b/app/design/frontend/base/default/template/paypal/hss/redirect.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/paypal/hss/redirect.phtml
+++ b/app/design/frontend/base/default/template/paypal/hss/redirect.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/paypal/hss/redirect.phtml
+++ b/app/design/frontend/base/default/template/paypal/hss/redirect.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/paypal/hss/review/button.phtml
+++ b/app/design/frontend/base/default/template/paypal/hss/review/button.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/paypal/hss/review/button.phtml
+++ b/app/design/frontend/base/default/template/paypal/hss/review/button.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/paypal/hss/review/button.phtml
+++ b/app/design/frontend/base/default/template/paypal/hss/review/button.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/paypal/partner/logo.phtml
+++ b/app/design/frontend/base/default/template/paypal/partner/logo.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/paypal/partner/logo.phtml
+++ b/app/design/frontend/base/default/template/paypal/partner/logo.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/paypal/partner/logo.phtml
+++ b/app/design/frontend/base/default/template/paypal/partner/logo.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/paypal/partner/us_logo.phtml
+++ b/app/design/frontend/base/default/template/paypal/partner/us_logo.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/paypal/partner/us_logo.phtml
+++ b/app/design/frontend/base/default/template/paypal/partner/us_logo.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/paypal/partner/us_logo.phtml
+++ b/app/design/frontend/base/default/template/paypal/partner/us_logo.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/paypal/payflowadvanced/iframe.phtml
+++ b/app/design/frontend/base/default/template/paypal/payflowadvanced/iframe.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/paypal/payflowadvanced/iframe.phtml
+++ b/app/design/frontend/base/default/template/paypal/payflowadvanced/iframe.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/paypal/payflowadvanced/iframe.phtml
+++ b/app/design/frontend/base/default/template/paypal/payflowadvanced/iframe.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/paypal/payflowadvanced/info.phtml
+++ b/app/design/frontend/base/default/template/paypal/payflowadvanced/info.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/paypal/payflowadvanced/info.phtml
+++ b/app/design/frontend/base/default/template/paypal/payflowadvanced/info.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/paypal/payflowadvanced/info.phtml
+++ b/app/design/frontend/base/default/template/paypal/payflowadvanced/info.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/paypal/payflowadvanced/redirect.phtml
+++ b/app/design/frontend/base/default/template/paypal/payflowadvanced/redirect.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/paypal/payflowadvanced/redirect.phtml
+++ b/app/design/frontend/base/default/template/paypal/payflowadvanced/redirect.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/paypal/payflowadvanced/redirect.phtml
+++ b/app/design/frontend/base/default/template/paypal/payflowadvanced/redirect.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/paypal/payflowlink/iframe.phtml
+++ b/app/design/frontend/base/default/template/paypal/payflowlink/iframe.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/paypal/payflowlink/iframe.phtml
+++ b/app/design/frontend/base/default/template/paypal/payflowlink/iframe.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/paypal/payflowlink/iframe.phtml
+++ b/app/design/frontend/base/default/template/paypal/payflowlink/iframe.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/paypal/payflowlink/info.phtml
+++ b/app/design/frontend/base/default/template/paypal/payflowlink/info.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/paypal/payflowlink/info.phtml
+++ b/app/design/frontend/base/default/template/paypal/payflowlink/info.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/paypal/payflowlink/info.phtml
+++ b/app/design/frontend/base/default/template/paypal/payflowlink/info.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/paypal/payflowlink/redirect.phtml
+++ b/app/design/frontend/base/default/template/paypal/payflowlink/redirect.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/paypal/payflowlink/redirect.phtml
+++ b/app/design/frontend/base/default/template/paypal/payflowlink/redirect.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/paypal/payflowlink/redirect.phtml
+++ b/app/design/frontend/base/default/template/paypal/payflowlink/redirect.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/paypal/payment/mark.phtml
+++ b/app/design/frontend/base/default/template/paypal/payment/mark.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/paypal/payment/mark.phtml
+++ b/app/design/frontend/base/default/template/paypal/payment/mark.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/paypal/payment/mark.phtml
+++ b/app/design/frontend/base/default/template/paypal/payment/mark.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/paypal/payment/redirect.phtml
+++ b/app/design/frontend/base/default/template/paypal/payment/redirect.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/paypal/payment/redirect.phtml
+++ b/app/design/frontend/base/default/template/paypal/payment/redirect.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/paypal/payment/redirect.phtml
+++ b/app/design/frontend/base/default/template/paypal/payment/redirect.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/persistent/checkout/onepage/billing.phtml
+++ b/app/design/frontend/base/default/template/persistent/checkout/onepage/billing.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/persistent/checkout/onepage/billing.phtml
+++ b/app/design/frontend/base/default/template/persistent/checkout/onepage/billing.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/persistent/checkout/onepage/billing.phtml
+++ b/app/design/frontend/base/default/template/persistent/checkout/onepage/billing.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/persistent/checkout/onepage/login.phtml
+++ b/app/design/frontend/base/default/template/persistent/checkout/onepage/login.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/persistent/checkout/onepage/login.phtml
+++ b/app/design/frontend/base/default/template/persistent/checkout/onepage/login.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/persistent/checkout/onepage/login.phtml
+++ b/app/design/frontend/base/default/template/persistent/checkout/onepage/login.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/persistent/customer/form/login.phtml
+++ b/app/design/frontend/base/default/template/persistent/customer/form/login.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/persistent/customer/form/login.phtml
+++ b/app/design/frontend/base/default/template/persistent/customer/form/login.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/persistent/customer/form/login.phtml
+++ b/app/design/frontend/base/default/template/persistent/customer/form/login.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/persistent/customer/form/register.phtml
+++ b/app/design/frontend/base/default/template/persistent/customer/form/register.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/persistent/customer/form/register.phtml
+++ b/app/design/frontend/base/default/template/persistent/customer/form/register.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/persistent/customer/form/register.phtml
+++ b/app/design/frontend/base/default/template/persistent/customer/form/register.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/persistent/remember_me.phtml
+++ b/app/design/frontend/base/default/template/persistent/remember_me.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/persistent/remember_me.phtml
+++ b/app/design/frontend/base/default/template/persistent/remember_me.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/persistent/remember_me.phtml
+++ b/app/design/frontend/base/default/template/persistent/remember_me.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/persistent/remember_me_tooltip.phtml
+++ b/app/design/frontend/base/default/template/persistent/remember_me_tooltip.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/persistent/remember_me_tooltip.phtml
+++ b/app/design/frontend/base/default/template/persistent/remember_me_tooltip.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/persistent/remember_me_tooltip.phtml
+++ b/app/design/frontend/base/default/template/persistent/remember_me_tooltip.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/poll/active.phtml
+++ b/app/design/frontend/base/default/template/poll/active.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/poll/active.phtml
+++ b/app/design/frontend/base/default/template/poll/active.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/poll/active.phtml
+++ b/app/design/frontend/base/default/template/poll/active.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/poll/result.phtml
+++ b/app/design/frontend/base/default/template/poll/result.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/poll/result.phtml
+++ b/app/design/frontend/base/default/template/poll/result.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/poll/result.phtml
+++ b/app/design/frontend/base/default/template/poll/result.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/productalert/price.phtml
+++ b/app/design/frontend/base/default/template/productalert/price.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/productalert/price.phtml
+++ b/app/design/frontend/base/default/template/productalert/price.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/productalert/price.phtml
+++ b/app/design/frontend/base/default/template/productalert/price.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/productalert/product/view.phtml
+++ b/app/design/frontend/base/default/template/productalert/product/view.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/productalert/product/view.phtml
+++ b/app/design/frontend/base/default/template/productalert/product/view.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/productalert/product/view.phtml
+++ b/app/design/frontend/base/default/template/productalert/product/view.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/productalert/stock.phtml
+++ b/app/design/frontend/base/default/template/productalert/stock.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/productalert/stock.phtml
+++ b/app/design/frontend/base/default/template/productalert/stock.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/productalert/stock.phtml
+++ b/app/design/frontend/base/default/template/productalert/stock.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/rating/detailed.phtml
+++ b/app/design/frontend/base/default/template/rating/detailed.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/rating/detailed.phtml
+++ b/app/design/frontend/base/default/template/rating/detailed.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/rating/detailed.phtml
+++ b/app/design/frontend/base/default/template/rating/detailed.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/rating/empty.phtml
+++ b/app/design/frontend/base/default/template/rating/empty.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/rating/empty.phtml
+++ b/app/design/frontend/base/default/template/rating/empty.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/rating/empty.phtml
+++ b/app/design/frontend/base/default/template/rating/empty.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/reports/home_product_compared.phtml
+++ b/app/design/frontend/base/default/template/reports/home_product_compared.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/reports/home_product_compared.phtml
+++ b/app/design/frontend/base/default/template/reports/home_product_compared.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/reports/home_product_compared.phtml
+++ b/app/design/frontend/base/default/template/reports/home_product_compared.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/reports/home_product_viewed.phtml
+++ b/app/design/frontend/base/default/template/reports/home_product_viewed.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/reports/home_product_viewed.phtml
+++ b/app/design/frontend/base/default/template/reports/home_product_viewed.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/reports/home_product_viewed.phtml
+++ b/app/design/frontend/base/default/template/reports/home_product_viewed.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/reports/product_compared.phtml
+++ b/app/design/frontend/base/default/template/reports/product_compared.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/reports/product_compared.phtml
+++ b/app/design/frontend/base/default/template/reports/product_compared.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/reports/product_compared.phtml
+++ b/app/design/frontend/base/default/template/reports/product_compared.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/reports/product_viewed.phtml
+++ b/app/design/frontend/base/default/template/reports/product_viewed.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/reports/product_viewed.phtml
+++ b/app/design/frontend/base/default/template/reports/product_viewed.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/reports/product_viewed.phtml
+++ b/app/design/frontend/base/default/template/reports/product_viewed.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/reports/widget/compared/column/compared_default_list.phtml
+++ b/app/design/frontend/base/default/template/reports/widget/compared/column/compared_default_list.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/reports/widget/compared/column/compared_default_list.phtml
+++ b/app/design/frontend/base/default/template/reports/widget/compared/column/compared_default_list.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/reports/widget/compared/column/compared_default_list.phtml
+++ b/app/design/frontend/base/default/template/reports/widget/compared/column/compared_default_list.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/reports/widget/compared/column/compared_images_list.phtml
+++ b/app/design/frontend/base/default/template/reports/widget/compared/column/compared_images_list.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/reports/widget/compared/column/compared_images_list.phtml
+++ b/app/design/frontend/base/default/template/reports/widget/compared/column/compared_images_list.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/reports/widget/compared/column/compared_images_list.phtml
+++ b/app/design/frontend/base/default/template/reports/widget/compared/column/compared_images_list.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/reports/widget/compared/column/compared_names_list.phtml
+++ b/app/design/frontend/base/default/template/reports/widget/compared/column/compared_names_list.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/reports/widget/compared/column/compared_names_list.phtml
+++ b/app/design/frontend/base/default/template/reports/widget/compared/column/compared_names_list.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/reports/widget/compared/column/compared_names_list.phtml
+++ b/app/design/frontend/base/default/template/reports/widget/compared/column/compared_names_list.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/reports/widget/compared/content/compared_grid.phtml
+++ b/app/design/frontend/base/default/template/reports/widget/compared/content/compared_grid.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/reports/widget/compared/content/compared_grid.phtml
+++ b/app/design/frontend/base/default/template/reports/widget/compared/content/compared_grid.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/reports/widget/compared/content/compared_grid.phtml
+++ b/app/design/frontend/base/default/template/reports/widget/compared/content/compared_grid.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/reports/widget/compared/content/compared_list.phtml
+++ b/app/design/frontend/base/default/template/reports/widget/compared/content/compared_list.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/reports/widget/compared/content/compared_list.phtml
+++ b/app/design/frontend/base/default/template/reports/widget/compared/content/compared_list.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/reports/widget/compared/content/compared_list.phtml
+++ b/app/design/frontend/base/default/template/reports/widget/compared/content/compared_list.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/reports/widget/viewed/column/viewed_default_list.phtml
+++ b/app/design/frontend/base/default/template/reports/widget/viewed/column/viewed_default_list.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/reports/widget/viewed/column/viewed_default_list.phtml
+++ b/app/design/frontend/base/default/template/reports/widget/viewed/column/viewed_default_list.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/reports/widget/viewed/column/viewed_default_list.phtml
+++ b/app/design/frontend/base/default/template/reports/widget/viewed/column/viewed_default_list.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/reports/widget/viewed/column/viewed_images_list.phtml
+++ b/app/design/frontend/base/default/template/reports/widget/viewed/column/viewed_images_list.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/reports/widget/viewed/column/viewed_images_list.phtml
+++ b/app/design/frontend/base/default/template/reports/widget/viewed/column/viewed_images_list.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/reports/widget/viewed/column/viewed_images_list.phtml
+++ b/app/design/frontend/base/default/template/reports/widget/viewed/column/viewed_images_list.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/reports/widget/viewed/column/viewed_names_list.phtml
+++ b/app/design/frontend/base/default/template/reports/widget/viewed/column/viewed_names_list.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/reports/widget/viewed/column/viewed_names_list.phtml
+++ b/app/design/frontend/base/default/template/reports/widget/viewed/column/viewed_names_list.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/reports/widget/viewed/column/viewed_names_list.phtml
+++ b/app/design/frontend/base/default/template/reports/widget/viewed/column/viewed_names_list.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/reports/widget/viewed/content/viewed_grid.phtml
+++ b/app/design/frontend/base/default/template/reports/widget/viewed/content/viewed_grid.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/reports/widget/viewed/content/viewed_grid.phtml
+++ b/app/design/frontend/base/default/template/reports/widget/viewed/content/viewed_grid.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/reports/widget/viewed/content/viewed_grid.phtml
+++ b/app/design/frontend/base/default/template/reports/widget/viewed/content/viewed_grid.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/reports/widget/viewed/content/viewed_list.phtml
+++ b/app/design/frontend/base/default/template/reports/widget/viewed/content/viewed_list.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/reports/widget/viewed/content/viewed_list.phtml
+++ b/app/design/frontend/base/default/template/reports/widget/viewed/content/viewed_list.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/reports/widget/viewed/content/viewed_list.phtml
+++ b/app/design/frontend/base/default/template/reports/widget/viewed/content/viewed_list.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/review/customer/list.phtml
+++ b/app/design/frontend/base/default/template/review/customer/list.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/review/customer/list.phtml
+++ b/app/design/frontend/base/default/template/review/customer/list.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/review/customer/list.phtml
+++ b/app/design/frontend/base/default/template/review/customer/list.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/review/customer/recent.phtml
+++ b/app/design/frontend/base/default/template/review/customer/recent.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/review/customer/recent.phtml
+++ b/app/design/frontend/base/default/template/review/customer/recent.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/review/customer/recent.phtml
+++ b/app/design/frontend/base/default/template/review/customer/recent.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/review/customer/view.phtml
+++ b/app/design/frontend/base/default/template/review/customer/view.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/review/customer/view.phtml
+++ b/app/design/frontend/base/default/template/review/customer/view.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/review/customer/view.phtml
+++ b/app/design/frontend/base/default/template/review/customer/view.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/review/form.phtml
+++ b/app/design/frontend/base/default/template/review/form.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/review/form.phtml
+++ b/app/design/frontend/base/default/template/review/form.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/review/form.phtml
+++ b/app/design/frontend/base/default/template/review/form.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/review/helper/summary.phtml
+++ b/app/design/frontend/base/default/template/review/helper/summary.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/review/helper/summary.phtml
+++ b/app/design/frontend/base/default/template/review/helper/summary.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/review/helper/summary.phtml
+++ b/app/design/frontend/base/default/template/review/helper/summary.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/review/helper/summary_short.phtml
+++ b/app/design/frontend/base/default/template/review/helper/summary_short.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/review/helper/summary_short.phtml
+++ b/app/design/frontend/base/default/template/review/helper/summary_short.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/review/helper/summary_short.phtml
+++ b/app/design/frontend/base/default/template/review/helper/summary_short.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/review/product/view/count.phtml
+++ b/app/design/frontend/base/default/template/review/product/view/count.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/review/product/view/count.phtml
+++ b/app/design/frontend/base/default/template/review/product/view/count.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/review/product/view/count.phtml
+++ b/app/design/frontend/base/default/template/review/product/view/count.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/review/product/view/list.phtml
+++ b/app/design/frontend/base/default/template/review/product/view/list.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/review/product/view/list.phtml
+++ b/app/design/frontend/base/default/template/review/product/view/list.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/review/product/view/list.phtml
+++ b/app/design/frontend/base/default/template/review/product/view/list.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/review/product/view/other.phtml
+++ b/app/design/frontend/base/default/template/review/product/view/other.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/review/product/view/other.phtml
+++ b/app/design/frontend/base/default/template/review/product/view/other.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/review/product/view/other.phtml
+++ b/app/design/frontend/base/default/template/review/product/view/other.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/review/view.phtml
+++ b/app/design/frontend/base/default/template/review/view.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/review/view.phtml
+++ b/app/design/frontend/base/default/template/review/view.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/review/view.phtml
+++ b/app/design/frontend/base/default/template/review/view.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/rss/list.phtml
+++ b/app/design/frontend/base/default/template/rss/list.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/rss/list.phtml
+++ b/app/design/frontend/base/default/template/rss/list.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/rss/list.phtml
+++ b/app/design/frontend/base/default/template/rss/list.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/rss/nofeed.phtml
+++ b/app/design/frontend/base/default/template/rss/nofeed.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/rss/nofeed.phtml
+++ b/app/design/frontend/base/default/template/rss/nofeed.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/rss/nofeed.phtml
+++ b/app/design/frontend/base/default/template/rss/nofeed.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/rss/order/details.phtml
+++ b/app/design/frontend/base/default/template/rss/order/details.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/rss/order/details.phtml
+++ b/app/design/frontend/base/default/template/rss/order/details.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/rss/order/details.phtml
+++ b/app/design/frontend/base/default/template/rss/order/details.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/sales/billing/agreement/view.phtml
+++ b/app/design/frontend/base/default/template/sales/billing/agreement/view.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/sales/billing/agreement/view.phtml
+++ b/app/design/frontend/base/default/template/sales/billing/agreement/view.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/sales/billing/agreement/view.phtml
+++ b/app/design/frontend/base/default/template/sales/billing/agreement/view.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/sales/billing/agreements.phtml
+++ b/app/design/frontend/base/default/template/sales/billing/agreements.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/sales/billing/agreements.phtml
+++ b/app/design/frontend/base/default/template/sales/billing/agreements.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/sales/billing/agreements.phtml
+++ b/app/design/frontend/base/default/template/sales/billing/agreements.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/sales/guest/form.phtml
+++ b/app/design/frontend/base/default/template/sales/guest/form.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/sales/guest/form.phtml
+++ b/app/design/frontend/base/default/template/sales/guest/form.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/sales/guest/form.phtml
+++ b/app/design/frontend/base/default/template/sales/guest/form.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/sales/order/comments.phtml
+++ b/app/design/frontend/base/default/template/sales/order/comments.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/sales/order/comments.phtml
+++ b/app/design/frontend/base/default/template/sales/order/comments.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/sales/order/comments.phtml
+++ b/app/design/frontend/base/default/template/sales/order/comments.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/sales/order/creditmemo.phtml
+++ b/app/design/frontend/base/default/template/sales/order/creditmemo.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/sales/order/creditmemo.phtml
+++ b/app/design/frontend/base/default/template/sales/order/creditmemo.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/sales/order/creditmemo.phtml
+++ b/app/design/frontend/base/default/template/sales/order/creditmemo.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/sales/order/creditmemo/items.phtml
+++ b/app/design/frontend/base/default/template/sales/order/creditmemo/items.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/sales/order/creditmemo/items.phtml
+++ b/app/design/frontend/base/default/template/sales/order/creditmemo/items.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/sales/order/creditmemo/items.phtml
+++ b/app/design/frontend/base/default/template/sales/order/creditmemo/items.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/sales/order/creditmemo/items/renderer/default.phtml
+++ b/app/design/frontend/base/default/template/sales/order/creditmemo/items/renderer/default.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/sales/order/creditmemo/items/renderer/default.phtml
+++ b/app/design/frontend/base/default/template/sales/order/creditmemo/items/renderer/default.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/sales/order/creditmemo/items/renderer/default.phtml
+++ b/app/design/frontend/base/default/template/sales/order/creditmemo/items/renderer/default.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/sales/order/details.phtml
+++ b/app/design/frontend/base/default/template/sales/order/details.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/sales/order/details.phtml
+++ b/app/design/frontend/base/default/template/sales/order/details.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/sales/order/details.phtml
+++ b/app/design/frontend/base/default/template/sales/order/details.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/sales/order/history.phtml
+++ b/app/design/frontend/base/default/template/sales/order/history.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/sales/order/history.phtml
+++ b/app/design/frontend/base/default/template/sales/order/history.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/sales/order/history.phtml
+++ b/app/design/frontend/base/default/template/sales/order/history.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/sales/order/info.phtml
+++ b/app/design/frontend/base/default/template/sales/order/info.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/sales/order/info.phtml
+++ b/app/design/frontend/base/default/template/sales/order/info.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/sales/order/info.phtml
+++ b/app/design/frontend/base/default/template/sales/order/info.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/sales/order/info/buttons.phtml
+++ b/app/design/frontend/base/default/template/sales/order/info/buttons.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/sales/order/info/buttons.phtml
+++ b/app/design/frontend/base/default/template/sales/order/info/buttons.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/sales/order/info/buttons.phtml
+++ b/app/design/frontend/base/default/template/sales/order/info/buttons.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/sales/order/invoice.phtml
+++ b/app/design/frontend/base/default/template/sales/order/invoice.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/sales/order/invoice.phtml
+++ b/app/design/frontend/base/default/template/sales/order/invoice.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/sales/order/invoice.phtml
+++ b/app/design/frontend/base/default/template/sales/order/invoice.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/sales/order/invoice/items.phtml
+++ b/app/design/frontend/base/default/template/sales/order/invoice/items.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/sales/order/invoice/items.phtml
+++ b/app/design/frontend/base/default/template/sales/order/invoice/items.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/sales/order/invoice/items.phtml
+++ b/app/design/frontend/base/default/template/sales/order/invoice/items.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/sales/order/invoice/items/renderer/default.phtml
+++ b/app/design/frontend/base/default/template/sales/order/invoice/items/renderer/default.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/sales/order/invoice/items/renderer/default.phtml
+++ b/app/design/frontend/base/default/template/sales/order/invoice/items/renderer/default.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/sales/order/invoice/items/renderer/default.phtml
+++ b/app/design/frontend/base/default/template/sales/order/invoice/items/renderer/default.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/sales/order/items.phtml
+++ b/app/design/frontend/base/default/template/sales/order/items.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/sales/order/items.phtml
+++ b/app/design/frontend/base/default/template/sales/order/items.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/sales/order/items.phtml
+++ b/app/design/frontend/base/default/template/sales/order/items.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/sales/order/items/renderer/default.phtml
+++ b/app/design/frontend/base/default/template/sales/order/items/renderer/default.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/sales/order/items/renderer/default.phtml
+++ b/app/design/frontend/base/default/template/sales/order/items/renderer/default.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/sales/order/items/renderer/default.phtml
+++ b/app/design/frontend/base/default/template/sales/order/items/renderer/default.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/sales/order/print.phtml
+++ b/app/design/frontend/base/default/template/sales/order/print.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/sales/order/print.phtml
+++ b/app/design/frontend/base/default/template/sales/order/print.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/sales/order/print.phtml
+++ b/app/design/frontend/base/default/template/sales/order/print.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/sales/order/print/creditmemo.phtml
+++ b/app/design/frontend/base/default/template/sales/order/print/creditmemo.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/sales/order/print/creditmemo.phtml
+++ b/app/design/frontend/base/default/template/sales/order/print/creditmemo.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/sales/order/print/creditmemo.phtml
+++ b/app/design/frontend/base/default/template/sales/order/print/creditmemo.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/sales/order/print/invoice.phtml
+++ b/app/design/frontend/base/default/template/sales/order/print/invoice.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/sales/order/print/invoice.phtml
+++ b/app/design/frontend/base/default/template/sales/order/print/invoice.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/sales/order/print/invoice.phtml
+++ b/app/design/frontend/base/default/template/sales/order/print/invoice.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/sales/order/print/shipment.phtml
+++ b/app/design/frontend/base/default/template/sales/order/print/shipment.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/sales/order/print/shipment.phtml
+++ b/app/design/frontend/base/default/template/sales/order/print/shipment.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/sales/order/print/shipment.phtml
+++ b/app/design/frontend/base/default/template/sales/order/print/shipment.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/sales/order/recent.phtml
+++ b/app/design/frontend/base/default/template/sales/order/recent.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/sales/order/recent.phtml
+++ b/app/design/frontend/base/default/template/sales/order/recent.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/sales/order/recent.phtml
+++ b/app/design/frontend/base/default/template/sales/order/recent.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/sales/order/shipment.phtml
+++ b/app/design/frontend/base/default/template/sales/order/shipment.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/sales/order/shipment.phtml
+++ b/app/design/frontend/base/default/template/sales/order/shipment.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/sales/order/shipment.phtml
+++ b/app/design/frontend/base/default/template/sales/order/shipment.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/sales/order/shipment/items.phtml
+++ b/app/design/frontend/base/default/template/sales/order/shipment/items.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/sales/order/shipment/items.phtml
+++ b/app/design/frontend/base/default/template/sales/order/shipment/items.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/sales/order/shipment/items.phtml
+++ b/app/design/frontend/base/default/template/sales/order/shipment/items.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/sales/order/shipment/items/renderer/default.phtml
+++ b/app/design/frontend/base/default/template/sales/order/shipment/items/renderer/default.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/sales/order/shipment/items/renderer/default.phtml
+++ b/app/design/frontend/base/default/template/sales/order/shipment/items/renderer/default.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/sales/order/shipment/items/renderer/default.phtml
+++ b/app/design/frontend/base/default/template/sales/order/shipment/items/renderer/default.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/sales/order/totals.phtml
+++ b/app/design/frontend/base/default/template/sales/order/totals.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/sales/order/totals.phtml
+++ b/app/design/frontend/base/default/template/sales/order/totals.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/sales/order/totals.phtml
+++ b/app/design/frontend/base/default/template/sales/order/totals.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/sales/order/trackinginfo.phtml
+++ b/app/design/frontend/base/default/template/sales/order/trackinginfo.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/sales/order/trackinginfo.phtml
+++ b/app/design/frontend/base/default/template/sales/order/trackinginfo.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/sales/order/trackinginfo.phtml
+++ b/app/design/frontend/base/default/template/sales/order/trackinginfo.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/sales/order/view.phtml
+++ b/app/design/frontend/base/default/template/sales/order/view.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/sales/order/view.phtml
+++ b/app/design/frontend/base/default/template/sales/order/view.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/sales/order/view.phtml
+++ b/app/design/frontend/base/default/template/sales/order/view.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/sales/payment/form/billing/agreement.phtml
+++ b/app/design/frontend/base/default/template/sales/payment/form/billing/agreement.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/sales/payment/form/billing/agreement.phtml
+++ b/app/design/frontend/base/default/template/sales/payment/form/billing/agreement.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/sales/payment/form/billing/agreement.phtml
+++ b/app/design/frontend/base/default/template/sales/payment/form/billing/agreement.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/sales/recurring/grid.phtml
+++ b/app/design/frontend/base/default/template/sales/recurring/grid.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/sales/recurring/grid.phtml
+++ b/app/design/frontend/base/default/template/sales/recurring/grid.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/sales/recurring/grid.phtml
+++ b/app/design/frontend/base/default/template/sales/recurring/grid.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/sales/recurring/profile/view.phtml
+++ b/app/design/frontend/base/default/template/sales/recurring/profile/view.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/sales/recurring/profile/view.phtml
+++ b/app/design/frontend/base/default/template/sales/recurring/profile/view.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/sales/recurring/profile/view.phtml
+++ b/app/design/frontend/base/default/template/sales/recurring/profile/view.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/sales/recurring/profile/view/info.phtml
+++ b/app/design/frontend/base/default/template/sales/recurring/profile/view/info.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/sales/recurring/profile/view/info.phtml
+++ b/app/design/frontend/base/default/template/sales/recurring/profile/view/info.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/sales/recurring/profile/view/info.phtml
+++ b/app/design/frontend/base/default/template/sales/recurring/profile/view/info.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/sales/recurring/profiles.phtml
+++ b/app/design/frontend/base/default/template/sales/recurring/profiles.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/sales/recurring/profiles.phtml
+++ b/app/design/frontend/base/default/template/sales/recurring/profiles.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/sales/recurring/profiles.phtml
+++ b/app/design/frontend/base/default/template/sales/recurring/profiles.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/sales/reorder/sidebar.phtml
+++ b/app/design/frontend/base/default/template/sales/reorder/sidebar.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/sales/reorder/sidebar.phtml
+++ b/app/design/frontend/base/default/template/sales/reorder/sidebar.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/sales/reorder/sidebar.phtml
+++ b/app/design/frontend/base/default/template/sales/reorder/sidebar.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/sales/widget/guest/form.phtml
+++ b/app/design/frontend/base/default/template/sales/widget/guest/form.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/sales/widget/guest/form.phtml
+++ b/app/design/frontend/base/default/template/sales/widget/guest/form.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/sales/widget/guest/form.phtml
+++ b/app/design/frontend/base/default/template/sales/widget/guest/form.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/sendfriend/send.phtml
+++ b/app/design/frontend/base/default/template/sendfriend/send.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/sendfriend/send.phtml
+++ b/app/design/frontend/base/default/template/sendfriend/send.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/sendfriend/send.phtml
+++ b/app/design/frontend/base/default/template/sendfriend/send.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/shipping/tracking/ajax.phtml
+++ b/app/design/frontend/base/default/template/shipping/tracking/ajax.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/shipping/tracking/ajax.phtml
+++ b/app/design/frontend/base/default/template/shipping/tracking/ajax.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/shipping/tracking/ajax.phtml
+++ b/app/design/frontend/base/default/template/shipping/tracking/ajax.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/shipping/tracking/popup.phtml
+++ b/app/design/frontend/base/default/template/shipping/tracking/popup.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/shipping/tracking/popup.phtml
+++ b/app/design/frontend/base/default/template/shipping/tracking/popup.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/shipping/tracking/popup.phtml
+++ b/app/design/frontend/base/default/template/shipping/tracking/popup.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/tag/cloud.phtml
+++ b/app/design/frontend/base/default/template/tag/cloud.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/tag/cloud.phtml
+++ b/app/design/frontend/base/default/template/tag/cloud.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/tag/cloud.phtml
+++ b/app/design/frontend/base/default/template/tag/cloud.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/tag/customer/recent.phtml
+++ b/app/design/frontend/base/default/template/tag/customer/recent.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/tag/customer/recent.phtml
+++ b/app/design/frontend/base/default/template/tag/customer/recent.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/tag/customer/recent.phtml
+++ b/app/design/frontend/base/default/template/tag/customer/recent.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/tag/customer/tags.phtml
+++ b/app/design/frontend/base/default/template/tag/customer/tags.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/tag/customer/tags.phtml
+++ b/app/design/frontend/base/default/template/tag/customer/tags.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/tag/customer/tags.phtml
+++ b/app/design/frontend/base/default/template/tag/customer/tags.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/tag/customer/view.phtml
+++ b/app/design/frontend/base/default/template/tag/customer/view.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/tag/customer/view.phtml
+++ b/app/design/frontend/base/default/template/tag/customer/view.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/tag/customer/view.phtml
+++ b/app/design/frontend/base/default/template/tag/customer/view.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/tag/list.phtml
+++ b/app/design/frontend/base/default/template/tag/list.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/tag/list.phtml
+++ b/app/design/frontend/base/default/template/tag/list.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/tag/list.phtml
+++ b/app/design/frontend/base/default/template/tag/list.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/tag/popular.phtml
+++ b/app/design/frontend/base/default/template/tag/popular.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/tag/popular.phtml
+++ b/app/design/frontend/base/default/template/tag/popular.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/tag/popular.phtml
+++ b/app/design/frontend/base/default/template/tag/popular.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/tax/checkout/discount.phtml
+++ b/app/design/frontend/base/default/template/tax/checkout/discount.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/tax/checkout/discount.phtml
+++ b/app/design/frontend/base/default/template/tax/checkout/discount.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/tax/checkout/discount.phtml
+++ b/app/design/frontend/base/default/template/tax/checkout/discount.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/tax/checkout/grandtotal.phtml
+++ b/app/design/frontend/base/default/template/tax/checkout/grandtotal.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/tax/checkout/grandtotal.phtml
+++ b/app/design/frontend/base/default/template/tax/checkout/grandtotal.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/tax/checkout/grandtotal.phtml
+++ b/app/design/frontend/base/default/template/tax/checkout/grandtotal.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/tax/checkout/shipping.phtml
+++ b/app/design/frontend/base/default/template/tax/checkout/shipping.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/tax/checkout/shipping.phtml
+++ b/app/design/frontend/base/default/template/tax/checkout/shipping.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/tax/checkout/shipping.phtml
+++ b/app/design/frontend/base/default/template/tax/checkout/shipping.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/tax/checkout/subtotal.phtml
+++ b/app/design/frontend/base/default/template/tax/checkout/subtotal.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/tax/checkout/subtotal.phtml
+++ b/app/design/frontend/base/default/template/tax/checkout/subtotal.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/tax/checkout/subtotal.phtml
+++ b/app/design/frontend/base/default/template/tax/checkout/subtotal.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/tax/checkout/tax.phtml
+++ b/app/design/frontend/base/default/template/tax/checkout/tax.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/tax/checkout/tax.phtml
+++ b/app/design/frontend/base/default/template/tax/checkout/tax.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/tax/checkout/tax.phtml
+++ b/app/design/frontend/base/default/template/tax/checkout/tax.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/tax/order/tax.phtml
+++ b/app/design/frontend/base/default/template/tax/order/tax.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/tax/order/tax.phtml
+++ b/app/design/frontend/base/default/template/tax/order/tax.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/tax/order/tax.phtml
+++ b/app/design/frontend/base/default/template/tax/order/tax.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/wishlist/button/share.phtml
+++ b/app/design/frontend/base/default/template/wishlist/button/share.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/wishlist/button/share.phtml
+++ b/app/design/frontend/base/default/template/wishlist/button/share.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/wishlist/button/share.phtml
+++ b/app/design/frontend/base/default/template/wishlist/button/share.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/wishlist/button/tocart.phtml
+++ b/app/design/frontend/base/default/template/wishlist/button/tocart.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/wishlist/button/tocart.phtml
+++ b/app/design/frontend/base/default/template/wishlist/button/tocart.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/wishlist/button/tocart.phtml
+++ b/app/design/frontend/base/default/template/wishlist/button/tocart.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/wishlist/button/update.phtml
+++ b/app/design/frontend/base/default/template/wishlist/button/update.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/wishlist/button/update.phtml
+++ b/app/design/frontend/base/default/template/wishlist/button/update.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/wishlist/button/update.phtml
+++ b/app/design/frontend/base/default/template/wishlist/button/update.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/wishlist/email/items.phtml
+++ b/app/design/frontend/base/default/template/wishlist/email/items.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/wishlist/email/items.phtml
+++ b/app/design/frontend/base/default/template/wishlist/email/items.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/wishlist/email/items.phtml
+++ b/app/design/frontend/base/default/template/wishlist/email/items.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/wishlist/email/rss.phtml
+++ b/app/design/frontend/base/default/template/wishlist/email/rss.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/wishlist/email/rss.phtml
+++ b/app/design/frontend/base/default/template/wishlist/email/rss.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/wishlist/email/rss.phtml
+++ b/app/design/frontend/base/default/template/wishlist/email/rss.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/wishlist/item/column/cart.phtml
+++ b/app/design/frontend/base/default/template/wishlist/item/column/cart.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/wishlist/item/column/cart.phtml
+++ b/app/design/frontend/base/default/template/wishlist/item/column/cart.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/wishlist/item/column/cart.phtml
+++ b/app/design/frontend/base/default/template/wishlist/item/column/cart.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/wishlist/item/column/image.phtml
+++ b/app/design/frontend/base/default/template/wishlist/item/column/image.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/wishlist/item/column/image.phtml
+++ b/app/design/frontend/base/default/template/wishlist/item/column/image.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/wishlist/item/column/image.phtml
+++ b/app/design/frontend/base/default/template/wishlist/item/column/image.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/wishlist/item/column/info.phtml
+++ b/app/design/frontend/base/default/template/wishlist/item/column/info.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/wishlist/item/column/info.phtml
+++ b/app/design/frontend/base/default/template/wishlist/item/column/info.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/wishlist/item/column/info.phtml
+++ b/app/design/frontend/base/default/template/wishlist/item/column/info.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/wishlist/item/column/remove.phtml
+++ b/app/design/frontend/base/default/template/wishlist/item/column/remove.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/wishlist/item/column/remove.phtml
+++ b/app/design/frontend/base/default/template/wishlist/item/column/remove.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/wishlist/item/column/remove.phtml
+++ b/app/design/frontend/base/default/template/wishlist/item/column/remove.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/wishlist/item/configure/addto.phtml
+++ b/app/design/frontend/base/default/template/wishlist/item/configure/addto.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/wishlist/item/configure/addto.phtml
+++ b/app/design/frontend/base/default/template/wishlist/item/configure/addto.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/wishlist/item/configure/addto.phtml
+++ b/app/design/frontend/base/default/template/wishlist/item/configure/addto.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/wishlist/item/list.phtml
+++ b/app/design/frontend/base/default/template/wishlist/item/list.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/wishlist/item/list.phtml
+++ b/app/design/frontend/base/default/template/wishlist/item/list.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/wishlist/item/list.phtml
+++ b/app/design/frontend/base/default/template/wishlist/item/list.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/wishlist/options_list.phtml
+++ b/app/design/frontend/base/default/template/wishlist/options_list.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/wishlist/options_list.phtml
+++ b/app/design/frontend/base/default/template/wishlist/options_list.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/wishlist/options_list.phtml
+++ b/app/design/frontend/base/default/template/wishlist/options_list.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/wishlist/render/item/price.phtml
+++ b/app/design/frontend/base/default/template/wishlist/render/item/price.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/wishlist/render/item/price.phtml
+++ b/app/design/frontend/base/default/template/wishlist/render/item/price.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/wishlist/render/item/price.phtml
+++ b/app/design/frontend/base/default/template/wishlist/render/item/price.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/wishlist/render/item/price_msrp_item.phtml
+++ b/app/design/frontend/base/default/template/wishlist/render/item/price_msrp_item.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/wishlist/render/item/price_msrp_item.phtml
+++ b/app/design/frontend/base/default/template/wishlist/render/item/price_msrp_item.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/wishlist/render/item/price_msrp_item.phtml
+++ b/app/design/frontend/base/default/template/wishlist/render/item/price_msrp_item.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/wishlist/render/item/price_msrp_rss.phtml
+++ b/app/design/frontend/base/default/template/wishlist/render/item/price_msrp_rss.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/wishlist/render/item/price_msrp_rss.phtml
+++ b/app/design/frontend/base/default/template/wishlist/render/item/price_msrp_rss.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/wishlist/render/item/price_msrp_rss.phtml
+++ b/app/design/frontend/base/default/template/wishlist/render/item/price_msrp_rss.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/wishlist/shared.phtml
+++ b/app/design/frontend/base/default/template/wishlist/shared.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/wishlist/shared.phtml
+++ b/app/design/frontend/base/default/template/wishlist/shared.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/wishlist/shared.phtml
+++ b/app/design/frontend/base/default/template/wishlist/shared.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/wishlist/sharing.phtml
+++ b/app/design/frontend/base/default/template/wishlist/sharing.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/wishlist/sharing.phtml
+++ b/app/design/frontend/base/default/template/wishlist/sharing.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/wishlist/sharing.phtml
+++ b/app/design/frontend/base/default/template/wishlist/sharing.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/wishlist/sidebar.phtml
+++ b/app/design/frontend/base/default/template/wishlist/sidebar.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/wishlist/sidebar.phtml
+++ b/app/design/frontend/base/default/template/wishlist/sidebar.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/wishlist/sidebar.phtml
+++ b/app/design/frontend/base/default/template/wishlist/sidebar.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/wishlist/view.phtml
+++ b/app/design/frontend/base/default/template/wishlist/view.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/base/default/template/wishlist/view.phtml
+++ b/app/design/frontend/base/default/template/wishlist/view.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/base/default/template/wishlist/view.phtml
+++ b/app/design/frontend/base/default/template/wishlist/view.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/app/design/frontend/rwd/default/etc/theme.xml
+++ b/app/design/frontend/rwd/default/etc/theme.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/etc/theme.xml
+++ b/app/design/frontend/rwd/default/etc/theme.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/etc/theme.xml
+++ b/app/design/frontend/rwd/default/etc/theme.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/etc/widget.xml
+++ b/app/design/frontend/rwd/default/etc/widget.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/etc/widget.xml
+++ b/app/design/frontend/rwd/default/etc/widget.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/etc/widget.xml
+++ b/app/design/frontend/rwd/default/etc/widget.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/layout/bundle.xml
+++ b/app/design/frontend/rwd/default/layout/bundle.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/layout/bundle.xml
+++ b/app/design/frontend/rwd/default/layout/bundle.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/layout/bundle.xml
+++ b/app/design/frontend/rwd/default/layout/bundle.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/layout/catalog.xml
+++ b/app/design/frontend/rwd/default/layout/catalog.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/layout/catalog.xml
+++ b/app/design/frontend/rwd/default/layout/catalog.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/layout/catalog.xml
+++ b/app/design/frontend/rwd/default/layout/catalog.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/layout/catalog_msrp.xml
+++ b/app/design/frontend/rwd/default/layout/catalog_msrp.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/layout/catalog_msrp.xml
+++ b/app/design/frontend/rwd/default/layout/catalog_msrp.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/layout/catalog_msrp.xml
+++ b/app/design/frontend/rwd/default/layout/catalog_msrp.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/layout/catalogsearch.xml
+++ b/app/design/frontend/rwd/default/layout/catalogsearch.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/layout/catalogsearch.xml
+++ b/app/design/frontend/rwd/default/layout/catalogsearch.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/layout/catalogsearch.xml
+++ b/app/design/frontend/rwd/default/layout/catalogsearch.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/layout/checkout.xml
+++ b/app/design/frontend/rwd/default/layout/checkout.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/layout/checkout.xml
+++ b/app/design/frontend/rwd/default/layout/checkout.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/layout/checkout.xml
+++ b/app/design/frontend/rwd/default/layout/checkout.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/layout/cms.xml
+++ b/app/design/frontend/rwd/default/layout/cms.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/layout/cms.xml
+++ b/app/design/frontend/rwd/default/layout/cms.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/layout/cms.xml
+++ b/app/design/frontend/rwd/default/layout/cms.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/layout/configurableswatches.xml
+++ b/app/design/frontend/rwd/default/layout/configurableswatches.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/layout/configurableswatches.xml
+++ b/app/design/frontend/rwd/default/layout/configurableswatches.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/layout/configurableswatches.xml
+++ b/app/design/frontend/rwd/default/layout/configurableswatches.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/layout/contacts.xml
+++ b/app/design/frontend/rwd/default/layout/contacts.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/layout/contacts.xml
+++ b/app/design/frontend/rwd/default/layout/contacts.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/layout/contacts.xml
+++ b/app/design/frontend/rwd/default/layout/contacts.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/layout/customer.xml
+++ b/app/design/frontend/rwd/default/layout/customer.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/layout/customer.xml
+++ b/app/design/frontend/rwd/default/layout/customer.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/layout/customer.xml
+++ b/app/design/frontend/rwd/default/layout/customer.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/layout/directory.xml
+++ b/app/design/frontend/rwd/default/layout/directory.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/layout/directory.xml
+++ b/app/design/frontend/rwd/default/layout/directory.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/layout/directory.xml
+++ b/app/design/frontend/rwd/default/layout/directory.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/layout/downloadable.xml
+++ b/app/design/frontend/rwd/default/layout/downloadable.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/layout/downloadable.xml
+++ b/app/design/frontend/rwd/default/layout/downloadable.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/layout/downloadable.xml
+++ b/app/design/frontend/rwd/default/layout/downloadable.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/layout/newsletter.xml
+++ b/app/design/frontend/rwd/default/layout/newsletter.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/layout/newsletter.xml
+++ b/app/design/frontend/rwd/default/layout/newsletter.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/layout/newsletter.xml
+++ b/app/design/frontend/rwd/default/layout/newsletter.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/layout/oauth.xml
+++ b/app/design/frontend/rwd/default/layout/oauth.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/layout/oauth.xml
+++ b/app/design/frontend/rwd/default/layout/oauth.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/layout/oauth.xml
+++ b/app/design/frontend/rwd/default/layout/oauth.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/layout/page.xml
+++ b/app/design/frontend/rwd/default/layout/page.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/layout/page.xml
+++ b/app/design/frontend/rwd/default/layout/page.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/layout/page.xml
+++ b/app/design/frontend/rwd/default/layout/page.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/layout/paypal.xml
+++ b/app/design/frontend/rwd/default/layout/paypal.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/layout/paypal.xml
+++ b/app/design/frontend/rwd/default/layout/paypal.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/layout/paypal.xml
+++ b/app/design/frontend/rwd/default/layout/paypal.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/layout/persistent.xml
+++ b/app/design/frontend/rwd/default/layout/persistent.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/layout/persistent.xml
+++ b/app/design/frontend/rwd/default/layout/persistent.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/layout/persistent.xml
+++ b/app/design/frontend/rwd/default/layout/persistent.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/layout/review.xml
+++ b/app/design/frontend/rwd/default/layout/review.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/layout/review.xml
+++ b/app/design/frontend/rwd/default/layout/review.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/layout/review.xml
+++ b/app/design/frontend/rwd/default/layout/review.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/layout/rss.xml
+++ b/app/design/frontend/rwd/default/layout/rss.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/layout/rss.xml
+++ b/app/design/frontend/rwd/default/layout/rss.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/layout/rss.xml
+++ b/app/design/frontend/rwd/default/layout/rss.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/layout/sales.xml
+++ b/app/design/frontend/rwd/default/layout/sales.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/layout/sales.xml
+++ b/app/design/frontend/rwd/default/layout/sales.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/layout/sales.xml
+++ b/app/design/frontend/rwd/default/layout/sales.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/layout/wishlist.xml
+++ b/app/design/frontend/rwd/default/layout/wishlist.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/layout/wishlist.xml
+++ b/app/design/frontend/rwd/default/layout/wishlist.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/layout/wishlist.xml
+++ b/app/design/frontend/rwd/default/layout/wishlist.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/authorizenet/directpost/form.phtml
+++ b/app/design/frontend/rwd/default/template/authorizenet/directpost/form.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/authorizenet/directpost/form.phtml
+++ b/app/design/frontend/rwd/default/template/authorizenet/directpost/form.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/authorizenet/directpost/form.phtml
+++ b/app/design/frontend/rwd/default/template/authorizenet/directpost/form.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/bundle/catalog/product/view/type/bundle.phtml
+++ b/app/design/frontend/rwd/default/template/bundle/catalog/product/view/type/bundle.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/bundle/catalog/product/view/type/bundle.phtml
+++ b/app/design/frontend/rwd/default/template/bundle/catalog/product/view/type/bundle.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/bundle/catalog/product/view/type/bundle.phtml
+++ b/app/design/frontend/rwd/default/template/bundle/catalog/product/view/type/bundle.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/bundle/catalog/product/view/type/bundle/availability.phtml
+++ b/app/design/frontend/rwd/default/template/bundle/catalog/product/view/type/bundle/availability.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/bundle/catalog/product/view/type/bundle/availability.phtml
+++ b/app/design/frontend/rwd/default/template/bundle/catalog/product/view/type/bundle/availability.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/bundle/catalog/product/view/type/bundle/availability.phtml
+++ b/app/design/frontend/rwd/default/template/bundle/catalog/product/view/type/bundle/availability.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/bundle/catalog/product/view/type/bundle/option/select.phtml
+++ b/app/design/frontend/rwd/default/template/bundle/catalog/product/view/type/bundle/option/select.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/bundle/catalog/product/view/type/bundle/option/select.phtml
+++ b/app/design/frontend/rwd/default/template/bundle/catalog/product/view/type/bundle/option/select.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/bundle/catalog/product/view/type/bundle/option/select.phtml
+++ b/app/design/frontend/rwd/default/template/bundle/catalog/product/view/type/bundle/option/select.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/bundle/email/order/items/creditmemo/default.phtml
+++ b/app/design/frontend/rwd/default/template/bundle/email/order/items/creditmemo/default.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/bundle/email/order/items/creditmemo/default.phtml
+++ b/app/design/frontend/rwd/default/template/bundle/email/order/items/creditmemo/default.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/bundle/email/order/items/creditmemo/default.phtml
+++ b/app/design/frontend/rwd/default/template/bundle/email/order/items/creditmemo/default.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/bundle/email/order/items/invoice/default.phtml
+++ b/app/design/frontend/rwd/default/template/bundle/email/order/items/invoice/default.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/bundle/email/order/items/invoice/default.phtml
+++ b/app/design/frontend/rwd/default/template/bundle/email/order/items/invoice/default.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/bundle/email/order/items/invoice/default.phtml
+++ b/app/design/frontend/rwd/default/template/bundle/email/order/items/invoice/default.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/bundle/email/order/items/order/default.phtml
+++ b/app/design/frontend/rwd/default/template/bundle/email/order/items/order/default.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/bundle/email/order/items/order/default.phtml
+++ b/app/design/frontend/rwd/default/template/bundle/email/order/items/order/default.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/bundle/email/order/items/order/default.phtml
+++ b/app/design/frontend/rwd/default/template/bundle/email/order/items/order/default.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/bundle/email/order/items/shipment/default.phtml
+++ b/app/design/frontend/rwd/default/template/bundle/email/order/items/shipment/default.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/bundle/email/order/items/shipment/default.phtml
+++ b/app/design/frontend/rwd/default/template/bundle/email/order/items/shipment/default.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/bundle/email/order/items/shipment/default.phtml
+++ b/app/design/frontend/rwd/default/template/bundle/email/order/items/shipment/default.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/bundle/sales/order/items/renderer.phtml
+++ b/app/design/frontend/rwd/default/template/bundle/sales/order/items/renderer.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/bundle/sales/order/items/renderer.phtml
+++ b/app/design/frontend/rwd/default/template/bundle/sales/order/items/renderer.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/bundle/sales/order/items/renderer.phtml
+++ b/app/design/frontend/rwd/default/template/bundle/sales/order/items/renderer.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/captcha/zend.phtml
+++ b/app/design/frontend/rwd/default/template/captcha/zend.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/captcha/zend.phtml
+++ b/app/design/frontend/rwd/default/template/captcha/zend.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/captcha/zend.phtml
+++ b/app/design/frontend/rwd/default/template/captcha/zend.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/catalog/layer/filter.phtml
+++ b/app/design/frontend/rwd/default/template/catalog/layer/filter.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/catalog/layer/filter.phtml
+++ b/app/design/frontend/rwd/default/template/catalog/layer/filter.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/catalog/layer/filter.phtml
+++ b/app/design/frontend/rwd/default/template/catalog/layer/filter.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/catalog/layer/state.phtml
+++ b/app/design/frontend/rwd/default/template/catalog/layer/state.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/catalog/layer/state.phtml
+++ b/app/design/frontend/rwd/default/template/catalog/layer/state.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/catalog/layer/state.phtml
+++ b/app/design/frontend/rwd/default/template/catalog/layer/state.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/catalog/layer/view.phtml
+++ b/app/design/frontend/rwd/default/template/catalog/layer/view.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/catalog/layer/view.phtml
+++ b/app/design/frontend/rwd/default/template/catalog/layer/view.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/catalog/layer/view.phtml
+++ b/app/design/frontend/rwd/default/template/catalog/layer/view.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/catalog/msrp/popup.phtml
+++ b/app/design/frontend/rwd/default/template/catalog/msrp/popup.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/catalog/msrp/popup.phtml
+++ b/app/design/frontend/rwd/default/template/catalog/msrp/popup.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/catalog/msrp/popup.phtml
+++ b/app/design/frontend/rwd/default/template/catalog/msrp/popup.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/catalog/navigation/left.phtml
+++ b/app/design/frontend/rwd/default/template/catalog/navigation/left.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/catalog/navigation/left.phtml
+++ b/app/design/frontend/rwd/default/template/catalog/navigation/left.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/catalog/navigation/left.phtml
+++ b/app/design/frontend/rwd/default/template/catalog/navigation/left.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/catalog/product/compare/list.phtml
+++ b/app/design/frontend/rwd/default/template/catalog/product/compare/list.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/catalog/product/compare/list.phtml
+++ b/app/design/frontend/rwd/default/template/catalog/product/compare/list.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/catalog/product/compare/list.phtml
+++ b/app/design/frontend/rwd/default/template/catalog/product/compare/list.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/catalog/product/compare/sidebar.phtml
+++ b/app/design/frontend/rwd/default/template/catalog/product/compare/sidebar.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/catalog/product/compare/sidebar.phtml
+++ b/app/design/frontend/rwd/default/template/catalog/product/compare/sidebar.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/catalog/product/compare/sidebar.phtml
+++ b/app/design/frontend/rwd/default/template/catalog/product/compare/sidebar.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/catalog/product/list.phtml
+++ b/app/design/frontend/rwd/default/template/catalog/product/list.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/catalog/product/list.phtml
+++ b/app/design/frontend/rwd/default/template/catalog/product/list.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/catalog/product/list.phtml
+++ b/app/design/frontend/rwd/default/template/catalog/product/list.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/catalog/product/list/related.phtml
+++ b/app/design/frontend/rwd/default/template/catalog/product/list/related.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/catalog/product/list/related.phtml
+++ b/app/design/frontend/rwd/default/template/catalog/product/list/related.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/catalog/product/list/related.phtml
+++ b/app/design/frontend/rwd/default/template/catalog/product/list/related.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/catalog/product/list/toolbar.phtml
+++ b/app/design/frontend/rwd/default/template/catalog/product/list/toolbar.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/catalog/product/list/toolbar.phtml
+++ b/app/design/frontend/rwd/default/template/catalog/product/list/toolbar.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/catalog/product/list/toolbar.phtml
+++ b/app/design/frontend/rwd/default/template/catalog/product/list/toolbar.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/catalog/product/list/upsell.phtml
+++ b/app/design/frontend/rwd/default/template/catalog/product/list/upsell.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/catalog/product/list/upsell.phtml
+++ b/app/design/frontend/rwd/default/template/catalog/product/list/upsell.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/catalog/product/list/upsell.phtml
+++ b/app/design/frontend/rwd/default/template/catalog/product/list/upsell.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/catalog/product/price.phtml
+++ b/app/design/frontend/rwd/default/template/catalog/product/price.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/catalog/product/price.phtml
+++ b/app/design/frontend/rwd/default/template/catalog/product/price.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/catalog/product/price.phtml
+++ b/app/design/frontend/rwd/default/template/catalog/product/price.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/catalog/product/view.phtml
+++ b/app/design/frontend/rwd/default/template/catalog/product/view.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/catalog/product/view.phtml
+++ b/app/design/frontend/rwd/default/template/catalog/product/view.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/catalog/product/view.phtml
+++ b/app/design/frontend/rwd/default/template/catalog/product/view.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/catalog/product/view/addto.phtml
+++ b/app/design/frontend/rwd/default/template/catalog/product/view/addto.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/catalog/product/view/addto.phtml
+++ b/app/design/frontend/rwd/default/template/catalog/product/view/addto.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/catalog/product/view/addto.phtml
+++ b/app/design/frontend/rwd/default/template/catalog/product/view/addto.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/catalog/product/view/addtocart.phtml
+++ b/app/design/frontend/rwd/default/template/catalog/product/view/addtocart.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/catalog/product/view/addtocart.phtml
+++ b/app/design/frontend/rwd/default/template/catalog/product/view/addtocart.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/catalog/product/view/addtocart.phtml
+++ b/app/design/frontend/rwd/default/template/catalog/product/view/addtocart.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/catalog/product/view/media.phtml
+++ b/app/design/frontend/rwd/default/template/catalog/product/view/media.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/catalog/product/view/media.phtml
+++ b/app/design/frontend/rwd/default/template/catalog/product/view/media.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/catalog/product/view/media.phtml
+++ b/app/design/frontend/rwd/default/template/catalog/product/view/media.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/catalog/product/view/sharing.phtml
+++ b/app/design/frontend/rwd/default/template/catalog/product/view/sharing.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/catalog/product/view/sharing.phtml
+++ b/app/design/frontend/rwd/default/template/catalog/product/view/sharing.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/catalog/product/view/sharing.phtml
+++ b/app/design/frontend/rwd/default/template/catalog/product/view/sharing.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/catalog/product/view/type/availability/default.phtml
+++ b/app/design/frontend/rwd/default/template/catalog/product/view/type/availability/default.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/catalog/product/view/type/availability/default.phtml
+++ b/app/design/frontend/rwd/default/template/catalog/product/view/type/availability/default.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/catalog/product/view/type/availability/default.phtml
+++ b/app/design/frontend/rwd/default/template/catalog/product/view/type/availability/default.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/catalog/product/view/type/availability/grouped.phtml
+++ b/app/design/frontend/rwd/default/template/catalog/product/view/type/availability/grouped.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/catalog/product/view/type/availability/grouped.phtml
+++ b/app/design/frontend/rwd/default/template/catalog/product/view/type/availability/grouped.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/catalog/product/view/type/availability/grouped.phtml
+++ b/app/design/frontend/rwd/default/template/catalog/product/view/type/availability/grouped.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/catalog/product/view/type/default.phtml
+++ b/app/design/frontend/rwd/default/template/catalog/product/view/type/default.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/catalog/product/view/type/default.phtml
+++ b/app/design/frontend/rwd/default/template/catalog/product/view/type/default.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/catalog/product/view/type/default.phtml
+++ b/app/design/frontend/rwd/default/template/catalog/product/view/type/default.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/catalog/product/view/type/grouped.phtml
+++ b/app/design/frontend/rwd/default/template/catalog/product/view/type/grouped.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/catalog/product/view/type/grouped.phtml
+++ b/app/design/frontend/rwd/default/template/catalog/product/view/type/grouped.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/catalog/product/view/type/grouped.phtml
+++ b/app/design/frontend/rwd/default/template/catalog/product/view/type/grouped.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/catalog/product/view/type/options/configurable.phtml
+++ b/app/design/frontend/rwd/default/template/catalog/product/view/type/options/configurable.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/catalog/product/view/type/options/configurable.phtml
+++ b/app/design/frontend/rwd/default/template/catalog/product/view/type/options/configurable.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/catalog/product/view/type/options/configurable.phtml
+++ b/app/design/frontend/rwd/default/template/catalog/product/view/type/options/configurable.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/catalog/product/widget/new/column/new_default_list.phtml
+++ b/app/design/frontend/rwd/default/template/catalog/product/widget/new/column/new_default_list.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/catalog/product/widget/new/column/new_default_list.phtml
+++ b/app/design/frontend/rwd/default/template/catalog/product/widget/new/column/new_default_list.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/catalog/product/widget/new/column/new_default_list.phtml
+++ b/app/design/frontend/rwd/default/template/catalog/product/widget/new/column/new_default_list.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/catalog/product/widget/new/column/new_images_list.phtml
+++ b/app/design/frontend/rwd/default/template/catalog/product/widget/new/column/new_images_list.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/catalog/product/widget/new/column/new_images_list.phtml
+++ b/app/design/frontend/rwd/default/template/catalog/product/widget/new/column/new_images_list.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/catalog/product/widget/new/column/new_images_list.phtml
+++ b/app/design/frontend/rwd/default/template/catalog/product/widget/new/column/new_images_list.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/catalog/product/widget/new/column/new_names_list.phtml
+++ b/app/design/frontend/rwd/default/template/catalog/product/widget/new/column/new_names_list.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/catalog/product/widget/new/column/new_names_list.phtml
+++ b/app/design/frontend/rwd/default/template/catalog/product/widget/new/column/new_names_list.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/catalog/product/widget/new/column/new_names_list.phtml
+++ b/app/design/frontend/rwd/default/template/catalog/product/widget/new/column/new_names_list.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/catalog/product/widget/new/content/new_grid.phtml
+++ b/app/design/frontend/rwd/default/template/catalog/product/widget/new/content/new_grid.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/catalog/product/widget/new/content/new_grid.phtml
+++ b/app/design/frontend/rwd/default/template/catalog/product/widget/new/content/new_grid.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/catalog/product/widget/new/content/new_grid.phtml
+++ b/app/design/frontend/rwd/default/template/catalog/product/widget/new/content/new_grid.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/catalog/product/widget/new/content/new_list.phtml
+++ b/app/design/frontend/rwd/default/template/catalog/product/widget/new/content/new_list.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/catalog/product/widget/new/content/new_list.phtml
+++ b/app/design/frontend/rwd/default/template/catalog/product/widget/new/content/new_list.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/catalog/product/widget/new/content/new_list.phtml
+++ b/app/design/frontend/rwd/default/template/catalog/product/widget/new/content/new_list.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/cataloginventory/stockqty/composite.phtml
+++ b/app/design/frontend/rwd/default/template/cataloginventory/stockqty/composite.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/cataloginventory/stockqty/composite.phtml
+++ b/app/design/frontend/rwd/default/template/cataloginventory/stockqty/composite.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/cataloginventory/stockqty/composite.phtml
+++ b/app/design/frontend/rwd/default/template/cataloginventory/stockqty/composite.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/catalogsearch/advanced/form.phtml
+++ b/app/design/frontend/rwd/default/template/catalogsearch/advanced/form.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/catalogsearch/advanced/form.phtml
+++ b/app/design/frontend/rwd/default/template/catalogsearch/advanced/form.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/catalogsearch/advanced/form.phtml
+++ b/app/design/frontend/rwd/default/template/catalogsearch/advanced/form.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/catalogsearch/form.mini.phtml
+++ b/app/design/frontend/rwd/default/template/catalogsearch/form.mini.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/catalogsearch/form.mini.phtml
+++ b/app/design/frontend/rwd/default/template/catalogsearch/form.mini.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/catalogsearch/form.mini.phtml
+++ b/app/design/frontend/rwd/default/template/catalogsearch/form.mini.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/catalogsearch/result.phtml
+++ b/app/design/frontend/rwd/default/template/catalogsearch/result.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/catalogsearch/result.phtml
+++ b/app/design/frontend/rwd/default/template/catalogsearch/result.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/catalogsearch/result.phtml
+++ b/app/design/frontend/rwd/default/template/catalogsearch/result.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/centinel/authentication/start.phtml
+++ b/app/design/frontend/rwd/default/template/centinel/authentication/start.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/centinel/authentication/start.phtml
+++ b/app/design/frontend/rwd/default/template/centinel/authentication/start.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/centinel/authentication/start.phtml
+++ b/app/design/frontend/rwd/default/template/centinel/authentication/start.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/checkout/cart.phtml
+++ b/app/design/frontend/rwd/default/template/checkout/cart.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/checkout/cart.phtml
+++ b/app/design/frontend/rwd/default/template/checkout/cart.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/checkout/cart.phtml
+++ b/app/design/frontend/rwd/default/template/checkout/cart.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/checkout/cart/coupon.phtml
+++ b/app/design/frontend/rwd/default/template/checkout/cart/coupon.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/checkout/cart/coupon.phtml
+++ b/app/design/frontend/rwd/default/template/checkout/cart/coupon.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/checkout/cart/coupon.phtml
+++ b/app/design/frontend/rwd/default/template/checkout/cart/coupon.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/checkout/cart/crosssell.phtml
+++ b/app/design/frontend/rwd/default/template/checkout/cart/crosssell.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/checkout/cart/crosssell.phtml
+++ b/app/design/frontend/rwd/default/template/checkout/cart/crosssell.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/checkout/cart/crosssell.phtml
+++ b/app/design/frontend/rwd/default/template/checkout/cart/crosssell.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/checkout/cart/item/configure/updatecart.phtml
+++ b/app/design/frontend/rwd/default/template/checkout/cart/item/configure/updatecart.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/checkout/cart/item/configure/updatecart.phtml
+++ b/app/design/frontend/rwd/default/template/checkout/cart/item/configure/updatecart.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/checkout/cart/item/configure/updatecart.phtml
+++ b/app/design/frontend/rwd/default/template/checkout/cart/item/configure/updatecart.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/checkout/cart/item/default.phtml
+++ b/app/design/frontend/rwd/default/template/checkout/cart/item/default.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/checkout/cart/item/default.phtml
+++ b/app/design/frontend/rwd/default/template/checkout/cart/item/default.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/checkout/cart/item/default.phtml
+++ b/app/design/frontend/rwd/default/template/checkout/cart/item/default.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/checkout/cart/minicart.phtml
+++ b/app/design/frontend/rwd/default/template/checkout/cart/minicart.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/checkout/cart/minicart.phtml
+++ b/app/design/frontend/rwd/default/template/checkout/cart/minicart.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/checkout/cart/minicart.phtml
+++ b/app/design/frontend/rwd/default/template/checkout/cart/minicart.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/checkout/cart/minicart/default.phtml
+++ b/app/design/frontend/rwd/default/template/checkout/cart/minicart/default.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/checkout/cart/minicart/default.phtml
+++ b/app/design/frontend/rwd/default/template/checkout/cart/minicart/default.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/checkout/cart/minicart/default.phtml
+++ b/app/design/frontend/rwd/default/template/checkout/cart/minicart/default.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/checkout/cart/minicart/items.phtml
+++ b/app/design/frontend/rwd/default/template/checkout/cart/minicart/items.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/checkout/cart/minicart/items.phtml
+++ b/app/design/frontend/rwd/default/template/checkout/cart/minicart/items.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/checkout/cart/minicart/items.phtml
+++ b/app/design/frontend/rwd/default/template/checkout/cart/minicart/items.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/checkout/cart/render/default.phtml
+++ b/app/design/frontend/rwd/default/template/checkout/cart/render/default.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/checkout/cart/render/default.phtml
+++ b/app/design/frontend/rwd/default/template/checkout/cart/render/default.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/checkout/cart/render/default.phtml
+++ b/app/design/frontend/rwd/default/template/checkout/cart/render/default.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/checkout/cart/render/simple.phtml
+++ b/app/design/frontend/rwd/default/template/checkout/cart/render/simple.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/checkout/cart/render/simple.phtml
+++ b/app/design/frontend/rwd/default/template/checkout/cart/render/simple.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/checkout/cart/render/simple.phtml
+++ b/app/design/frontend/rwd/default/template/checkout/cart/render/simple.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/checkout/cart/shipping.phtml
+++ b/app/design/frontend/rwd/default/template/checkout/cart/shipping.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/checkout/cart/shipping.phtml
+++ b/app/design/frontend/rwd/default/template/checkout/cart/shipping.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/checkout/cart/shipping.phtml
+++ b/app/design/frontend/rwd/default/template/checkout/cart/shipping.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/checkout/cart/sidebar.phtml
+++ b/app/design/frontend/rwd/default/template/checkout/cart/sidebar.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/checkout/cart/sidebar.phtml
+++ b/app/design/frontend/rwd/default/template/checkout/cart/sidebar.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/checkout/cart/sidebar.phtml
+++ b/app/design/frontend/rwd/default/template/checkout/cart/sidebar.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/checkout/cart/sidebar/default.phtml
+++ b/app/design/frontend/rwd/default/template/checkout/cart/sidebar/default.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/checkout/cart/sidebar/default.phtml
+++ b/app/design/frontend/rwd/default/template/checkout/cart/sidebar/default.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/checkout/cart/sidebar/default.phtml
+++ b/app/design/frontend/rwd/default/template/checkout/cart/sidebar/default.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/checkout/multishipping/addresses.phtml
+++ b/app/design/frontend/rwd/default/template/checkout/multishipping/addresses.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/checkout/multishipping/addresses.phtml
+++ b/app/design/frontend/rwd/default/template/checkout/multishipping/addresses.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/checkout/multishipping/addresses.phtml
+++ b/app/design/frontend/rwd/default/template/checkout/multishipping/addresses.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/checkout/multishipping/billing.phtml
+++ b/app/design/frontend/rwd/default/template/checkout/multishipping/billing.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/checkout/multishipping/billing.phtml
+++ b/app/design/frontend/rwd/default/template/checkout/multishipping/billing.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/checkout/multishipping/billing.phtml
+++ b/app/design/frontend/rwd/default/template/checkout/multishipping/billing.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/checkout/multishipping/item/default.phtml
+++ b/app/design/frontend/rwd/default/template/checkout/multishipping/item/default.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/checkout/multishipping/item/default.phtml
+++ b/app/design/frontend/rwd/default/template/checkout/multishipping/item/default.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/checkout/multishipping/item/default.phtml
+++ b/app/design/frontend/rwd/default/template/checkout/multishipping/item/default.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/checkout/multishipping/overview.phtml
+++ b/app/design/frontend/rwd/default/template/checkout/multishipping/overview.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/checkout/multishipping/overview.phtml
+++ b/app/design/frontend/rwd/default/template/checkout/multishipping/overview.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/checkout/multishipping/overview.phtml
+++ b/app/design/frontend/rwd/default/template/checkout/multishipping/overview.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/checkout/multishipping/overview/item.phtml
+++ b/app/design/frontend/rwd/default/template/checkout/multishipping/overview/item.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/checkout/multishipping/overview/item.phtml
+++ b/app/design/frontend/rwd/default/template/checkout/multishipping/overview/item.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/checkout/multishipping/overview/item.phtml
+++ b/app/design/frontend/rwd/default/template/checkout/multishipping/overview/item.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/checkout/onepage.phtml
+++ b/app/design/frontend/rwd/default/template/checkout/onepage.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/checkout/onepage.phtml
+++ b/app/design/frontend/rwd/default/template/checkout/onepage.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/checkout/onepage.phtml
+++ b/app/design/frontend/rwd/default/template/checkout/onepage.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/checkout/onepage/payment.phtml
+++ b/app/design/frontend/rwd/default/template/checkout/onepage/payment.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/checkout/onepage/payment.phtml
+++ b/app/design/frontend/rwd/default/template/checkout/onepage/payment.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/checkout/onepage/payment.phtml
+++ b/app/design/frontend/rwd/default/template/checkout/onepage/payment.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/checkout/onepage/progress.phtml
+++ b/app/design/frontend/rwd/default/template/checkout/onepage/progress.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/checkout/onepage/progress.phtml
+++ b/app/design/frontend/rwd/default/template/checkout/onepage/progress.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/checkout/onepage/progress.phtml
+++ b/app/design/frontend/rwd/default/template/checkout/onepage/progress.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/checkout/onepage/review/info.phtml
+++ b/app/design/frontend/rwd/default/template/checkout/onepage/review/info.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/checkout/onepage/review/info.phtml
+++ b/app/design/frontend/rwd/default/template/checkout/onepage/review/info.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/checkout/onepage/review/info.phtml
+++ b/app/design/frontend/rwd/default/template/checkout/onepage/review/info.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/checkout/onepage/review/item.phtml
+++ b/app/design/frontend/rwd/default/template/checkout/onepage/review/item.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/checkout/onepage/review/item.phtml
+++ b/app/design/frontend/rwd/default/template/checkout/onepage/review/item.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/checkout/onepage/review/item.phtml
+++ b/app/design/frontend/rwd/default/template/checkout/onepage/review/item.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/checkout/onepage/shipping.phtml
+++ b/app/design/frontend/rwd/default/template/checkout/onepage/shipping.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/checkout/onepage/shipping.phtml
+++ b/app/design/frontend/rwd/default/template/checkout/onepage/shipping.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/checkout/onepage/shipping.phtml
+++ b/app/design/frontend/rwd/default/template/checkout/onepage/shipping.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/configurableswatches/catalog/layer/filter/swatches.phtml
+++ b/app/design/frontend/rwd/default/template/configurableswatches/catalog/layer/filter/swatches.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/configurableswatches/catalog/layer/filter/swatches.phtml
+++ b/app/design/frontend/rwd/default/template/configurableswatches/catalog/layer/filter/swatches.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/configurableswatches/catalog/layer/filter/swatches.phtml
+++ b/app/design/frontend/rwd/default/template/configurableswatches/catalog/layer/filter/swatches.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/configurableswatches/catalog/layer/state/swatch.phtml
+++ b/app/design/frontend/rwd/default/template/configurableswatches/catalog/layer/state/swatch.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/configurableswatches/catalog/layer/state/swatch.phtml
+++ b/app/design/frontend/rwd/default/template/configurableswatches/catalog/layer/state/swatch.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/configurableswatches/catalog/layer/state/swatch.phtml
+++ b/app/design/frontend/rwd/default/template/configurableswatches/catalog/layer/state/swatch.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/configurableswatches/catalog/media/js.phtml
+++ b/app/design/frontend/rwd/default/template/configurableswatches/catalog/media/js.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/configurableswatches/catalog/media/js.phtml
+++ b/app/design/frontend/rwd/default/template/configurableswatches/catalog/media/js.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/configurableswatches/catalog/media/js.phtml
+++ b/app/design/frontend/rwd/default/template/configurableswatches/catalog/media/js.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/configurableswatches/catalog/product/list/price/js.phtml
+++ b/app/design/frontend/rwd/default/template/configurableswatches/catalog/product/list/price/js.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/configurableswatches/catalog/product/list/price/js.phtml
+++ b/app/design/frontend/rwd/default/template/configurableswatches/catalog/product/list/price/js.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/configurableswatches/catalog/product/list/price/js.phtml
+++ b/app/design/frontend/rwd/default/template/configurableswatches/catalog/product/list/price/js.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/configurableswatches/catalog/product/list/swatches.phtml
+++ b/app/design/frontend/rwd/default/template/configurableswatches/catalog/product/list/swatches.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/configurableswatches/catalog/product/list/swatches.phtml
+++ b/app/design/frontend/rwd/default/template/configurableswatches/catalog/product/list/swatches.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/configurableswatches/catalog/product/list/swatches.phtml
+++ b/app/design/frontend/rwd/default/template/configurableswatches/catalog/product/list/swatches.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/configurableswatches/catalog/product/view/type/configurable/swatch-js.phtml
+++ b/app/design/frontend/rwd/default/template/configurableswatches/catalog/product/view/type/configurable/swatch-js.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/configurableswatches/catalog/product/view/type/configurable/swatch-js.phtml
+++ b/app/design/frontend/rwd/default/template/configurableswatches/catalog/product/view/type/configurable/swatch-js.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/configurableswatches/catalog/product/view/type/configurable/swatch-js.phtml
+++ b/app/design/frontend/rwd/default/template/configurableswatches/catalog/product/view/type/configurable/swatch-js.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/configurableswatches/catalog/product/view/type/options/configurable/swatches.phtml
+++ b/app/design/frontend/rwd/default/template/configurableswatches/catalog/product/view/type/options/configurable/swatches.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/configurableswatches/catalog/product/view/type/options/configurable/swatches.phtml
+++ b/app/design/frontend/rwd/default/template/configurableswatches/catalog/product/view/type/options/configurable/swatches.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/configurableswatches/catalog/product/view/type/options/configurable/swatches.phtml
+++ b/app/design/frontend/rwd/default/template/configurableswatches/catalog/product/view/type/options/configurable/swatches.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/contacts/form.phtml
+++ b/app/design/frontend/rwd/default/template/contacts/form.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/contacts/form.phtml
+++ b/app/design/frontend/rwd/default/template/contacts/form.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/contacts/form.phtml
+++ b/app/design/frontend/rwd/default/template/contacts/form.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/customer/account/dashboard.phtml
+++ b/app/design/frontend/rwd/default/template/customer/account/dashboard.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/customer/account/dashboard.phtml
+++ b/app/design/frontend/rwd/default/template/customer/account/dashboard.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/customer/account/dashboard.phtml
+++ b/app/design/frontend/rwd/default/template/customer/account/dashboard.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/customer/account/dashboard/address.phtml
+++ b/app/design/frontend/rwd/default/template/customer/account/dashboard/address.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/customer/account/dashboard/address.phtml
+++ b/app/design/frontend/rwd/default/template/customer/account/dashboard/address.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/customer/account/dashboard/address.phtml
+++ b/app/design/frontend/rwd/default/template/customer/account/dashboard/address.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/customer/account/navigation.phtml
+++ b/app/design/frontend/rwd/default/template/customer/account/navigation.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/customer/account/navigation.phtml
+++ b/app/design/frontend/rwd/default/template/customer/account/navigation.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/customer/account/navigation.phtml
+++ b/app/design/frontend/rwd/default/template/customer/account/navigation.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/customer/address/edit.phtml
+++ b/app/design/frontend/rwd/default/template/customer/address/edit.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/customer/address/edit.phtml
+++ b/app/design/frontend/rwd/default/template/customer/address/edit.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/customer/address/edit.phtml
+++ b/app/design/frontend/rwd/default/template/customer/address/edit.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/customer/form/address.phtml
+++ b/app/design/frontend/rwd/default/template/customer/form/address.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/customer/form/address.phtml
+++ b/app/design/frontend/rwd/default/template/customer/form/address.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/customer/form/address.phtml
+++ b/app/design/frontend/rwd/default/template/customer/form/address.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/customer/form/changepassword.phtml
+++ b/app/design/frontend/rwd/default/template/customer/form/changepassword.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/customer/form/changepassword.phtml
+++ b/app/design/frontend/rwd/default/template/customer/form/changepassword.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/customer/form/changepassword.phtml
+++ b/app/design/frontend/rwd/default/template/customer/form/changepassword.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/customer/form/confirmation.phtml
+++ b/app/design/frontend/rwd/default/template/customer/form/confirmation.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/customer/form/confirmation.phtml
+++ b/app/design/frontend/rwd/default/template/customer/form/confirmation.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/customer/form/confirmation.phtml
+++ b/app/design/frontend/rwd/default/template/customer/form/confirmation.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/customer/form/edit.phtml
+++ b/app/design/frontend/rwd/default/template/customer/form/edit.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/customer/form/edit.phtml
+++ b/app/design/frontend/rwd/default/template/customer/form/edit.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/customer/form/edit.phtml
+++ b/app/design/frontend/rwd/default/template/customer/form/edit.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/customer/form/forgotpassword.phtml
+++ b/app/design/frontend/rwd/default/template/customer/form/forgotpassword.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/customer/form/forgotpassword.phtml
+++ b/app/design/frontend/rwd/default/template/customer/form/forgotpassword.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/customer/form/forgotpassword.phtml
+++ b/app/design/frontend/rwd/default/template/customer/form/forgotpassword.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/customer/form/mini.login.phtml
+++ b/app/design/frontend/rwd/default/template/customer/form/mini.login.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/customer/form/mini.login.phtml
+++ b/app/design/frontend/rwd/default/template/customer/form/mini.login.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/customer/form/mini.login.phtml
+++ b/app/design/frontend/rwd/default/template/customer/form/mini.login.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/customer/form/resetforgottenpassword.phtml
+++ b/app/design/frontend/rwd/default/template/customer/form/resetforgottenpassword.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/customer/form/resetforgottenpassword.phtml
+++ b/app/design/frontend/rwd/default/template/customer/form/resetforgottenpassword.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/customer/form/resetforgottenpassword.phtml
+++ b/app/design/frontend/rwd/default/template/customer/form/resetforgottenpassword.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/directory/currency.phtml
+++ b/app/design/frontend/rwd/default/template/directory/currency.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/directory/currency.phtml
+++ b/app/design/frontend/rwd/default/template/directory/currency.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/directory/currency.phtml
+++ b/app/design/frontend/rwd/default/template/directory/currency.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/downloadable/catalog/product/type.phtml
+++ b/app/design/frontend/rwd/default/template/downloadable/catalog/product/type.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/downloadable/catalog/product/type.phtml
+++ b/app/design/frontend/rwd/default/template/downloadable/catalog/product/type.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/downloadable/catalog/product/type.phtml
+++ b/app/design/frontend/rwd/default/template/downloadable/catalog/product/type.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/downloadable/checkout/cart/item/default.phtml
+++ b/app/design/frontend/rwd/default/template/downloadable/checkout/cart/item/default.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/downloadable/checkout/cart/item/default.phtml
+++ b/app/design/frontend/rwd/default/template/downloadable/checkout/cart/item/default.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/downloadable/checkout/cart/item/default.phtml
+++ b/app/design/frontend/rwd/default/template/downloadable/checkout/cart/item/default.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/downloadable/checkout/onepage/review/item.phtml
+++ b/app/design/frontend/rwd/default/template/downloadable/checkout/onepage/review/item.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/downloadable/checkout/onepage/review/item.phtml
+++ b/app/design/frontend/rwd/default/template/downloadable/checkout/onepage/review/item.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/downloadable/checkout/onepage/review/item.phtml
+++ b/app/design/frontend/rwd/default/template/downloadable/checkout/onepage/review/item.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/downloadable/customer/products/list.phtml
+++ b/app/design/frontend/rwd/default/template/downloadable/customer/products/list.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/downloadable/customer/products/list.phtml
+++ b/app/design/frontend/rwd/default/template/downloadable/customer/products/list.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/downloadable/customer/products/list.phtml
+++ b/app/design/frontend/rwd/default/template/downloadable/customer/products/list.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/downloadable/email/order/items/creditmemo/downloadable.phtml
+++ b/app/design/frontend/rwd/default/template/downloadable/email/order/items/creditmemo/downloadable.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/downloadable/email/order/items/creditmemo/downloadable.phtml
+++ b/app/design/frontend/rwd/default/template/downloadable/email/order/items/creditmemo/downloadable.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/downloadable/email/order/items/creditmemo/downloadable.phtml
+++ b/app/design/frontend/rwd/default/template/downloadable/email/order/items/creditmemo/downloadable.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/downloadable/email/order/items/invoice/downloadable.phtml
+++ b/app/design/frontend/rwd/default/template/downloadable/email/order/items/invoice/downloadable.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/downloadable/email/order/items/invoice/downloadable.phtml
+++ b/app/design/frontend/rwd/default/template/downloadable/email/order/items/invoice/downloadable.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/downloadable/email/order/items/invoice/downloadable.phtml
+++ b/app/design/frontend/rwd/default/template/downloadable/email/order/items/invoice/downloadable.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/downloadable/email/order/items/order/downloadable.phtml
+++ b/app/design/frontend/rwd/default/template/downloadable/email/order/items/order/downloadable.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/downloadable/email/order/items/order/downloadable.phtml
+++ b/app/design/frontend/rwd/default/template/downloadable/email/order/items/order/downloadable.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/downloadable/email/order/items/order/downloadable.phtml
+++ b/app/design/frontend/rwd/default/template/downloadable/email/order/items/order/downloadable.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/downloadable/sales/order/items/renderer/downloadable.phtml
+++ b/app/design/frontend/rwd/default/template/downloadable/sales/order/items/renderer/downloadable.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/downloadable/sales/order/items/renderer/downloadable.phtml
+++ b/app/design/frontend/rwd/default/template/downloadable/sales/order/items/renderer/downloadable.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/downloadable/sales/order/items/renderer/downloadable.phtml
+++ b/app/design/frontend/rwd/default/template/downloadable/sales/order/items/renderer/downloadable.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/email/catalog/product/list.phtml
+++ b/app/design/frontend/rwd/default/template/email/catalog/product/list.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/email/catalog/product/list.phtml
+++ b/app/design/frontend/rwd/default/template/email/catalog/product/list.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/email/catalog/product/list.phtml
+++ b/app/design/frontend/rwd/default/template/email/catalog/product/list.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/email/catalog/product/new.phtml
+++ b/app/design/frontend/rwd/default/template/email/catalog/product/new.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/email/catalog/product/new.phtml
+++ b/app/design/frontend/rwd/default/template/email/catalog/product/new.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/email/catalog/product/new.phtml
+++ b/app/design/frontend/rwd/default/template/email/catalog/product/new.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/email/order/creditmemo/items.phtml
+++ b/app/design/frontend/rwd/default/template/email/order/creditmemo/items.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/email/order/creditmemo/items.phtml
+++ b/app/design/frontend/rwd/default/template/email/order/creditmemo/items.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/email/order/creditmemo/items.phtml
+++ b/app/design/frontend/rwd/default/template/email/order/creditmemo/items.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/email/order/invoice/items.phtml
+++ b/app/design/frontend/rwd/default/template/email/order/invoice/items.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/email/order/invoice/items.phtml
+++ b/app/design/frontend/rwd/default/template/email/order/invoice/items.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/email/order/invoice/items.phtml
+++ b/app/design/frontend/rwd/default/template/email/order/invoice/items.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/email/order/items.phtml
+++ b/app/design/frontend/rwd/default/template/email/order/items.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/email/order/items.phtml
+++ b/app/design/frontend/rwd/default/template/email/order/items.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/email/order/items.phtml
+++ b/app/design/frontend/rwd/default/template/email/order/items.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/email/order/items/creditmemo/default.phtml
+++ b/app/design/frontend/rwd/default/template/email/order/items/creditmemo/default.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/email/order/items/creditmemo/default.phtml
+++ b/app/design/frontend/rwd/default/template/email/order/items/creditmemo/default.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/email/order/items/creditmemo/default.phtml
+++ b/app/design/frontend/rwd/default/template/email/order/items/creditmemo/default.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/email/order/items/invoice/default.phtml
+++ b/app/design/frontend/rwd/default/template/email/order/items/invoice/default.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/email/order/items/invoice/default.phtml
+++ b/app/design/frontend/rwd/default/template/email/order/items/invoice/default.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/email/order/items/invoice/default.phtml
+++ b/app/design/frontend/rwd/default/template/email/order/items/invoice/default.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/email/order/items/order/default.phtml
+++ b/app/design/frontend/rwd/default/template/email/order/items/order/default.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/email/order/items/order/default.phtml
+++ b/app/design/frontend/rwd/default/template/email/order/items/order/default.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/email/order/items/order/default.phtml
+++ b/app/design/frontend/rwd/default/template/email/order/items/order/default.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/email/order/items/shipment/default.phtml
+++ b/app/design/frontend/rwd/default/template/email/order/items/shipment/default.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/email/order/items/shipment/default.phtml
+++ b/app/design/frontend/rwd/default/template/email/order/items/shipment/default.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/email/order/items/shipment/default.phtml
+++ b/app/design/frontend/rwd/default/template/email/order/items/shipment/default.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/email/order/shipment/items.phtml
+++ b/app/design/frontend/rwd/default/template/email/order/shipment/items.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/email/order/shipment/items.phtml
+++ b/app/design/frontend/rwd/default/template/email/order/shipment/items.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/email/order/shipment/items.phtml
+++ b/app/design/frontend/rwd/default/template/email/order/shipment/items.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/email/order/shipment/track.phtml
+++ b/app/design/frontend/rwd/default/template/email/order/shipment/track.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/email/order/shipment/track.phtml
+++ b/app/design/frontend/rwd/default/template/email/order/shipment/track.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/email/order/shipment/track.phtml
+++ b/app/design/frontend/rwd/default/template/email/order/shipment/track.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/email/order/totals/wrapper.phtml
+++ b/app/design/frontend/rwd/default/template/email/order/totals/wrapper.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/email/order/totals/wrapper.phtml
+++ b/app/design/frontend/rwd/default/template/email/order/totals/wrapper.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/email/order/totals/wrapper.phtml
+++ b/app/design/frontend/rwd/default/template/email/order/totals/wrapper.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/email/productalert/price.phtml
+++ b/app/design/frontend/rwd/default/template/email/productalert/price.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/email/productalert/price.phtml
+++ b/app/design/frontend/rwd/default/template/email/productalert/price.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/email/productalert/price.phtml
+++ b/app/design/frontend/rwd/default/template/email/productalert/price.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/email/productalert/stock.phtml
+++ b/app/design/frontend/rwd/default/template/email/productalert/stock.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/email/productalert/stock.phtml
+++ b/app/design/frontend/rwd/default/template/email/productalert/stock.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/email/productalert/stock.phtml
+++ b/app/design/frontend/rwd/default/template/email/productalert/stock.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/newsletter/subscribe.phtml
+++ b/app/design/frontend/rwd/default/template/newsletter/subscribe.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/newsletter/subscribe.phtml
+++ b/app/design/frontend/rwd/default/template/newsletter/subscribe.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/newsletter/subscribe.phtml
+++ b/app/design/frontend/rwd/default/template/newsletter/subscribe.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/oauth/authorize/form/login-simple.phtml
+++ b/app/design/frontend/rwd/default/template/oauth/authorize/form/login-simple.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/oauth/authorize/form/login-simple.phtml
+++ b/app/design/frontend/rwd/default/template/oauth/authorize/form/login-simple.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/oauth/authorize/form/login-simple.phtml
+++ b/app/design/frontend/rwd/default/template/oauth/authorize/form/login-simple.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/page/1column.phtml
+++ b/app/design/frontend/rwd/default/template/page/1column.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/page/1column.phtml
+++ b/app/design/frontend/rwd/default/template/page/1column.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/page/1column.phtml
+++ b/app/design/frontend/rwd/default/template/page/1column.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/page/2columns-left.phtml
+++ b/app/design/frontend/rwd/default/template/page/2columns-left.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/page/2columns-left.phtml
+++ b/app/design/frontend/rwd/default/template/page/2columns-left.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/page/2columns-left.phtml
+++ b/app/design/frontend/rwd/default/template/page/2columns-left.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/page/2columns-right.phtml
+++ b/app/design/frontend/rwd/default/template/page/2columns-right.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/page/2columns-right.phtml
+++ b/app/design/frontend/rwd/default/template/page/2columns-right.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/page/2columns-right.phtml
+++ b/app/design/frontend/rwd/default/template/page/2columns-right.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/page/3columns.phtml
+++ b/app/design/frontend/rwd/default/template/page/3columns.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/page/3columns.phtml
+++ b/app/design/frontend/rwd/default/template/page/3columns.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/page/3columns.phtml
+++ b/app/design/frontend/rwd/default/template/page/3columns.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/page/empty.phtml
+++ b/app/design/frontend/rwd/default/template/page/empty.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/page/empty.phtml
+++ b/app/design/frontend/rwd/default/template/page/empty.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/page/empty.phtml
+++ b/app/design/frontend/rwd/default/template/page/empty.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/page/html/footer.phtml
+++ b/app/design/frontend/rwd/default/template/page/html/footer.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/page/html/footer.phtml
+++ b/app/design/frontend/rwd/default/template/page/html/footer.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/page/html/footer.phtml
+++ b/app/design/frontend/rwd/default/template/page/html/footer.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/page/html/header.phtml
+++ b/app/design/frontend/rwd/default/template/page/html/header.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/page/html/header.phtml
+++ b/app/design/frontend/rwd/default/template/page/html/header.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/page/html/header.phtml
+++ b/app/design/frontend/rwd/default/template/page/html/header.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/page/html/pager.phtml
+++ b/app/design/frontend/rwd/default/template/page/html/pager.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/page/html/pager.phtml
+++ b/app/design/frontend/rwd/default/template/page/html/pager.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/page/html/pager.phtml
+++ b/app/design/frontend/rwd/default/template/page/html/pager.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/page/html/topmenu.phtml
+++ b/app/design/frontend/rwd/default/template/page/html/topmenu.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/page/html/topmenu.phtml
+++ b/app/design/frontend/rwd/default/template/page/html/topmenu.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/page/html/topmenu.phtml
+++ b/app/design/frontend/rwd/default/template/page/html/topmenu.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/page/html/topmenu/renderer.phtml
+++ b/app/design/frontend/rwd/default/template/page/html/topmenu/renderer.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/page/html/topmenu/renderer.phtml
+++ b/app/design/frontend/rwd/default/template/page/html/topmenu/renderer.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/page/html/topmenu/renderer.phtml
+++ b/app/design/frontend/rwd/default/template/page/html/topmenu/renderer.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/page/popup.phtml
+++ b/app/design/frontend/rwd/default/template/page/popup.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/page/popup.phtml
+++ b/app/design/frontend/rwd/default/template/page/popup.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/page/popup.phtml
+++ b/app/design/frontend/rwd/default/template/page/popup.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/page/print.phtml
+++ b/app/design/frontend/rwd/default/template/page/print.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/page/print.phtml
+++ b/app/design/frontend/rwd/default/template/page/print.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/page/print.phtml
+++ b/app/design/frontend/rwd/default/template/page/print.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/page/template/links.phtml
+++ b/app/design/frontend/rwd/default/template/page/template/links.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/page/template/links.phtml
+++ b/app/design/frontend/rwd/default/template/page/template/links.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/page/template/links.phtml
+++ b/app/design/frontend/rwd/default/template/page/template/links.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/payment/form/cc.phtml
+++ b/app/design/frontend/rwd/default/template/payment/form/cc.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/payment/form/cc.phtml
+++ b/app/design/frontend/rwd/default/template/payment/form/cc.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/payment/form/cc.phtml
+++ b/app/design/frontend/rwd/default/template/payment/form/cc.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/payment/form/ccsave.phtml
+++ b/app/design/frontend/rwd/default/template/payment/form/ccsave.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/payment/form/ccsave.phtml
+++ b/app/design/frontend/rwd/default/template/payment/form/ccsave.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/payment/form/ccsave.phtml
+++ b/app/design/frontend/rwd/default/template/payment/form/ccsave.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/payment/info/default.phtml
+++ b/app/design/frontend/rwd/default/template/payment/info/default.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/payment/info/default.phtml
+++ b/app/design/frontend/rwd/default/template/payment/info/default.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/payment/info/default.phtml
+++ b/app/design/frontend/rwd/default/template/payment/info/default.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/paypal/bml.phtml
+++ b/app/design/frontend/rwd/default/template/paypal/bml.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/paypal/bml.phtml
+++ b/app/design/frontend/rwd/default/template/paypal/bml.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/paypal/bml.phtml
+++ b/app/design/frontend/rwd/default/template/paypal/bml.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/paypal/express/minicart/shortcut.phtml
+++ b/app/design/frontend/rwd/default/template/paypal/express/minicart/shortcut.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/paypal/express/minicart/shortcut.phtml
+++ b/app/design/frontend/rwd/default/template/paypal/express/minicart/shortcut.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/paypal/express/minicart/shortcut.phtml
+++ b/app/design/frontend/rwd/default/template/paypal/express/minicart/shortcut.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/paypal/express/product/shortcut.phtml
+++ b/app/design/frontend/rwd/default/template/paypal/express/product/shortcut.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/paypal/express/product/shortcut.phtml
+++ b/app/design/frontend/rwd/default/template/paypal/express/product/shortcut.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/paypal/express/product/shortcut.phtml
+++ b/app/design/frontend/rwd/default/template/paypal/express/product/shortcut.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/paypal/express/review.phtml
+++ b/app/design/frontend/rwd/default/template/paypal/express/review.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/paypal/express/review.phtml
+++ b/app/design/frontend/rwd/default/template/paypal/express/review.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/paypal/express/review.phtml
+++ b/app/design/frontend/rwd/default/template/paypal/express/review.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/paypal/express/review/address.phtml
+++ b/app/design/frontend/rwd/default/template/paypal/express/review/address.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/paypal/express/review/address.phtml
+++ b/app/design/frontend/rwd/default/template/paypal/express/review/address.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/paypal/express/review/address.phtml
+++ b/app/design/frontend/rwd/default/template/paypal/express/review/address.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/paypal/express/review/details.phtml
+++ b/app/design/frontend/rwd/default/template/paypal/express/review/details.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/paypal/express/review/details.phtml
+++ b/app/design/frontend/rwd/default/template/paypal/express/review/details.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/paypal/express/review/details.phtml
+++ b/app/design/frontend/rwd/default/template/paypal/express/review/details.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/paypal/express/review/shipping/method.phtml
+++ b/app/design/frontend/rwd/default/template/paypal/express/review/shipping/method.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/paypal/express/review/shipping/method.phtml
+++ b/app/design/frontend/rwd/default/template/paypal/express/review/shipping/method.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/paypal/express/review/shipping/method.phtml
+++ b/app/design/frontend/rwd/default/template/paypal/express/review/shipping/method.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/paypal/partner/us_logo.phtml
+++ b/app/design/frontend/rwd/default/template/paypal/partner/us_logo.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/paypal/partner/us_logo.phtml
+++ b/app/design/frontend/rwd/default/template/paypal/partner/us_logo.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/paypal/partner/us_logo.phtml
+++ b/app/design/frontend/rwd/default/template/paypal/partner/us_logo.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/persistent/checkout/onepage/billing.phtml
+++ b/app/design/frontend/rwd/default/template/persistent/checkout/onepage/billing.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/persistent/checkout/onepage/billing.phtml
+++ b/app/design/frontend/rwd/default/template/persistent/checkout/onepage/billing.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/persistent/checkout/onepage/billing.phtml
+++ b/app/design/frontend/rwd/default/template/persistent/checkout/onepage/billing.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/persistent/checkout/onepage/login.phtml
+++ b/app/design/frontend/rwd/default/template/persistent/checkout/onepage/login.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/persistent/checkout/onepage/login.phtml
+++ b/app/design/frontend/rwd/default/template/persistent/checkout/onepage/login.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/persistent/checkout/onepage/login.phtml
+++ b/app/design/frontend/rwd/default/template/persistent/checkout/onepage/login.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/persistent/customer/form/login.phtml
+++ b/app/design/frontend/rwd/default/template/persistent/customer/form/login.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/persistent/customer/form/login.phtml
+++ b/app/design/frontend/rwd/default/template/persistent/customer/form/login.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/persistent/customer/form/login.phtml
+++ b/app/design/frontend/rwd/default/template/persistent/customer/form/login.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/persistent/customer/form/register.phtml
+++ b/app/design/frontend/rwd/default/template/persistent/customer/form/register.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/persistent/customer/form/register.phtml
+++ b/app/design/frontend/rwd/default/template/persistent/customer/form/register.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/persistent/customer/form/register.phtml
+++ b/app/design/frontend/rwd/default/template/persistent/customer/form/register.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/persistent/header/links.phtml
+++ b/app/design/frontend/rwd/default/template/persistent/header/links.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/persistent/header/links.phtml
+++ b/app/design/frontend/rwd/default/template/persistent/header/links.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/persistent/header/links.phtml
+++ b/app/design/frontend/rwd/default/template/persistent/header/links.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/persistent/remember_me.phtml
+++ b/app/design/frontend/rwd/default/template/persistent/remember_me.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/persistent/remember_me.phtml
+++ b/app/design/frontend/rwd/default/template/persistent/remember_me.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/persistent/remember_me.phtml
+++ b/app/design/frontend/rwd/default/template/persistent/remember_me.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/persistent/remember_me_tooltip.phtml
+++ b/app/design/frontend/rwd/default/template/persistent/remember_me_tooltip.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/persistent/remember_me_tooltip.phtml
+++ b/app/design/frontend/rwd/default/template/persistent/remember_me_tooltip.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/persistent/remember_me_tooltip.phtml
+++ b/app/design/frontend/rwd/default/template/persistent/remember_me_tooltip.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/rating/detailed.phtml
+++ b/app/design/frontend/rwd/default/template/rating/detailed.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/rating/detailed.phtml
+++ b/app/design/frontend/rwd/default/template/rating/detailed.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/rating/detailed.phtml
+++ b/app/design/frontend/rwd/default/template/rating/detailed.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/reports/product_viewed.phtml
+++ b/app/design/frontend/rwd/default/template/reports/product_viewed.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/reports/product_viewed.phtml
+++ b/app/design/frontend/rwd/default/template/reports/product_viewed.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/reports/product_viewed.phtml
+++ b/app/design/frontend/rwd/default/template/reports/product_viewed.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/reports/widget/compared/column/compared_default_list.phtml
+++ b/app/design/frontend/rwd/default/template/reports/widget/compared/column/compared_default_list.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/reports/widget/compared/column/compared_default_list.phtml
+++ b/app/design/frontend/rwd/default/template/reports/widget/compared/column/compared_default_list.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/reports/widget/compared/column/compared_default_list.phtml
+++ b/app/design/frontend/rwd/default/template/reports/widget/compared/column/compared_default_list.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/reports/widget/compared/column/compared_images_list.phtml
+++ b/app/design/frontend/rwd/default/template/reports/widget/compared/column/compared_images_list.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/reports/widget/compared/column/compared_images_list.phtml
+++ b/app/design/frontend/rwd/default/template/reports/widget/compared/column/compared_images_list.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/reports/widget/compared/column/compared_images_list.phtml
+++ b/app/design/frontend/rwd/default/template/reports/widget/compared/column/compared_images_list.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/reports/widget/compared/column/compared_names_list.phtml
+++ b/app/design/frontend/rwd/default/template/reports/widget/compared/column/compared_names_list.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/reports/widget/compared/column/compared_names_list.phtml
+++ b/app/design/frontend/rwd/default/template/reports/widget/compared/column/compared_names_list.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/reports/widget/compared/column/compared_names_list.phtml
+++ b/app/design/frontend/rwd/default/template/reports/widget/compared/column/compared_names_list.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/reports/widget/compared/content/compared_grid.phtml
+++ b/app/design/frontend/rwd/default/template/reports/widget/compared/content/compared_grid.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/reports/widget/compared/content/compared_grid.phtml
+++ b/app/design/frontend/rwd/default/template/reports/widget/compared/content/compared_grid.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/reports/widget/compared/content/compared_grid.phtml
+++ b/app/design/frontend/rwd/default/template/reports/widget/compared/content/compared_grid.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/reports/widget/compared/content/compared_list.phtml
+++ b/app/design/frontend/rwd/default/template/reports/widget/compared/content/compared_list.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/reports/widget/compared/content/compared_list.phtml
+++ b/app/design/frontend/rwd/default/template/reports/widget/compared/content/compared_list.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/reports/widget/compared/content/compared_list.phtml
+++ b/app/design/frontend/rwd/default/template/reports/widget/compared/content/compared_list.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/reports/widget/viewed/column/viewed_default_list.phtml
+++ b/app/design/frontend/rwd/default/template/reports/widget/viewed/column/viewed_default_list.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/reports/widget/viewed/column/viewed_default_list.phtml
+++ b/app/design/frontend/rwd/default/template/reports/widget/viewed/column/viewed_default_list.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/reports/widget/viewed/column/viewed_default_list.phtml
+++ b/app/design/frontend/rwd/default/template/reports/widget/viewed/column/viewed_default_list.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/reports/widget/viewed/column/viewed_images_list.phtml
+++ b/app/design/frontend/rwd/default/template/reports/widget/viewed/column/viewed_images_list.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/reports/widget/viewed/column/viewed_images_list.phtml
+++ b/app/design/frontend/rwd/default/template/reports/widget/viewed/column/viewed_images_list.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/reports/widget/viewed/column/viewed_images_list.phtml
+++ b/app/design/frontend/rwd/default/template/reports/widget/viewed/column/viewed_images_list.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/reports/widget/viewed/column/viewed_names_list.phtml
+++ b/app/design/frontend/rwd/default/template/reports/widget/viewed/column/viewed_names_list.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/reports/widget/viewed/column/viewed_names_list.phtml
+++ b/app/design/frontend/rwd/default/template/reports/widget/viewed/column/viewed_names_list.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/reports/widget/viewed/column/viewed_names_list.phtml
+++ b/app/design/frontend/rwd/default/template/reports/widget/viewed/column/viewed_names_list.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/reports/widget/viewed/content/viewed_grid.phtml
+++ b/app/design/frontend/rwd/default/template/reports/widget/viewed/content/viewed_grid.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/reports/widget/viewed/content/viewed_grid.phtml
+++ b/app/design/frontend/rwd/default/template/reports/widget/viewed/content/viewed_grid.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/reports/widget/viewed/content/viewed_grid.phtml
+++ b/app/design/frontend/rwd/default/template/reports/widget/viewed/content/viewed_grid.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/reports/widget/viewed/content/viewed_list.phtml
+++ b/app/design/frontend/rwd/default/template/reports/widget/viewed/content/viewed_list.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/reports/widget/viewed/content/viewed_list.phtml
+++ b/app/design/frontend/rwd/default/template/reports/widget/viewed/content/viewed_list.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/reports/widget/viewed/content/viewed_list.phtml
+++ b/app/design/frontend/rwd/default/template/reports/widget/viewed/content/viewed_list.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/review/customer/view.phtml
+++ b/app/design/frontend/rwd/default/template/review/customer/view.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/review/customer/view.phtml
+++ b/app/design/frontend/rwd/default/template/review/customer/view.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/review/customer/view.phtml
+++ b/app/design/frontend/rwd/default/template/review/customer/view.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/review/form.phtml
+++ b/app/design/frontend/rwd/default/template/review/form.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/review/form.phtml
+++ b/app/design/frontend/rwd/default/template/review/form.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/review/form.phtml
+++ b/app/design/frontend/rwd/default/template/review/form.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/review/product/view/list.phtml
+++ b/app/design/frontend/rwd/default/template/review/product/view/list.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/review/product/view/list.phtml
+++ b/app/design/frontend/rwd/default/template/review/product/view/list.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/review/product/view/list.phtml
+++ b/app/design/frontend/rwd/default/template/review/product/view/list.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/review/view.phtml
+++ b/app/design/frontend/rwd/default/template/review/view.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/review/view.phtml
+++ b/app/design/frontend/rwd/default/template/review/view.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/review/view.phtml
+++ b/app/design/frontend/rwd/default/template/review/view.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/sales/billing/agreement/view.phtml
+++ b/app/design/frontend/rwd/default/template/sales/billing/agreement/view.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/sales/billing/agreement/view.phtml
+++ b/app/design/frontend/rwd/default/template/sales/billing/agreement/view.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/sales/billing/agreement/view.phtml
+++ b/app/design/frontend/rwd/default/template/sales/billing/agreement/view.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/sales/billing/agreements.phtml
+++ b/app/design/frontend/rwd/default/template/sales/billing/agreements.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/sales/billing/agreements.phtml
+++ b/app/design/frontend/rwd/default/template/sales/billing/agreements.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/sales/billing/agreements.phtml
+++ b/app/design/frontend/rwd/default/template/sales/billing/agreements.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/sales/order/creditmemo/items.phtml
+++ b/app/design/frontend/rwd/default/template/sales/order/creditmemo/items.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/sales/order/creditmemo/items.phtml
+++ b/app/design/frontend/rwd/default/template/sales/order/creditmemo/items.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/sales/order/creditmemo/items.phtml
+++ b/app/design/frontend/rwd/default/template/sales/order/creditmemo/items.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/sales/order/creditmemo/items/renderer/default.phtml
+++ b/app/design/frontend/rwd/default/template/sales/order/creditmemo/items/renderer/default.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/sales/order/creditmemo/items/renderer/default.phtml
+++ b/app/design/frontend/rwd/default/template/sales/order/creditmemo/items/renderer/default.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/sales/order/creditmemo/items/renderer/default.phtml
+++ b/app/design/frontend/rwd/default/template/sales/order/creditmemo/items/renderer/default.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/sales/order/history.phtml
+++ b/app/design/frontend/rwd/default/template/sales/order/history.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/sales/order/history.phtml
+++ b/app/design/frontend/rwd/default/template/sales/order/history.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/sales/order/history.phtml
+++ b/app/design/frontend/rwd/default/template/sales/order/history.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/sales/order/invoice/items.phtml
+++ b/app/design/frontend/rwd/default/template/sales/order/invoice/items.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/sales/order/invoice/items.phtml
+++ b/app/design/frontend/rwd/default/template/sales/order/invoice/items.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/sales/order/invoice/items.phtml
+++ b/app/design/frontend/rwd/default/template/sales/order/invoice/items.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/sales/order/invoice/items/renderer/default.phtml
+++ b/app/design/frontend/rwd/default/template/sales/order/invoice/items/renderer/default.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/sales/order/invoice/items/renderer/default.phtml
+++ b/app/design/frontend/rwd/default/template/sales/order/invoice/items/renderer/default.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/sales/order/invoice/items/renderer/default.phtml
+++ b/app/design/frontend/rwd/default/template/sales/order/invoice/items/renderer/default.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/sales/order/items.phtml
+++ b/app/design/frontend/rwd/default/template/sales/order/items.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/sales/order/items.phtml
+++ b/app/design/frontend/rwd/default/template/sales/order/items.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/sales/order/items.phtml
+++ b/app/design/frontend/rwd/default/template/sales/order/items.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/sales/order/items/renderer/default.phtml
+++ b/app/design/frontend/rwd/default/template/sales/order/items/renderer/default.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/sales/order/items/renderer/default.phtml
+++ b/app/design/frontend/rwd/default/template/sales/order/items/renderer/default.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/sales/order/items/renderer/default.phtml
+++ b/app/design/frontend/rwd/default/template/sales/order/items/renderer/default.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/sales/order/recent.phtml
+++ b/app/design/frontend/rwd/default/template/sales/order/recent.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/sales/order/recent.phtml
+++ b/app/design/frontend/rwd/default/template/sales/order/recent.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/sales/order/recent.phtml
+++ b/app/design/frontend/rwd/default/template/sales/order/recent.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/sales/order/shipment/items.phtml
+++ b/app/design/frontend/rwd/default/template/sales/order/shipment/items.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/sales/order/shipment/items.phtml
+++ b/app/design/frontend/rwd/default/template/sales/order/shipment/items.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/sales/order/shipment/items.phtml
+++ b/app/design/frontend/rwd/default/template/sales/order/shipment/items.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/sales/recurring/grid.phtml
+++ b/app/design/frontend/rwd/default/template/sales/recurring/grid.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/sales/recurring/grid.phtml
+++ b/app/design/frontend/rwd/default/template/sales/recurring/grid.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/sales/recurring/grid.phtml
+++ b/app/design/frontend/rwd/default/template/sales/recurring/grid.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/sales/recurring/profile/view.phtml
+++ b/app/design/frontend/rwd/default/template/sales/recurring/profile/view.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/sales/recurring/profile/view.phtml
+++ b/app/design/frontend/rwd/default/template/sales/recurring/profile/view.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/sales/recurring/profile/view.phtml
+++ b/app/design/frontend/rwd/default/template/sales/recurring/profile/view.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/sales/widget/guest/form.phtml
+++ b/app/design/frontend/rwd/default/template/sales/widget/guest/form.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/sales/widget/guest/form.phtml
+++ b/app/design/frontend/rwd/default/template/sales/widget/guest/form.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/sales/widget/guest/form.phtml
+++ b/app/design/frontend/rwd/default/template/sales/widget/guest/form.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/sendfriend/send.phtml
+++ b/app/design/frontend/rwd/default/template/sendfriend/send.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/sendfriend/send.phtml
+++ b/app/design/frontend/rwd/default/template/sendfriend/send.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/sendfriend/send.phtml
+++ b/app/design/frontend/rwd/default/template/sendfriend/send.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/wishlist/button/update.phtml
+++ b/app/design/frontend/rwd/default/template/wishlist/button/update.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/wishlist/button/update.phtml
+++ b/app/design/frontend/rwd/default/template/wishlist/button/update.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/wishlist/button/update.phtml
+++ b/app/design/frontend/rwd/default/template/wishlist/button/update.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/wishlist/item/column/cart.phtml
+++ b/app/design/frontend/rwd/default/template/wishlist/item/column/cart.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/wishlist/item/column/cart.phtml
+++ b/app/design/frontend/rwd/default/template/wishlist/item/column/cart.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/wishlist/item/column/cart.phtml
+++ b/app/design/frontend/rwd/default/template/wishlist/item/column/cart.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/wishlist/item/column/info.phtml
+++ b/app/design/frontend/rwd/default/template/wishlist/item/column/info.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/wishlist/item/column/info.phtml
+++ b/app/design/frontend/rwd/default/template/wishlist/item/column/info.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/wishlist/item/column/info.phtml
+++ b/app/design/frontend/rwd/default/template/wishlist/item/column/info.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/wishlist/item/column/price.phtml
+++ b/app/design/frontend/rwd/default/template/wishlist/item/column/price.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/wishlist/item/column/price.phtml
+++ b/app/design/frontend/rwd/default/template/wishlist/item/column/price.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/wishlist/item/column/price.phtml
+++ b/app/design/frontend/rwd/default/template/wishlist/item/column/price.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/wishlist/item/column/quantity.phtml
+++ b/app/design/frontend/rwd/default/template/wishlist/item/column/quantity.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/wishlist/item/column/quantity.phtml
+++ b/app/design/frontend/rwd/default/template/wishlist/item/column/quantity.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/wishlist/item/column/quantity.phtml
+++ b/app/design/frontend/rwd/default/template/wishlist/item/column/quantity.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/wishlist/item/list.phtml
+++ b/app/design/frontend/rwd/default/template/wishlist/item/list.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/wishlist/item/list.phtml
+++ b/app/design/frontend/rwd/default/template/wishlist/item/list.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/wishlist/item/list.phtml
+++ b/app/design/frontend/rwd/default/template/wishlist/item/list.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/wishlist/shared.phtml
+++ b/app/design/frontend/rwd/default/template/wishlist/shared.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/wishlist/shared.phtml
+++ b/app/design/frontend/rwd/default/template/wishlist/shared.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/wishlist/shared.phtml
+++ b/app/design/frontend/rwd/default/template/wishlist/shared.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/wishlist/sidebar.phtml
+++ b/app/design/frontend/rwd/default/template/wishlist/sidebar.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/wishlist/sidebar.phtml
+++ b/app/design/frontend/rwd/default/template/wishlist/sidebar.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/wishlist/sidebar.phtml
+++ b/app/design/frontend/rwd/default/template/wishlist/sidebar.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/wishlist/view.phtml
+++ b/app/design/frontend/rwd/default/template/wishlist/view.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/frontend/rwd/default/template/wishlist/view.phtml
+++ b/app/design/frontend/rwd/default/template/wishlist/view.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/frontend/rwd/default/template/wishlist/view.phtml
+++ b/app/design/frontend/rwd/default/template/wishlist/view.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/app/design/install/default/default/etc/theme.xml
+++ b/app/design/install/default/default/etc/theme.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/install/default/default/etc/theme.xml
+++ b/app/design/install/default/default/etc/theme.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/install/default/default/etc/theme.xml
+++ b/app/design/install/default/default/etc/theme.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/install/default/default/layout/main.xml
+++ b/app/design/install/default/default/layout/main.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/install/default/default/layout/main.xml
+++ b/app/design/install/default/default/layout/main.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/install/default/default/layout/main.xml
+++ b/app/design/install/default/default/layout/main.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/install/default/default/template/install/begin.phtml
+++ b/app/design/install/default/default/template/install/begin.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/install/default/default/template/install/begin.phtml
+++ b/app/design/install/default/default/template/install/begin.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/install/default/default/template/install/begin.phtml
+++ b/app/design/install/default/default/template/install/begin.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/install/default/default/template/install/config.phtml
+++ b/app/design/install/default/default/template/install/config.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/install/default/default/template/install/config.phtml
+++ b/app/design/install/default/default/template/install/config.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/install/default/default/template/install/config.phtml
+++ b/app/design/install/default/default/template/install/config.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/install/default/default/template/install/create_admin.phtml
+++ b/app/design/install/default/default/template/install/create_admin.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/install/default/default/template/install/create_admin.phtml
+++ b/app/design/install/default/default/template/install/create_admin.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/install/default/default/template/install/create_admin.phtml
+++ b/app/design/install/default/default/template/install/create_admin.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/install/default/default/template/install/db/main.phtml
+++ b/app/design/install/default/default/template/install/db/main.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/install/default/default/template/install/db/main.phtml
+++ b/app/design/install/default/default/template/install/db/main.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/install/default/default/template/install/db/main.phtml
+++ b/app/design/install/default/default/template/install/db/main.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/install/default/default/template/install/db/mysql4.phtml
+++ b/app/design/install/default/default/template/install/db/mysql4.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/install/default/default/template/install/db/mysql4.phtml
+++ b/app/design/install/default/default/template/install/db/mysql4.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/install/default/default/template/install/db/mysql4.phtml
+++ b/app/design/install/default/default/template/install/db/mysql4.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/install/default/default/template/install/end.phtml
+++ b/app/design/install/default/default/template/install/end.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/install/default/default/template/install/end.phtml
+++ b/app/design/install/default/default/template/install/end.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/install/default/default/template/install/end.phtml
+++ b/app/design/install/default/default/template/install/end.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/install/default/default/template/install/locale.phtml
+++ b/app/design/install/default/default/template/install/locale.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/install/default/default/template/install/locale.phtml
+++ b/app/design/install/default/default/template/install/locale.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/install/default/default/template/install/locale.phtml
+++ b/app/design/install/default/default/template/install/locale.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/install/default/default/template/install/state.phtml
+++ b/app/design/install/default/default/template/install/state.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/install/default/default/template/install/state.phtml
+++ b/app/design/install/default/default/template/install/state.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/install/default/default/template/install/state.phtml
+++ b/app/design/install/default/default/template/install/state.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/design/install/default/default/template/page.phtml
+++ b/app/design/install/default/default/template/page.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/design/install/default/default/template/page.phtml
+++ b/app/design/install/default/default/template/page.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/app/design/install/default/default/template/page.phtml
+++ b/app/design/install/default/default/template/page.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/app/etc/config.xml
+++ b/app/etc/config.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/etc/config.xml
+++ b/app/etc/config.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/etc/config.xml
+++ b/app/etc/config.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/etc/local.xml.additional
+++ b/app/etc/local.xml.additional
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Mage
  * @package     Mage_Core

--- a/app/etc/local.xml.additional
+++ b/app/etc/local.xml.additional
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/etc/local.xml.additional
+++ b/app/etc/local.xml.additional
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    Mage
  * @package     Mage_Core

--- a/app/etc/local.xml.template
+++ b/app/etc/local.xml.template
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Mage
  * @package     Mage_Core

--- a/app/etc/local.xml.template
+++ b/app/etc/local.xml.template
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/etc/local.xml.template
+++ b/app/etc/local.xml.template
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    Mage
  * @package     Mage_Core

--- a/app/etc/modules/Mage_Admin.xml
+++ b/app/etc/modules/Mage_Admin.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/etc/modules/Mage_Admin.xml
+++ b/app/etc/modules/Mage_Admin.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/etc/modules/Mage_Admin.xml
+++ b/app/etc/modules/Mage_Admin.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Admin

--- a/app/etc/modules/Mage_AdminNotification.xml
+++ b/app/etc/modules/Mage_AdminNotification.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_AdminNotification

--- a/app/etc/modules/Mage_AdminNotification.xml
+++ b/app/etc/modules/Mage_AdminNotification.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_AdminNotification

--- a/app/etc/modules/Mage_AdminNotification.xml
+++ b/app/etc/modules/Mage_AdminNotification.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/etc/modules/Mage_Adminhtml.xml
+++ b/app/etc/modules/Mage_Adminhtml.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/etc/modules/Mage_Adminhtml.xml
+++ b/app/etc/modules/Mage_Adminhtml.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/etc/modules/Mage_Adminhtml.xml
+++ b/app/etc/modules/Mage_Adminhtml.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Adminhtml

--- a/app/etc/modules/Mage_Api.xml
+++ b/app/etc/modules/Mage_Api.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/etc/modules/Mage_Api.xml
+++ b/app/etc/modules/Mage_Api.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api

--- a/app/etc/modules/Mage_Api.xml
+++ b/app/etc/modules/Mage_Api.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/etc/modules/Mage_Api2.xml
+++ b/app/etc/modules/Mage_Api2.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/etc/modules/Mage_Api2.xml
+++ b/app/etc/modules/Mage_Api2.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Api2

--- a/app/etc/modules/Mage_Api2.xml
+++ b/app/etc/modules/Mage_Api2.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/etc/modules/Mage_Authorizenet.xml
+++ b/app/etc/modules/Mage_Authorizenet.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Authorizenet

--- a/app/etc/modules/Mage_Authorizenet.xml
+++ b/app/etc/modules/Mage_Authorizenet.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Authorizenet

--- a/app/etc/modules/Mage_Authorizenet.xml
+++ b/app/etc/modules/Mage_Authorizenet.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/etc/modules/Mage_Bundle.xml
+++ b/app/etc/modules/Mage_Bundle.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/etc/modules/Mage_Bundle.xml
+++ b/app/etc/modules/Mage_Bundle.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Bundle

--- a/app/etc/modules/Mage_Bundle.xml
+++ b/app/etc/modules/Mage_Bundle.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/etc/modules/Mage_Captcha.xml
+++ b/app/etc/modules/Mage_Captcha.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Captcha

--- a/app/etc/modules/Mage_Captcha.xml
+++ b/app/etc/modules/Mage_Captcha.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/etc/modules/Mage_Captcha.xml
+++ b/app/etc/modules/Mage_Captcha.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Captcha

--- a/app/etc/modules/Mage_Catalog.xml
+++ b/app/etc/modules/Mage_Catalog.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/etc/modules/Mage_Catalog.xml
+++ b/app/etc/modules/Mage_Catalog.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Catalog

--- a/app/etc/modules/Mage_Catalog.xml
+++ b/app/etc/modules/Mage_Catalog.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/etc/modules/Mage_CatalogIndex.xml
+++ b/app/etc/modules/Mage_CatalogIndex.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/etc/modules/Mage_CatalogIndex.xml
+++ b/app/etc/modules/Mage_CatalogIndex.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogIndex

--- a/app/etc/modules/Mage_CatalogIndex.xml
+++ b/app/etc/modules/Mage_CatalogIndex.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/etc/modules/Mage_CatalogInventory.xml
+++ b/app/etc/modules/Mage_CatalogInventory.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/etc/modules/Mage_CatalogInventory.xml
+++ b/app/etc/modules/Mage_CatalogInventory.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogInventory

--- a/app/etc/modules/Mage_CatalogInventory.xml
+++ b/app/etc/modules/Mage_CatalogInventory.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/etc/modules/Mage_CatalogRule.xml
+++ b/app/etc/modules/Mage_CatalogRule.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogRule

--- a/app/etc/modules/Mage_CatalogRule.xml
+++ b/app/etc/modules/Mage_CatalogRule.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogRule

--- a/app/etc/modules/Mage_CatalogRule.xml
+++ b/app/etc/modules/Mage_CatalogRule.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/etc/modules/Mage_CatalogSearch.xml
+++ b/app/etc/modules/Mage_CatalogSearch.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/etc/modules/Mage_CatalogSearch.xml
+++ b/app/etc/modules/Mage_CatalogSearch.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CatalogSearch

--- a/app/etc/modules/Mage_CatalogSearch.xml
+++ b/app/etc/modules/Mage_CatalogSearch.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/etc/modules/Mage_Centinel.xml
+++ b/app/etc/modules/Mage_Centinel.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Centinel

--- a/app/etc/modules/Mage_Centinel.xml
+++ b/app/etc/modules/Mage_Centinel.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Centinel

--- a/app/etc/modules/Mage_Centinel.xml
+++ b/app/etc/modules/Mage_Centinel.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/etc/modules/Mage_Checkout.xml
+++ b/app/etc/modules/Mage_Checkout.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/etc/modules/Mage_Checkout.xml
+++ b/app/etc/modules/Mage_Checkout.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Checkout

--- a/app/etc/modules/Mage_Checkout.xml
+++ b/app/etc/modules/Mage_Checkout.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/etc/modules/Mage_Cms.xml
+++ b/app/etc/modules/Mage_Cms.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/etc/modules/Mage_Cms.xml
+++ b/app/etc/modules/Mage_Cms.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Cms

--- a/app/etc/modules/Mage_Cms.xml
+++ b/app/etc/modules/Mage_Cms.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/etc/modules/Mage_ConfigurableSwatches.xml
+++ b/app/etc/modules/Mage_ConfigurableSwatches.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ConfigurableSwatches

--- a/app/etc/modules/Mage_ConfigurableSwatches.xml
+++ b/app/etc/modules/Mage_ConfigurableSwatches.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ConfigurableSwatches

--- a/app/etc/modules/Mage_ConfigurableSwatches.xml
+++ b/app/etc/modules/Mage_ConfigurableSwatches.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/etc/modules/Mage_Contacts.xml
+++ b/app/etc/modules/Mage_Contacts.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Contacts

--- a/app/etc/modules/Mage_Contacts.xml
+++ b/app/etc/modules/Mage_Contacts.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/etc/modules/Mage_Contacts.xml
+++ b/app/etc/modules/Mage_Contacts.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Contacts

--- a/app/etc/modules/Mage_Core.xml
+++ b/app/etc/modules/Mage_Core.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/etc/modules/Mage_Core.xml
+++ b/app/etc/modules/Mage_Core.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/etc/modules/Mage_Core.xml
+++ b/app/etc/modules/Mage_Core.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Core

--- a/app/etc/modules/Mage_Cron.xml
+++ b/app/etc/modules/Mage_Cron.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Cron

--- a/app/etc/modules/Mage_Cron.xml
+++ b/app/etc/modules/Mage_Cron.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/etc/modules/Mage_Cron.xml
+++ b/app/etc/modules/Mage_Cron.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Cron

--- a/app/etc/modules/Mage_CurrencySymbol.xml
+++ b/app/etc/modules/Mage_CurrencySymbol.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_CurrencySymbol

--- a/app/etc/modules/Mage_CurrencySymbol.xml
+++ b/app/etc/modules/Mage_CurrencySymbol.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_CurrencySymbol

--- a/app/etc/modules/Mage_CurrencySymbol.xml
+++ b/app/etc/modules/Mage_CurrencySymbol.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/etc/modules/Mage_Customer.xml
+++ b/app/etc/modules/Mage_Customer.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/etc/modules/Mage_Customer.xml
+++ b/app/etc/modules/Mage_Customer.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/etc/modules/Mage_Customer.xml
+++ b/app/etc/modules/Mage_Customer.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Customer

--- a/app/etc/modules/Mage_Dataflow.xml
+++ b/app/etc/modules/Mage_Dataflow.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/etc/modules/Mage_Dataflow.xml
+++ b/app/etc/modules/Mage_Dataflow.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Dataflow

--- a/app/etc/modules/Mage_Dataflow.xml
+++ b/app/etc/modules/Mage_Dataflow.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/etc/modules/Mage_Directory.xml
+++ b/app/etc/modules/Mage_Directory.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/etc/modules/Mage_Directory.xml
+++ b/app/etc/modules/Mage_Directory.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/etc/modules/Mage_Directory.xml
+++ b/app/etc/modules/Mage_Directory.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Directory

--- a/app/etc/modules/Mage_Downloadable.xml
+++ b/app/etc/modules/Mage_Downloadable.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/etc/modules/Mage_Downloadable.xml
+++ b/app/etc/modules/Mage_Downloadable.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Downloadable

--- a/app/etc/modules/Mage_Downloadable.xml
+++ b/app/etc/modules/Mage_Downloadable.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/etc/modules/Mage_Eav.xml
+++ b/app/etc/modules/Mage_Eav.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/etc/modules/Mage_Eav.xml
+++ b/app/etc/modules/Mage_Eav.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Eav

--- a/app/etc/modules/Mage_Eav.xml
+++ b/app/etc/modules/Mage_Eav.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/etc/modules/Mage_GiftMessage.xml
+++ b/app/etc/modules/Mage_GiftMessage.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_GiftMessage

--- a/app/etc/modules/Mage_GiftMessage.xml
+++ b/app/etc/modules/Mage_GiftMessage.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/etc/modules/Mage_GiftMessage.xml
+++ b/app/etc/modules/Mage_GiftMessage.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_GiftMessage

--- a/app/etc/modules/Mage_GoogleAnalytics.xml
+++ b/app/etc/modules/Mage_GoogleAnalytics.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_GoogleAnalytics

--- a/app/etc/modules/Mage_GoogleAnalytics.xml
+++ b/app/etc/modules/Mage_GoogleAnalytics.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_GoogleAnalytics

--- a/app/etc/modules/Mage_GoogleAnalytics.xml
+++ b/app/etc/modules/Mage_GoogleAnalytics.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/etc/modules/Mage_GoogleCheckout.xml
+++ b/app/etc/modules/Mage_GoogleCheckout.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_GoogleCheckout

--- a/app/etc/modules/Mage_GoogleCheckout.xml
+++ b/app/etc/modules/Mage_GoogleCheckout.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_GoogleCheckout

--- a/app/etc/modules/Mage_GoogleCheckout.xml
+++ b/app/etc/modules/Mage_GoogleCheckout.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/etc/modules/Mage_ImportExport.xml
+++ b/app/etc/modules/Mage_ImportExport.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/etc/modules/Mage_ImportExport.xml
+++ b/app/etc/modules/Mage_ImportExport.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ImportExport

--- a/app/etc/modules/Mage_ImportExport.xml
+++ b/app/etc/modules/Mage_ImportExport.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/etc/modules/Mage_Index.xml
+++ b/app/etc/modules/Mage_Index.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Index

--- a/app/etc/modules/Mage_Index.xml
+++ b/app/etc/modules/Mage_Index.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Index

--- a/app/etc/modules/Mage_Index.xml
+++ b/app/etc/modules/Mage_Index.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/etc/modules/Mage_Install.xml
+++ b/app/etc/modules/Mage_Install.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Install

--- a/app/etc/modules/Mage_Install.xml
+++ b/app/etc/modules/Mage_Install.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/etc/modules/Mage_Install.xml
+++ b/app/etc/modules/Mage_Install.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Install

--- a/app/etc/modules/Mage_Log.xml
+++ b/app/etc/modules/Mage_Log.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Log

--- a/app/etc/modules/Mage_Log.xml
+++ b/app/etc/modules/Mage_Log.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Log

--- a/app/etc/modules/Mage_Log.xml
+++ b/app/etc/modules/Mage_Log.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/etc/modules/Mage_Media.xml
+++ b/app/etc/modules/Mage_Media.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Media

--- a/app/etc/modules/Mage_Media.xml
+++ b/app/etc/modules/Mage_Media.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Media

--- a/app/etc/modules/Mage_Media.xml
+++ b/app/etc/modules/Mage_Media.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/etc/modules/Mage_Newsletter.xml
+++ b/app/etc/modules/Mage_Newsletter.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Newsletter

--- a/app/etc/modules/Mage_Newsletter.xml
+++ b/app/etc/modules/Mage_Newsletter.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Newsletter

--- a/app/etc/modules/Mage_Newsletter.xml
+++ b/app/etc/modules/Mage_Newsletter.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/etc/modules/Mage_Oauth.xml
+++ b/app/etc/modules/Mage_Oauth.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Oauth

--- a/app/etc/modules/Mage_Oauth.xml
+++ b/app/etc/modules/Mage_Oauth.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/etc/modules/Mage_Oauth.xml
+++ b/app/etc/modules/Mage_Oauth.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Oauth

--- a/app/etc/modules/Mage_Page.xml
+++ b/app/etc/modules/Mage_Page.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Page

--- a/app/etc/modules/Mage_Page.xml
+++ b/app/etc/modules/Mage_Page.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Page

--- a/app/etc/modules/Mage_Page.xml
+++ b/app/etc/modules/Mage_Page.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/etc/modules/Mage_Paygate.xml
+++ b/app/etc/modules/Mage_Paygate.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paygate

--- a/app/etc/modules/Mage_Paygate.xml
+++ b/app/etc/modules/Mage_Paygate.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paygate

--- a/app/etc/modules/Mage_Paygate.xml
+++ b/app/etc/modules/Mage_Paygate.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/etc/modules/Mage_Payment.xml
+++ b/app/etc/modules/Mage_Payment.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Payment

--- a/app/etc/modules/Mage_Payment.xml
+++ b/app/etc/modules/Mage_Payment.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Payment

--- a/app/etc/modules/Mage_Payment.xml
+++ b/app/etc/modules/Mage_Payment.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/etc/modules/Mage_Paypal.xml
+++ b/app/etc/modules/Mage_Paypal.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/etc/modules/Mage_Paypal.xml
+++ b/app/etc/modules/Mage_Paypal.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Paypal

--- a/app/etc/modules/Mage_Paypal.xml
+++ b/app/etc/modules/Mage_Paypal.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/etc/modules/Mage_PaypalUk.xml
+++ b/app/etc/modules/Mage_PaypalUk.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_PaypalUk

--- a/app/etc/modules/Mage_PaypalUk.xml
+++ b/app/etc/modules/Mage_PaypalUk.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_PaypalUk

--- a/app/etc/modules/Mage_PaypalUk.xml
+++ b/app/etc/modules/Mage_PaypalUk.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/etc/modules/Mage_Persistent.xml
+++ b/app/etc/modules/Mage_Persistent.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Persistent

--- a/app/etc/modules/Mage_Persistent.xml
+++ b/app/etc/modules/Mage_Persistent.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/etc/modules/Mage_Persistent.xml
+++ b/app/etc/modules/Mage_Persistent.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Persistent

--- a/app/etc/modules/Mage_Poll.xml
+++ b/app/etc/modules/Mage_Poll.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Poll

--- a/app/etc/modules/Mage_Poll.xml
+++ b/app/etc/modules/Mage_Poll.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Poll

--- a/app/etc/modules/Mage_Poll.xml
+++ b/app/etc/modules/Mage_Poll.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/etc/modules/Mage_ProductAlert.xml
+++ b/app/etc/modules/Mage_ProductAlert.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_ProductAlert

--- a/app/etc/modules/Mage_ProductAlert.xml
+++ b/app/etc/modules/Mage_ProductAlert.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_ProductAlert

--- a/app/etc/modules/Mage_ProductAlert.xml
+++ b/app/etc/modules/Mage_ProductAlert.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/etc/modules/Mage_Rating.xml
+++ b/app/etc/modules/Mage_Rating.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Rating

--- a/app/etc/modules/Mage_Rating.xml
+++ b/app/etc/modules/Mage_Rating.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Rating

--- a/app/etc/modules/Mage_Rating.xml
+++ b/app/etc/modules/Mage_Rating.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/etc/modules/Mage_Reports.xml
+++ b/app/etc/modules/Mage_Reports.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/etc/modules/Mage_Reports.xml
+++ b/app/etc/modules/Mage_Reports.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Reports

--- a/app/etc/modules/Mage_Reports.xml
+++ b/app/etc/modules/Mage_Reports.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/etc/modules/Mage_Review.xml
+++ b/app/etc/modules/Mage_Review.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Review

--- a/app/etc/modules/Mage_Review.xml
+++ b/app/etc/modules/Mage_Review.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Review

--- a/app/etc/modules/Mage_Review.xml
+++ b/app/etc/modules/Mage_Review.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/etc/modules/Mage_Rss.xml
+++ b/app/etc/modules/Mage_Rss.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Rss

--- a/app/etc/modules/Mage_Rss.xml
+++ b/app/etc/modules/Mage_Rss.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/etc/modules/Mage_Rss.xml
+++ b/app/etc/modules/Mage_Rss.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Rss

--- a/app/etc/modules/Mage_Rule.xml
+++ b/app/etc/modules/Mage_Rule.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Rule

--- a/app/etc/modules/Mage_Rule.xml
+++ b/app/etc/modules/Mage_Rule.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Rule

--- a/app/etc/modules/Mage_Rule.xml
+++ b/app/etc/modules/Mage_Rule.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/etc/modules/Mage_Sales.xml
+++ b/app/etc/modules/Mage_Sales.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/etc/modules/Mage_Sales.xml
+++ b/app/etc/modules/Mage_Sales.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sales

--- a/app/etc/modules/Mage_Sales.xml
+++ b/app/etc/modules/Mage_Sales.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/etc/modules/Mage_SalesRule.xml
+++ b/app/etc/modules/Mage_SalesRule.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/etc/modules/Mage_SalesRule.xml
+++ b/app/etc/modules/Mage_SalesRule.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_SalesRule

--- a/app/etc/modules/Mage_SalesRule.xml
+++ b/app/etc/modules/Mage_SalesRule.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/etc/modules/Mage_Sendfriend.xml
+++ b/app/etc/modules/Mage_Sendfriend.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sendfriend

--- a/app/etc/modules/Mage_Sendfriend.xml
+++ b/app/etc/modules/Mage_Sendfriend.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sendfriend

--- a/app/etc/modules/Mage_Sendfriend.xml
+++ b/app/etc/modules/Mage_Sendfriend.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/etc/modules/Mage_Shipping.xml
+++ b/app/etc/modules/Mage_Shipping.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Shipping

--- a/app/etc/modules/Mage_Shipping.xml
+++ b/app/etc/modules/Mage_Shipping.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Shipping

--- a/app/etc/modules/Mage_Shipping.xml
+++ b/app/etc/modules/Mage_Shipping.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/etc/modules/Mage_Sitemap.xml
+++ b/app/etc/modules/Mage_Sitemap.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Sitemap

--- a/app/etc/modules/Mage_Sitemap.xml
+++ b/app/etc/modules/Mage_Sitemap.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Sitemap

--- a/app/etc/modules/Mage_Sitemap.xml
+++ b/app/etc/modules/Mage_Sitemap.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/etc/modules/Mage_Tag.xml
+++ b/app/etc/modules/Mage_Tag.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tag

--- a/app/etc/modules/Mage_Tag.xml
+++ b/app/etc/modules/Mage_Tag.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tag

--- a/app/etc/modules/Mage_Tag.xml
+++ b/app/etc/modules/Mage_Tag.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/etc/modules/Mage_Tax.xml
+++ b/app/etc/modules/Mage_Tax.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/etc/modules/Mage_Tax.xml
+++ b/app/etc/modules/Mage_Tax.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Tax

--- a/app/etc/modules/Mage_Tax.xml
+++ b/app/etc/modules/Mage_Tax.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/etc/modules/Mage_Uploader.xml
+++ b/app/etc/modules/Mage_Uploader.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Uploader

--- a/app/etc/modules/Mage_Uploader.xml
+++ b/app/etc/modules/Mage_Uploader.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Uploader

--- a/app/etc/modules/Mage_Uploader.xml
+++ b/app/etc/modules/Mage_Uploader.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/etc/modules/Mage_Usa.xml
+++ b/app/etc/modules/Mage_Usa.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/etc/modules/Mage_Usa.xml
+++ b/app/etc/modules/Mage_Usa.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Usa

--- a/app/etc/modules/Mage_Usa.xml
+++ b/app/etc/modules/Mage_Usa.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/etc/modules/Mage_Weee.xml
+++ b/app/etc/modules/Mage_Weee.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Weee

--- a/app/etc/modules/Mage_Weee.xml
+++ b/app/etc/modules/Mage_Weee.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/etc/modules/Mage_Weee.xml
+++ b/app/etc/modules/Mage_Weee.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Weee

--- a/app/etc/modules/Mage_Widget.xml
+++ b/app/etc/modules/Mage_Widget.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Widget

--- a/app/etc/modules/Mage_Widget.xml
+++ b/app/etc/modules/Mage_Widget.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/app/etc/modules/Mage_Widget.xml
+++ b/app/etc/modules/Mage_Widget.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Widget

--- a/app/etc/modules/Mage_Wishlist.xml
+++ b/app/etc/modules/Mage_Wishlist.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/etc/modules/Mage_Wishlist.xml
+++ b/app/etc/modules/Mage_Wishlist.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Wishlist

--- a/app/etc/modules/Mage_Wishlist.xml
+++ b/app/etc/modules/Mage_Wishlist.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/cron.php
+++ b/cron.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Mage
  * @package     Mage

--- a/cron.php
+++ b/cron.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/cron.php
+++ b/cron.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Mage
  * @package     Mage

--- a/cron.sh
+++ b/cron.sh
@@ -2,8 +2,6 @@
 #
 # OpenMage
 #
-# NOTICE OF LICENSE
-#
 # This source file is subject to the Open Software License (OSL 3.0)
 # that is bundled with this package in the file LICENSE.txt.
 # It is also available through the world-wide-web at this URL:

--- a/cron.sh
+++ b/cron.sh
@@ -4,8 +4,7 @@
 #
 # This source file is subject to the Open Software License (OSL 3.0)
 # that is bundled with this package in the file LICENSE.txt.
-# It is also available through the world-wide-web at this URL:
-# https://opensource.org/licenses/osl-3.0.php
+# It is also available at https://opensource.org/license/osl-3-0-php
 #
 # @category    Mage
 # @package     Mage

--- a/cron.sh
+++ b/cron.sh
@@ -6,9 +6,6 @@
 # that is bundled with this package in the file LICENSE.txt.
 # It is also available through the world-wide-web at this URL:
 # https://opensource.org/licenses/osl-3.0.php
-# If you did not receive a copy of the license and are unable to
-# obtain it through the world-wide-web, please send an email
-# to license@magento.com so we can send you a copy immediately.
 #
 # @category    Mage
 # @package     Mage

--- a/dev/tests/functional/bootstrap.php
+++ b/dev/tests/functional/bootstrap.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/bootstrap.php
+++ b/dev/tests/functional/bootstrap.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/bootstrap.php
+++ b/dev/tests/functional/bootstrap.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/credentials.xml.dist
+++ b/dev/tests/functional/credentials.xml.dist
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/credentials.xml.dist
+++ b/dev/tests/functional/credentials.xml.dist
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/credentials.xml.dist
+++ b/dev/tests/functional/credentials.xml.dist
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/etc/config.xml
+++ b/dev/tests/functional/etc/config.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/etc/config.xml
+++ b/dev/tests/functional/etc/config.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/etc/config.xml
+++ b/dev/tests/functional/etc/config.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/etc/config.xsd
+++ b/dev/tests/functional/etc/config.xsd
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/etc/config.xsd
+++ b/dev/tests/functional/etc/config.xsd
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/etc/config.xsd
+++ b/dev/tests/functional/etc/config.xsd
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/etc/di.xml
+++ b/dev/tests/functional/etc/di.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/etc/di.xml
+++ b/dev/tests/functional/etc/di.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/etc/di.xml
+++ b/dev/tests/functional/etc/di.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/etc/events.xml
+++ b/dev/tests/functional/etc/events.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/etc/events.xml
+++ b/dev/tests/functional/etc/events.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/etc/events.xml
+++ b/dev/tests/functional/etc/events.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/etc/events.xsd
+++ b/dev/tests/functional/etc/events.xsd
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/etc/events.xsd
+++ b/dev/tests/functional/etc/events.xsd
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/etc/events.xsd
+++ b/dev/tests/functional/etc/events.xsd
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/isolation.php
+++ b/dev/tests/functional/isolation.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/isolation.php
+++ b/dev/tests/functional/isolation.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/isolation.php
+++ b/dev/tests/functional/isolation.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/lib/Magento/Mtf/App/State/AbstractState.php
+++ b/dev/tests/functional/lib/Magento/Mtf/App/State/AbstractState.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/lib/Magento/Mtf/App/State/AbstractState.php
+++ b/dev/tests/functional/lib/Magento/Mtf/App/State/AbstractState.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/lib/Magento/Mtf/App/State/AbstractState.php
+++ b/dev/tests/functional/lib/Magento/Mtf/App/State/AbstractState.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/lib/Magento/Mtf/App/State/State1.php
+++ b/dev/tests/functional/lib/Magento/Mtf/App/State/State1.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/lib/Magento/Mtf/App/State/State1.php
+++ b/dev/tests/functional/lib/Magento/Mtf/App/State/State1.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/lib/Magento/Mtf/App/State/State1.php
+++ b/dev/tests/functional/lib/Magento/Mtf/App/State/State1.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/lib/Magento/Mtf/Client/Driver/Selenium/Driver.php
+++ b/dev/tests/functional/lib/Magento/Mtf/Client/Driver/Selenium/Driver.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/lib/Magento/Mtf/Client/Driver/Selenium/Driver.php
+++ b/dev/tests/functional/lib/Magento/Mtf/Client/Driver/Selenium/Driver.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/lib/Magento/Mtf/Client/Driver/Selenium/Driver.php
+++ b/dev/tests/functional/lib/Magento/Mtf/Client/Driver/Selenium/Driver.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/lib/Magento/Mtf/Client/Element/ConditionsElement.php
+++ b/dev/tests/functional/lib/Magento/Mtf/Client/Element/ConditionsElement.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/lib/Magento/Mtf/Client/Element/ConditionsElement.php
+++ b/dev/tests/functional/lib/Magento/Mtf/Client/Element/ConditionsElement.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/lib/Magento/Mtf/Client/Element/ConditionsElement.php
+++ b/dev/tests/functional/lib/Magento/Mtf/Client/Element/ConditionsElement.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/lib/Magento/Mtf/Client/Element/MultiselectgrouplistElement.php
+++ b/dev/tests/functional/lib/Magento/Mtf/Client/Element/MultiselectgrouplistElement.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/lib/Magento/Mtf/Client/Element/MultiselectgrouplistElement.php
+++ b/dev/tests/functional/lib/Magento/Mtf/Client/Element/MultiselectgrouplistElement.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/lib/Magento/Mtf/Client/Element/MultiselectgrouplistElement.php
+++ b/dev/tests/functional/lib/Magento/Mtf/Client/Element/MultiselectgrouplistElement.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/lib/Magento/Mtf/Client/Element/MultiselectlistElement.php
+++ b/dev/tests/functional/lib/Magento/Mtf/Client/Element/MultiselectlistElement.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/lib/Magento/Mtf/Client/Element/MultiselectlistElement.php
+++ b/dev/tests/functional/lib/Magento/Mtf/Client/Element/MultiselectlistElement.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/lib/Magento/Mtf/Client/Element/MultiselectlistElement.php
+++ b/dev/tests/functional/lib/Magento/Mtf/Client/Element/MultiselectlistElement.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/lib/Magento/Mtf/Client/Element/OptgroupselectElement.php
+++ b/dev/tests/functional/lib/Magento/Mtf/Client/Element/OptgroupselectElement.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/lib/Magento/Mtf/Client/Element/OptgroupselectElement.php
+++ b/dev/tests/functional/lib/Magento/Mtf/Client/Element/OptgroupselectElement.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/lib/Magento/Mtf/Client/Element/OptgroupselectElement.php
+++ b/dev/tests/functional/lib/Magento/Mtf/Client/Element/OptgroupselectElement.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/lib/Magento/Mtf/Client/Element/SelectstoreElement.php
+++ b/dev/tests/functional/lib/Magento/Mtf/Client/Element/SelectstoreElement.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/lib/Magento/Mtf/Client/Element/SelectstoreElement.php
+++ b/dev/tests/functional/lib/Magento/Mtf/Client/Element/SelectstoreElement.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/lib/Magento/Mtf/Client/Element/SelectstoreElement.php
+++ b/dev/tests/functional/lib/Magento/Mtf/Client/Element/SelectstoreElement.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/lib/Magento/Mtf/Client/Element/SimpleElement.php
+++ b/dev/tests/functional/lib/Magento/Mtf/Client/Element/SimpleElement.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/lib/Magento/Mtf/Client/Element/SimpleElement.php
+++ b/dev/tests/functional/lib/Magento/Mtf/Client/Element/SimpleElement.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/lib/Magento/Mtf/Client/Element/SimpleElement.php
+++ b/dev/tests/functional/lib/Magento/Mtf/Client/Element/SimpleElement.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/lib/Magento/Mtf/Client/Element/TreeElement.php
+++ b/dev/tests/functional/lib/Magento/Mtf/Client/Element/TreeElement.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/lib/Magento/Mtf/Client/Element/TreeElement.php
+++ b/dev/tests/functional/lib/Magento/Mtf/Client/Element/TreeElement.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/lib/Magento/Mtf/Client/Element/TreeElement.php
+++ b/dev/tests/functional/lib/Magento/Mtf/Client/Element/TreeElement.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/lib/Magento/Mtf/Constraint/AbstractAssertForm.php
+++ b/dev/tests/functional/lib/Magento/Mtf/Constraint/AbstractAssertForm.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/lib/Magento/Mtf/Constraint/AbstractAssertForm.php
+++ b/dev/tests/functional/lib/Magento/Mtf/Constraint/AbstractAssertForm.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/lib/Magento/Mtf/Constraint/AbstractAssertForm.php
+++ b/dev/tests/functional/lib/Magento/Mtf/Constraint/AbstractAssertForm.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/lib/Magento/Mtf/Page/BackendPage.php
+++ b/dev/tests/functional/lib/Magento/Mtf/Page/BackendPage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/lib/Magento/Mtf/Page/BackendPage.php
+++ b/dev/tests/functional/lib/Magento/Mtf/Page/BackendPage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/lib/Magento/Mtf/Page/BackendPage.php
+++ b/dev/tests/functional/lib/Magento/Mtf/Page/BackendPage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/lib/Magento/Mtf/Util/Generate/Fixture/FieldsProvider.php
+++ b/dev/tests/functional/lib/Magento/Mtf/Util/Generate/Fixture/FieldsProvider.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/lib/Magento/Mtf/Util/Generate/Fixture/FieldsProvider.php
+++ b/dev/tests/functional/lib/Magento/Mtf/Util/Generate/Fixture/FieldsProvider.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/lib/Magento/Mtf/Util/Generate/Fixture/FieldsProvider.php
+++ b/dev/tests/functional/lib/Magento/Mtf/Util/Generate/Fixture/FieldsProvider.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/lib/Magento/Mtf/Util/Generate/Page.php
+++ b/dev/tests/functional/lib/Magento/Mtf/Util/Generate/Page.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/lib/Magento/Mtf/Util/Generate/Page.php
+++ b/dev/tests/functional/lib/Magento/Mtf/Util/Generate/Page.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/lib/Magento/Mtf/Util/Generate/Page.php
+++ b/dev/tests/functional/lib/Magento/Mtf/Util/Generate/Page.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/lib/Magento/Mtf/Util/Protocol/CurlTransport/BackendDecorator.php
+++ b/dev/tests/functional/lib/Magento/Mtf/Util/Protocol/CurlTransport/BackendDecorator.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/lib/Magento/Mtf/Util/Protocol/CurlTransport/BackendDecorator.php
+++ b/dev/tests/functional/lib/Magento/Mtf/Util/Protocol/CurlTransport/BackendDecorator.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/lib/Magento/Mtf/Util/Protocol/CurlTransport/BackendDecorator.php
+++ b/dev/tests/functional/lib/Magento/Mtf/Util/Protocol/CurlTransport/BackendDecorator.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/lib/Magento/Mtf/Util/Protocol/CurlTransport/FrontendDecorator.php
+++ b/dev/tests/functional/lib/Magento/Mtf/Util/Protocol/CurlTransport/FrontendDecorator.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/lib/Magento/Mtf/Util/Protocol/CurlTransport/FrontendDecorator.php
+++ b/dev/tests/functional/lib/Magento/Mtf/Util/Protocol/CurlTransport/FrontendDecorator.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/lib/Magento/Mtf/Util/Protocol/CurlTransport/FrontendDecorator.php
+++ b/dev/tests/functional/lib/Magento/Mtf/Util/Protocol/CurlTransport/FrontendDecorator.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/phpunit.xml.dist
+++ b/dev/tests/functional/phpunit.xml.dist
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/phpunit.xml.dist
+++ b/dev/tests/functional/phpunit.xml.dist
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/phpunit.xml.dist
+++ b/dev/tests/functional/phpunit.xml.dist
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/Constraint/AssertRoleInGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/Constraint/AssertRoleInGrid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/Constraint/AssertRoleInGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/Constraint/AssertRoleInGrid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/Constraint/AssertRoleInGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/Constraint/AssertRoleInGrid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/Constraint/AssertRoleSuccessSaveMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/Constraint/AssertRoleSuccessSaveMessage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/Constraint/AssertRoleSuccessSaveMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/Constraint/AssertRoleSuccessSaveMessage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/Constraint/AssertRoleSuccessSaveMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/Constraint/AssertRoleSuccessSaveMessage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/Constraint/AssertUserAccessDeniedMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/Constraint/AssertUserAccessDeniedMessage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/Constraint/AssertUserAccessDeniedMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/Constraint/AssertUserAccessDeniedMessage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/Constraint/AssertUserAccessDeniedMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/Constraint/AssertUserAccessDeniedMessage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/Constraint/AssertUserAccountInactiveMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/Constraint/AssertUserAccountInactiveMessage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/Constraint/AssertUserAccountInactiveMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/Constraint/AssertUserAccountInactiveMessage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/Constraint/AssertUserAccountInactiveMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/Constraint/AssertUserAccountInactiveMessage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/Constraint/AssertUserDuplicateMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/Constraint/AssertUserDuplicateMessage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/Constraint/AssertUserDuplicateMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/Constraint/AssertUserDuplicateMessage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/Constraint/AssertUserDuplicateMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/Constraint/AssertUserDuplicateMessage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/Constraint/AssertUserInGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/Constraint/AssertUserInGrid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/Constraint/AssertUserInGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/Constraint/AssertUserInGrid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/Constraint/AssertUserInGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/Constraint/AssertUserInGrid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/Constraint/AssertUserInvalidEmailMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/Constraint/AssertUserInvalidEmailMessage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/Constraint/AssertUserInvalidEmailMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/Constraint/AssertUserInvalidEmailMessage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/Constraint/AssertUserInvalidEmailMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/Constraint/AssertUserInvalidEmailMessage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/Constraint/AssertUserIsLockedMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/Constraint/AssertUserIsLockedMessage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/Constraint/AssertUserIsLockedMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/Constraint/AssertUserIsLockedMessage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/Constraint/AssertUserIsLockedMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/Constraint/AssertUserIsLockedMessage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/Constraint/AssertUserSuccessLogOut.php
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/Constraint/AssertUserSuccessLogOut.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/Constraint/AssertUserSuccessLogOut.php
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/Constraint/AssertUserSuccessLogOut.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/Constraint/AssertUserSuccessLogOut.php
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/Constraint/AssertUserSuccessLogOut.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/Constraint/AssertUserSuccessLogin.php
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/Constraint/AssertUserSuccessLogin.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/Constraint/AssertUserSuccessLogin.php
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/Constraint/AssertUserSuccessLogin.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/Constraint/AssertUserSuccessLogin.php
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/Constraint/AssertUserSuccessLogin.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/Constraint/AssertUserSuccessSaveMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/Constraint/AssertUserSuccessSaveMessage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/Constraint/AssertUserSuccessSaveMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/Constraint/AssertUserSuccessSaveMessage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/Constraint/AssertUserSuccessSaveMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/Constraint/AssertUserSuccessSaveMessage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/Constraint/AssertUserWithCustomRole.php
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/Constraint/AssertUserWithCustomRole.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/Constraint/AssertUserWithCustomRole.php
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/Constraint/AssertUserWithCustomRole.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/Constraint/AssertUserWithCustomRole.php
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/Constraint/AssertUserWithCustomRole.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/Constraint/AssertUserWithRestrictedResources.php
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/Constraint/AssertUserWithRestrictedResources.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/Constraint/AssertUserWithRestrictedResources.php
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/Constraint/AssertUserWithRestrictedResources.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/Constraint/AssertUserWithRestrictedResources.php
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/Constraint/AssertUserWithRestrictedResources.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/Constraint/AssertUserWrongCredentialsMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/Constraint/AssertUserWrongCredentialsMessage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/Constraint/AssertUserWrongCredentialsMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/Constraint/AssertUserWrongCredentialsMessage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/Constraint/AssertUserWrongCredentialsMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/Constraint/AssertUserWrongCredentialsMessage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/Fixture/Role.xml
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/Fixture/Role.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/Fixture/Role.xml
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/Fixture/Role.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/Fixture/Role.xml
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/Fixture/Role.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/Fixture/Role/GwsStoreGroups.php
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/Fixture/Role/GwsStoreGroups.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/Fixture/Role/GwsStoreGroups.php
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/Fixture/Role/GwsStoreGroups.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/Fixture/Role/GwsStoreGroups.php
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/Fixture/Role/GwsStoreGroups.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/Fixture/Role/InRoleUsers.php
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/Fixture/Role/InRoleUsers.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/Fixture/Role/InRoleUsers.php
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/Fixture/Role/InRoleUsers.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/Fixture/Role/InRoleUsers.php
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/Fixture/Role/InRoleUsers.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/Fixture/Role/RolesResources.php
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/Fixture/Role/RolesResources.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/Fixture/Role/RolesResources.php
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/Fixture/Role/RolesResources.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/Fixture/Role/RolesResources.php
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/Fixture/Role/RolesResources.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/Fixture/User.xml
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/Fixture/User.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/Fixture/User.xml
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/Fixture/User.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/Fixture/User.xml
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/Fixture/User.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/Fixture/User/RoleId.php
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/Fixture/User/RoleId.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/Fixture/User/RoleId.php
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/Fixture/User/RoleId.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/Fixture/User/RoleId.php
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/Fixture/User/RoleId.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/Handler/Role/Curl.php
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/Handler/Role/Curl.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/Handler/Role/Curl.php
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/Handler/Role/Curl.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/Handler/Role/Curl.php
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/Handler/Role/Curl.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/Handler/Role/RoleInterface.php
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/Handler/Role/RoleInterface.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/Handler/Role/RoleInterface.php
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/Handler/Role/RoleInterface.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/Handler/Role/RoleInterface.php
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/Handler/Role/RoleInterface.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/Handler/User/Curl.php
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/Handler/User/Curl.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/Handler/User/Curl.php
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/Handler/User/Curl.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/Handler/User/Curl.php
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/Handler/User/Curl.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/Handler/User/UserInterface.php
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/Handler/User/UserInterface.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/Handler/User/UserInterface.php
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/Handler/User/UserInterface.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/Handler/User/UserInterface.php
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/Handler/User/UserInterface.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/Page/Adminhtml/UserEdit.xml
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/Page/Adminhtml/UserEdit.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/Page/Adminhtml/UserEdit.xml
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/Page/Adminhtml/UserEdit.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/Page/Adminhtml/UserEdit.xml
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/Page/Adminhtml/UserEdit.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/Page/Adminhtml/UserIndex.xml
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/Page/Adminhtml/UserIndex.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/Page/Adminhtml/UserIndex.xml
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/Page/Adminhtml/UserIndex.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/Page/Adminhtml/UserIndex.xml
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/Page/Adminhtml/UserIndex.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/Page/Adminhtml/UserRoleEditRole.xml
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/Page/Adminhtml/UserRoleEditRole.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/Page/Adminhtml/UserRoleEditRole.xml
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/Page/Adminhtml/UserRoleEditRole.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/Page/Adminhtml/UserRoleEditRole.xml
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/Page/Adminhtml/UserRoleEditRole.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/Page/Adminhtml/UserRoleIndex.xml
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/Page/Adminhtml/UserRoleIndex.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/Page/Adminhtml/UserRoleIndex.xml
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/Page/Adminhtml/UserRoleIndex.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/Page/Adminhtml/UserRoleIndex.xml
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/Page/Adminhtml/UserRoleIndex.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/Repository/Role.xml
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/Repository/Role.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/Repository/Role.xml
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/Repository/Role.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/Repository/Role.xml
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/Repository/Role.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/Repository/User.xml
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/Repository/User.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/Repository/User.xml
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/Repository/User.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/Repository/User.xml
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/Repository/User.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/TestCase/CreateAdminUserEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/TestCase/CreateAdminUserEntityTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/TestCase/CreateAdminUserEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/TestCase/CreateAdminUserEntityTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/TestCase/CreateAdminUserEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/TestCase/CreateAdminUserEntityTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/TestCase/CreateAdminUserEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/TestCase/CreateAdminUserEntityTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/TestCase/CreateAdminUserEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/TestCase/CreateAdminUserEntityTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/TestCase/CreateAdminUserEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/TestCase/CreateAdminUserEntityTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/TestCase/CreateAdminUserRoleEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/TestCase/CreateAdminUserRoleEntityTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/TestCase/CreateAdminUserRoleEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/TestCase/CreateAdminUserRoleEntityTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/TestCase/CreateAdminUserRoleEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/TestCase/CreateAdminUserRoleEntityTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/TestCase/CreateAdminUserRoleEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/TestCase/CreateAdminUserRoleEntityTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/TestCase/CreateAdminUserRoleEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/TestCase/CreateAdminUserRoleEntityTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/TestCase/CreateAdminUserRoleEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/TestCase/CreateAdminUserRoleEntityTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/TestCase/UseAclRoleWithRestrictedGwsScopeTest.php
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/TestCase/UseAclRoleWithRestrictedGwsScopeTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/TestCase/UseAclRoleWithRestrictedGwsScopeTest.php
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/TestCase/UseAclRoleWithRestrictedGwsScopeTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/TestCase/UseAclRoleWithRestrictedGwsScopeTest.php
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/TestCase/UseAclRoleWithRestrictedGwsScopeTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/TestCase/UseAclRoleWithRestrictedGwsScopeTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/TestCase/UseAclRoleWithRestrictedGwsScopeTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/TestCase/UseAclRoleWithRestrictedGwsScopeTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/TestCase/UseAclRoleWithRestrictedGwsScopeTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/TestCase/UseAclRoleWithRestrictedGwsScopeTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/TestCase/UseAclRoleWithRestrictedGwsScopeTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/etc/curl/di.xml
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/etc/curl/di.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/etc/curl/di.xml
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/etc/curl/di.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/etc/curl/di.xml
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/etc/curl/di.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/etc/fixture.xml
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/etc/fixture.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/etc/fixture.xml
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/etc/fixture.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Admin/Test/etc/fixture.xml
+++ b/dev/tests/functional/tests/app/Mage/Admin/Test/etc/fixture.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Admin/Login.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Admin/Login.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Admin/Login.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Admin/Login.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Admin/Login.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Admin/Login.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Admin/Login.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Admin/Login.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Admin/Login.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Admin/Login.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Admin/Login.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Admin/Login.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Api/User/Tab/Role.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Api/User/Tab/Role.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Api/User/Tab/Role.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Api/User/Tab/Role.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Api/User/Tab/Role.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Api/User/Tab/Role.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Api/User/Tab/Role/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Api/User/Tab/Role/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Api/User/Tab/Role/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Api/User/Tab/Role/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Api/User/Tab/Role/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Api/User/Tab/Role/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Api/User/UserForm.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Api/User/UserForm.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Api/User/UserForm.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Api/User/UserForm.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Api/User/UserForm.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Api/User/UserForm.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Api/User/UserForm.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Api/User/UserForm.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Api/User/UserForm.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Api/User/UserForm.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Api/User/UserForm.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Api/User/UserForm.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Cache/PageActions.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Cache/PageActions.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Cache/PageActions.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Cache/PageActions.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Cache/PageActions.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Cache/PageActions.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Category/Content.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Category/Content.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Category/Content.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Category/Content.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Category/Content.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Category/Content.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Category/Edit/CategoryForm.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Category/Edit/CategoryForm.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Category/Edit/CategoryForm.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Category/Edit/CategoryForm.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Category/Edit/CategoryForm.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Category/Edit/CategoryForm.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Category/Edit/CategoryForm.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Category/Edit/CategoryForm.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Category/Edit/CategoryForm.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Category/Edit/CategoryForm.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Category/Edit/CategoryForm.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Category/Edit/CategoryForm.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Category/Edit/Tab/Product.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Category/Edit/Tab/Product.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Category/Edit/Tab/Product.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Category/Edit/Tab/Product.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Category/Edit/Tab/Product.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Category/Edit/Tab/Product.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Category/Edit/Tab/Product/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Category/Edit/Tab/Product/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Category/Edit/Tab/Product/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Category/Edit/Tab/Product/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Category/Edit/Tab/Product/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Category/Edit/Tab/Product/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Category/Tree.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Category/Tree.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Category/Tree.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Category/Tree.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Category/Tree.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Category/Tree.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Attribute/CustomAttribute.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Attribute/CustomAttribute.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Attribute/CustomAttribute.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Attribute/CustomAttribute.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Attribute/CustomAttribute.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Attribute/CustomAttribute.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Attribute/Edit/AttributeForm.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Attribute/Edit/AttributeForm.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Attribute/Edit/AttributeForm.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Attribute/Edit/AttributeForm.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Attribute/Edit/AttributeForm.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Attribute/Edit/AttributeForm.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Attribute/Edit/AttributeForm.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Attribute/Edit/AttributeForm.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Attribute/Edit/AttributeForm.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Attribute/Edit/AttributeForm.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Attribute/Edit/AttributeForm.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Attribute/Edit/AttributeForm.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Attribute/Edit/Tab/Options.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Attribute/Edit/Tab/Options.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Attribute/Edit/Tab/Options.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Attribute/Edit/Tab/Options.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Attribute/Edit/Tab/Options.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Attribute/Edit/Tab/Options.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Attribute/Edit/Tab/Options/Option.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Attribute/Edit/Tab/Options/Option.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Attribute/Edit/Tab/Options/Option.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Attribute/Edit/Tab/Options/Option.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Attribute/Edit/Tab/Options/Option.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Attribute/Edit/Tab/Options/Option.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Attribute/Edit/Tab/Options/Option.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Attribute/Edit/Tab/Options/Option.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Attribute/Edit/Tab/Options/Option.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Attribute/Edit/Tab/Options/Option.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Attribute/Edit/Tab/Options/Option.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Attribute/Edit/Tab/Options/Option.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Attribute/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Attribute/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Attribute/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Attribute/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Attribute/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Attribute/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Attribute/Set/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Attribute/Set/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Attribute/Set/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Attribute/Set/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Attribute/Set/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Attribute/Set/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Attribute/Set/Main.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Attribute/Set/Main.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Attribute/Set/Main.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Attribute/Set/Main.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Attribute/Set/Main.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Attribute/Set/Main.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Attribute/Set/Main/AttributeSetForm.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Attribute/Set/Main/AttributeSetForm.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Attribute/Set/Main/AttributeSetForm.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Attribute/Set/Main/AttributeSetForm.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Attribute/Set/Main/AttributeSetForm.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Attribute/Set/Main/AttributeSetForm.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Attribute/Set/Main/AttributeSetForm.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Attribute/Set/Main/AttributeSetForm.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Attribute/Set/Main/AttributeSetForm.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Attribute/Set/Main/AttributeSetForm.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Attribute/Set/Main/AttributeSetForm.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Attribute/Set/Main/AttributeSetForm.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Attribute/Set/Main/EditForm.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Attribute/Set/Main/EditForm.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Attribute/Set/Main/EditForm.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Attribute/Set/Main/EditForm.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Attribute/Set/Main/EditForm.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Attribute/Set/Main/EditForm.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Attribute/Set/Main/EditForm.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Attribute/Set/Main/EditForm.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Attribute/Set/Main/EditForm.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Attribute/Set/Main/EditForm.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Attribute/Set/Main/EditForm.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Attribute/Set/Main/EditForm.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/AbstractAppurtenant.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/AbstractAppurtenant.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/AbstractAppurtenant.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/AbstractAppurtenant.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/AbstractAppurtenant.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/AbstractAppurtenant.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/AbstractAppurtenantProductsGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/AbstractAppurtenantProductsGrid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/AbstractAppurtenantProductsGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/AbstractAppurtenantProductsGrid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/AbstractAppurtenantProductsGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/AbstractAppurtenantProductsGrid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/AbstractOptions.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/AbstractOptions.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/AbstractOptions.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/AbstractOptions.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/AbstractOptions.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/AbstractOptions.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/AbstractSelectOptions.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/AbstractSelectOptions.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/AbstractSelectOptions.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/AbstractSelectOptions.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/AbstractSelectOptions.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/AbstractSelectOptions.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/AssociatedProducts.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/AssociatedProducts.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/AssociatedProducts.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/AssociatedProducts.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/AssociatedProducts.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/AssociatedProducts.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/AssociatedProducts/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/AssociatedProducts/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/AssociatedProducts/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/AssociatedProducts/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/AssociatedProducts/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/AssociatedProducts/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/AssociatedProducts/Product.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/AssociatedProducts/Product.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/AssociatedProducts/Product.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/AssociatedProducts/Product.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/AssociatedProducts/Product.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/AssociatedProducts/Product.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/AssociatedProducts/Product.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/AssociatedProducts/Product.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/AssociatedProducts/Product.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/AssociatedProducts/Product.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/AssociatedProducts/Product.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/AssociatedProducts/Product.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Categories.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Categories.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Categories.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Categories.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Categories.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Categories.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Configurable.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Configurable.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Configurable.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Configurable.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Configurable.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Configurable.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Configurable/Attribute.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Configurable/Attribute.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Configurable/Attribute.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Configurable/Attribute.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Configurable/Attribute.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Configurable/Attribute.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Configurable/Attribute.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Configurable/Attribute.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Configurable/Attribute.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Configurable/Attribute.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Configurable/Attribute.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Configurable/Attribute.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Configurable/Attribute/Option.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Configurable/Attribute/Option.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Configurable/Attribute/Option.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Configurable/Attribute/Option.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Configurable/Attribute/Option.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Configurable/Attribute/Option.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Configurable/Attribute/Option.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Configurable/Attribute/Option.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Configurable/Attribute/Option.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Configurable/Attribute/Option.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Configurable/Attribute/Option.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Configurable/Attribute/Option.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Configurable/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Configurable/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Configurable/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Configurable/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Configurable/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Configurable/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Configurable/NewProductPopup.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Configurable/NewProductPopup.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Configurable/NewProductPopup.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Configurable/NewProductPopup.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Configurable/NewProductPopup.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Configurable/NewProductPopup.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Configurable/NewProductPopup.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Configurable/NewProductPopup.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Configurable/NewProductPopup.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Configurable/NewProductPopup.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Configurable/NewProductPopup.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Configurable/NewProductPopup.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Configurable/QuickCreation.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Configurable/QuickCreation.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Configurable/QuickCreation.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Configurable/QuickCreation.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Configurable/QuickCreation.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Configurable/QuickCreation.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Configurable/QuickCreation.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Configurable/QuickCreation.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Configurable/QuickCreation.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Configurable/QuickCreation.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Configurable/QuickCreation.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Configurable/QuickCreation.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Configurable/QuickCreation/AttributesElement.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Configurable/QuickCreation/AttributesElement.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Configurable/QuickCreation/AttributesElement.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Configurable/QuickCreation/AttributesElement.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Configurable/QuickCreation/AttributesElement.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Configurable/QuickCreation/AttributesElement.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Configurable/SimpleAssociatedProduct.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Configurable/SimpleAssociatedProduct.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Configurable/SimpleAssociatedProduct.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Configurable/SimpleAssociatedProduct.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Configurable/SimpleAssociatedProduct.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Configurable/SimpleAssociatedProduct.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Crosssell.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Crosssell.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Crosssell.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Crosssell.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Crosssell.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Crosssell.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Crosssell/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Crosssell/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Crosssell/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Crosssell/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Crosssell/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Crosssell/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/Area.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/Area.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/Area.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/Area.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/Area.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/Area.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/Area.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/Area.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/Area.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/Area.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/Area.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/Area.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/Checkbox.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/Checkbox.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/Checkbox.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/Checkbox.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/Checkbox.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/Checkbox.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/Checkbox.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/Checkbox.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/Checkbox.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/Checkbox.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/Checkbox.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/Checkbox.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/Date.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/Date.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/Date.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/Date.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/Date.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/Date.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/Date.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/Date.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/Date.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/Date.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/Date.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/Date.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/DateTime.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/DateTime.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/DateTime.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/DateTime.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/DateTime.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/DateTime.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/DateTime.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/DateTime.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/DateTime.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/DateTime.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/DateTime.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/DateTime.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/DropDown.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/DropDown.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/DropDown.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/DropDown.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/DropDown.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/DropDown.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/DropDown.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/DropDown.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/DropDown.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/DropDown.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/DropDown.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/DropDown.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/Field.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/Field.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/Field.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/Field.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/Field.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/Field.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/Field.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/Field.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/Field.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/Field.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/Field.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/Field.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/File.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/File.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/File.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/File.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/File.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/File.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/File.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/File.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/File.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/File.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/File.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/File.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/MultipleSelect.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/MultipleSelect.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/MultipleSelect.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/MultipleSelect.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/MultipleSelect.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/MultipleSelect.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/MultipleSelect.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/MultipleSelect.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/MultipleSelect.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/MultipleSelect.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/MultipleSelect.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/MultipleSelect.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/RadioButtons.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/RadioButtons.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/RadioButtons.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/RadioButtons.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/RadioButtons.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/RadioButtons.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/RadioButtons.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/RadioButtons.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/RadioButtons.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/RadioButtons.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/RadioButtons.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/RadioButtons.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/Time.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/Time.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/Time.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/Time.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/Time.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/Time.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/Time.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/Time.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/Time.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/Time.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/Time.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/CustomOptions/Time.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Prices.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Prices.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Prices.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Prices.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Prices.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Prices.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Prices/OptionGroup.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Prices/OptionGroup.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Prices/OptionGroup.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Prices/OptionGroup.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Prices/OptionGroup.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Prices/OptionGroup.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Prices/OptionGroup.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Prices/OptionGroup.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Prices/OptionGroup.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Prices/OptionGroup.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Prices/OptionGroup.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Prices/OptionGroup.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Prices/OptionTier.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Prices/OptionTier.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Prices/OptionTier.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Prices/OptionTier.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Prices/OptionTier.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Prices/OptionTier.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Prices/OptionTier.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Prices/OptionTier.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Prices/OptionTier.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Prices/OptionTier.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Prices/OptionTier.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Prices/OptionTier.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/ProductSettings.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/ProductSettings.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/ProductSettings.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/ProductSettings.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/ProductSettings.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/ProductSettings.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Related.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Related.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Related.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Related.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Related.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Related.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Related/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Related/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Related/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Related/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Related/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Related/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/SuperSettings.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/SuperSettings.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/SuperSettings.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/SuperSettings.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/SuperSettings.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/SuperSettings.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Upsell.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Upsell.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Upsell.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Upsell.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Upsell.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Upsell.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Upsell/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Upsell/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Upsell/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Upsell/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Upsell/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Upsell/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Websites.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Websites.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Websites.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Websites.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Websites.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Edit/Tab/Websites.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/FormPageActions.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/FormPageActions.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/FormPageActions.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/FormPageActions.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/FormPageActions.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/FormPageActions.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/ProductForm.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/ProductForm.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/ProductForm.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/ProductForm.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/ProductForm.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/ProductForm.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/ProductForm.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/ProductForm.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/ProductForm.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/ProductForm.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/ProductForm.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Catalog/Product/ProductForm.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/CatalogRule/FormPageActions.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/CatalogRule/FormPageActions.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/CatalogRule/FormPageActions.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/CatalogRule/FormPageActions.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/CatalogRule/FormPageActions.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/CatalogRule/FormPageActions.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/CatalogRule/Promo/Catalog.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/CatalogRule/Promo/Catalog.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/CatalogRule/Promo/Catalog.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/CatalogRule/Promo/Catalog.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/CatalogRule/Promo/Catalog.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/CatalogRule/Promo/Catalog.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/CatalogRule/Promo/Catalog/Edit/Form.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/CatalogRule/Promo/Catalog/Edit/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/CatalogRule/Promo/Catalog/Edit/Form.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/CatalogRule/Promo/Catalog/Edit/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/CatalogRule/Promo/Catalog/Edit/Form.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/CatalogRule/Promo/Catalog/Edit/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/CatalogRule/Promo/Catalog/Edit/Form.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/CatalogRule/Promo/Catalog/Edit/Form.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/CatalogRule/Promo/Catalog/Edit/Form.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/CatalogRule/Promo/Catalog/Edit/Form.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/CatalogRule/Promo/Catalog/Edit/Form.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/CatalogRule/Promo/Catalog/Edit/Form.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/CatalogRule/Promo/Catalog/Edit/PromoForm.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/CatalogRule/Promo/Catalog/Edit/PromoForm.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/CatalogRule/Promo/Catalog/Edit/PromoForm.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/CatalogRule/Promo/Catalog/Edit/PromoForm.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/CatalogRule/Promo/Catalog/Edit/PromoForm.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/CatalogRule/Promo/Catalog/Edit/PromoForm.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/CatalogRule/Promo/Catalog/Edit/PromoForm.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/CatalogRule/Promo/Catalog/Edit/PromoForm.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/CatalogRule/Promo/Catalog/Edit/PromoForm.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/CatalogRule/Promo/Catalog/Edit/PromoForm.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/CatalogRule/Promo/Catalog/Edit/PromoForm.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/CatalogRule/Promo/Catalog/Edit/PromoForm.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/CatalogRule/Promo/GridPageActions.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/CatalogRule/Promo/GridPageActions.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/CatalogRule/Promo/GridPageActions.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/CatalogRule/Promo/GridPageActions.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/CatalogRule/Promo/GridPageActions.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/CatalogRule/Promo/GridPageActions.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/CatalogSearch/Edit/SearchTermForm.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/CatalogSearch/Edit/SearchTermForm.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/CatalogSearch/Edit/SearchTermForm.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/CatalogSearch/Edit/SearchTermForm.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/CatalogSearch/Edit/SearchTermForm.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/CatalogSearch/Edit/SearchTermForm.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/CatalogSearch/Edit/SearchTermForm.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/CatalogSearch/Edit/SearchTermForm.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/CatalogSearch/Edit/SearchTermForm.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/CatalogSearch/Edit/SearchTermForm.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/CatalogSearch/Edit/SearchTermForm.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/CatalogSearch/Edit/SearchTermForm.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/CatalogSearch/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/CatalogSearch/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/CatalogSearch/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/CatalogSearch/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/CatalogSearch/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/CatalogSearch/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Checkout/Agreement/Edit/Form.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Checkout/Agreement/Edit/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Checkout/Agreement/Edit/Form.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Checkout/Agreement/Edit/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Checkout/Agreement/Edit/Form.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Checkout/Agreement/Edit/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Checkout/Agreement/Edit/Form.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Checkout/Agreement/Edit/Form.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Checkout/Agreement/Edit/Form.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Checkout/Agreement/Edit/Form.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Checkout/Agreement/Edit/Form.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Checkout/Agreement/Edit/Form.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Checkout/Agreement/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Checkout/Agreement/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Checkout/Agreement/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Checkout/Agreement/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Checkout/Agreement/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Checkout/Agreement/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Cms/Block/CmsGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Cms/Block/CmsGrid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Cms/Block/CmsGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Cms/Block/CmsGrid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Cms/Block/CmsGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Cms/Block/CmsGrid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Cms/Block/Edit/BlockForm.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Cms/Block/Edit/BlockForm.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Cms/Block/Edit/BlockForm.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Cms/Block/Edit/BlockForm.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Cms/Block/Edit/BlockForm.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Cms/Block/Edit/BlockForm.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Cms/Block/Edit/BlockForm.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Cms/Block/Edit/BlockForm.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Cms/Block/Edit/BlockForm.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Cms/Block/Edit/BlockForm.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Cms/Block/Edit/BlockForm.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Cms/Block/Edit/BlockForm.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Cms/Block/Edit/FormPageActions.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Cms/Block/Edit/FormPageActions.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Cms/Block/Edit/FormPageActions.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Cms/Block/Edit/FormPageActions.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Cms/Block/Edit/FormPageActions.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Cms/Block/Edit/FormPageActions.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Cms/Page/Edit/FormPageActions.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Cms/Page/Edit/FormPageActions.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Cms/Page/Edit/FormPageActions.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Cms/Page/Edit/FormPageActions.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Cms/Page/Edit/FormPageActions.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Cms/Page/Edit/FormPageActions.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Cms/Page/Edit/PageForm.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Cms/Page/Edit/PageForm.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Cms/Page/Edit/PageForm.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Cms/Page/Edit/PageForm.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Cms/Page/Edit/PageForm.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Cms/Page/Edit/PageForm.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Cms/Page/Edit/PageForm.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Cms/Page/Edit/PageForm.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Cms/Page/Edit/PageForm.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Cms/Page/Edit/PageForm.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Cms/Page/Edit/PageForm.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Cms/Page/Edit/PageForm.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Cms/Page/Edit/Tab/Content.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Cms/Page/Edit/Tab/Content.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Cms/Page/Edit/Tab/Content.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Cms/Page/Edit/Tab/Content.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Cms/Page/Edit/Tab/Content.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Cms/Page/Edit/Tab/Content.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Cms/Page/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Cms/Page/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Cms/Page/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Cms/Page/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Cms/Page/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Cms/Page/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Cms/Page/Widget/Chooser.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Cms/Page/Widget/Chooser.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Cms/Page/Widget/Chooser.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Cms/Page/Widget/Chooser.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Cms/Page/Widget/Chooser.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Cms/Page/Widget/Chooser.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Cms/Wysiwyg/Config.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Cms/Wysiwyg/Config.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Cms/Wysiwyg/Config.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Cms/Wysiwyg/Config.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Cms/Wysiwyg/Config.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Cms/Wysiwyg/Config.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Customer/CustomerGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Customer/CustomerGrid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Customer/CustomerGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Customer/CustomerGrid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Customer/CustomerGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Customer/CustomerGrid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Customer/Edit/CustomerForm.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Customer/Edit/CustomerForm.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Customer/Edit/CustomerForm.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Customer/Edit/CustomerForm.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Customer/Edit/CustomerForm.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Customer/Edit/CustomerForm.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Customer/Edit/CustomerForm.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Customer/Edit/CustomerForm.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Customer/Edit/CustomerForm.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Customer/Edit/CustomerForm.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Customer/Edit/CustomerForm.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Customer/Edit/CustomerForm.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Customer/Edit/FormPageActions.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Customer/Edit/FormPageActions.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Customer/Edit/FormPageActions.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Customer/Edit/FormPageActions.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Customer/Edit/FormPageActions.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Customer/Edit/FormPageActions.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Customer/Edit/Tab/Addresses.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Customer/Edit/Tab/Addresses.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Customer/Edit/Tab/Addresses.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Customer/Edit/Tab/Addresses.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Customer/Edit/Tab/Addresses.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Customer/Edit/Tab/Addresses.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Customer/Edit/Tab/Addresses.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Customer/Edit/Tab/Addresses.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Customer/Edit/Tab/Addresses.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Customer/Edit/Tab/Addresses.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Customer/Edit/Tab/Addresses.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Customer/Edit/Tab/Addresses.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Customer/Group/Edit/Form.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Customer/Group/Edit/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Customer/Group/Edit/Form.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Customer/Group/Edit/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Customer/Group/Edit/Form.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Customer/Group/Edit/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Customer/Group/Edit/Form.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Customer/Group/Edit/Form.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Customer/Group/Edit/Form.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Customer/Group/Edit/Form.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Customer/Group/Edit/Form.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Customer/Group/Edit/Form.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Customer/Group/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Customer/Group/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Customer/Group/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Customer/Group/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Customer/Group/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Customer/Group/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/FormPageActions.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/FormPageActions.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/FormPageActions.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/FormPageActions.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/FormPageActions.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/FormPageActions.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/GridPageActions.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/GridPageActions.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/GridPageActions.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/GridPageActions.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/GridPageActions.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/GridPageActions.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Newsletter/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Newsletter/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Newsletter/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Newsletter/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Newsletter/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Newsletter/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Page/Footer.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Page/Footer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Page/Footer.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Page/Footer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Page/Footer.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Page/Footer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Page/Header.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Page/Header.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Page/Header.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Page/Header.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Page/Header.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Page/Header.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Page/Main.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Page/Main.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Page/Main.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Page/Main.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Page/Main.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Page/Main.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/PageActions.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/PageActions.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/PageActions.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/PageActions.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/PageActions.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/PageActions.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Permissions/Role/Edit/Tab/RoleResources.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Permissions/Role/Edit/Tab/RoleResources.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Permissions/Role/Edit/Tab/RoleResources.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Permissions/Role/Edit/Tab/RoleResources.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Permissions/Role/Edit/Tab/RoleResources.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Permissions/Role/Edit/Tab/RoleResources.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Permissions/Role/Grid/RoleGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Permissions/Role/Grid/RoleGrid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Permissions/Role/Grid/RoleGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Permissions/Role/Grid/RoleGrid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Permissions/Role/Grid/RoleGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Permissions/Role/Grid/RoleGrid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Permissions/Role/RoleForm.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Permissions/Role/RoleForm.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Permissions/Role/RoleForm.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Permissions/Role/RoleForm.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Permissions/Role/RoleForm.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Permissions/Role/RoleForm.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Permissions/Role/RoleForm.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Permissions/Role/RoleForm.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Permissions/Role/RoleForm.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Permissions/Role/RoleForm.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Permissions/Role/RoleForm.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Permissions/Role/RoleForm.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Permissions/User/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Permissions/User/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Permissions/User/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Permissions/User/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Permissions/User/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Permissions/User/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Promo/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Promo/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Promo/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Promo/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Promo/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Promo/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Promo/Quote/Edit/FormPageActions.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Promo/Quote/Edit/FormPageActions.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Promo/Quote/Edit/FormPageActions.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Promo/Quote/Edit/FormPageActions.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Promo/Quote/Edit/FormPageActions.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Promo/Quote/Edit/FormPageActions.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Promo/Quote/Edit/PromoQuoteForm.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Promo/Quote/Edit/PromoQuoteForm.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Promo/Quote/Edit/PromoQuoteForm.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Promo/Quote/Edit/PromoQuoteForm.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Promo/Quote/Edit/PromoQuoteForm.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Promo/Quote/Edit/PromoQuoteForm.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Promo/Quote/Edit/PromoQuoteForm.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Promo/Quote/Edit/PromoQuoteForm.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Promo/Quote/Edit/PromoQuoteForm.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Promo/Quote/Edit/PromoQuoteForm.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Promo/Quote/Edit/PromoQuoteForm.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Promo/Quote/Edit/PromoQuoteForm.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Promo/Quote/Edit/Tab/Labels.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Promo/Quote/Edit/Tab/Labels.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Promo/Quote/Edit/Tab/Labels.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Promo/Quote/Edit/Tab/Labels.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Promo/Quote/Edit/Tab/Labels.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Promo/Quote/Edit/Tab/Labels.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Promo/Quote/Edit/Tab/RuleInformation.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Promo/Quote/Edit/Tab/RuleInformation.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Promo/Quote/Edit/Tab/RuleInformation.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Promo/Quote/Edit/Tab/RuleInformation.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Promo/Quote/Edit/Tab/RuleInformation.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Promo/Quote/Edit/Tab/RuleInformation.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Rating/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Rating/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Rating/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Rating/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Rating/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Rating/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Review/Edit/ReviewDetails.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Review/Edit/ReviewDetails.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Review/Edit/ReviewDetails.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Review/Edit/ReviewDetails.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Review/Edit/ReviewDetails.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Review/Edit/ReviewDetails.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Review/Edit/ReviewDetails/RatingElement.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Review/Edit/ReviewDetails/RatingElement.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Review/Edit/ReviewDetails/RatingElement.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Review/Edit/ReviewDetails/RatingElement.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Review/Edit/ReviewDetails/RatingElement.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Review/Edit/ReviewDetails/RatingElement.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Review/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Review/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Review/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Review/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Review/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Review/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Review/ReviewForm.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Review/ReviewForm.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Review/ReviewForm.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Review/ReviewForm.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Review/ReviewForm.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Review/ReviewForm.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Review/ReviewForm.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Review/ReviewForm.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Review/ReviewForm.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Review/ReviewForm.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Review/ReviewForm.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Review/ReviewForm.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/AbstractGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/AbstractGrid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/AbstractGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/AbstractGrid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/AbstractGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/AbstractGrid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/CreditMemos/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/CreditMemos/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/CreditMemos/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/CreditMemos/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/CreditMemos/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/CreditMemos/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/CreditMemos/View/Items.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/CreditMemos/View/Items.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/CreditMemos/View/Items.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/CreditMemos/View/Items.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/CreditMemos/View/Items.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/CreditMemos/View/Items.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/CreditMemos/View/Items/Item.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/CreditMemos/View/Items/Item.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/CreditMemos/View/Items/Item.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/CreditMemos/View/Items/Item.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/CreditMemos/View/Items/Item.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/CreditMemos/View/Items/Item.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Invoices/Actions.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Invoices/Actions.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Invoices/Actions.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Invoices/Actions.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Invoices/Actions.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Invoices/Actions.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Invoices/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Invoices/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Invoices/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Invoices/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Invoices/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Invoices/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Invoices/View/Items.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Invoices/View/Items.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Invoices/View/Items.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Invoices/View/Items.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Invoices/View/Items.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Invoices/View/Items.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Invoices/View/Items/Item.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Invoices/View/Items/Item.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Invoices/View/Items/Item.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Invoices/View/Items/Item.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Invoices/View/Items/Item.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Invoices/View/Items/Item.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/AbstractForm.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/AbstractForm.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/AbstractForm.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/AbstractForm.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/AbstractForm.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/AbstractForm.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/AbstractForm/Product.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/AbstractForm/Product.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/AbstractForm/Product.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/AbstractForm/Product.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/AbstractForm/Product.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/AbstractForm/Product.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/AbstractForm/ProductForm.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/AbstractForm/ProductForm.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/AbstractForm/ProductForm.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/AbstractForm/ProductForm.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/AbstractForm/ProductForm.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/AbstractForm/ProductForm.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/AbstractItems.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/AbstractItems.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/AbstractItems.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/AbstractItems.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/AbstractItems.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/AbstractItems.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/AbstractItems/AbstractItem.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/AbstractItems/AbstractItem.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/AbstractItems/AbstractItem.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/AbstractItems/AbstractItem.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/AbstractItems/AbstractItem.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/AbstractItems/AbstractItem.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/AbstractItemsNewBlock.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/AbstractItemsNewBlock.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/AbstractItemsNewBlock.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/AbstractItemsNewBlock.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/AbstractItemsNewBlock.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/AbstractItemsNewBlock.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Actions.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Actions.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Actions.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Actions.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Actions.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Actions.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Address.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Address.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Address.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Address.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Address.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Address.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Comments.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Comments.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Comments.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Comments.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Comments.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Comments.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/Billing/Address.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/Billing/Address.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/Billing/Address.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/Billing/Address.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/Billing/Address.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/Billing/Address.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/Billing/Address.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/Billing/Address.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/Billing/Address.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/Billing/Address.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/Billing/Address.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/Billing/Address.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/Coupons.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/Coupons.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/Coupons.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/Coupons.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/Coupons.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/Coupons.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/Coupons.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/Coupons.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/Coupons.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/Coupons.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/Coupons.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/Coupons.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/CustomerActivities.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/CustomerActivities.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/CustomerActivities.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/CustomerActivities.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/CustomerActivities.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/CustomerActivities.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/CustomerActivities/Sidebar.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/CustomerActivities/Sidebar.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/CustomerActivities/Sidebar.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/CustomerActivities/Sidebar.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/CustomerActivities/Sidebar.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/CustomerActivities/Sidebar.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/CustomerActivities/Sidebar/ShoppingCartItems.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/CustomerActivities/Sidebar/ShoppingCartItems.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/CustomerActivities/Sidebar/ShoppingCartItems.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/CustomerActivities/Sidebar/ShoppingCartItems.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/CustomerActivities/Sidebar/ShoppingCartItems.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/CustomerActivities/Sidebar/ShoppingCartItems.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/CustomerGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/CustomerGrid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/CustomerGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/CustomerGrid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/CustomerGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/CustomerGrid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/Items.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/Items.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/Items.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/Items.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/Items.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/Items.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/Items/ItemProduct.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/Items/ItemProduct.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/Items/ItemProduct.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/Items/ItemProduct.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/Items/ItemProduct.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/Items/ItemProduct.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/Items/ItemProduct.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/Items/ItemProduct.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/Items/ItemProduct.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/Items/ItemProduct.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/Items/ItemProduct.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/Items/ItemProduct.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/Payment.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/Payment.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/Payment.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/Payment.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/Payment.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/Payment.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/Search.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/Search.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/Search.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/Search.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/Search.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/Search.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/Search/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/Search/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/Search/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/Search/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/Search/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/Search/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/Shipping.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/Shipping.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/Shipping.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/Shipping.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/Shipping.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/Shipping.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/Store.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/Store.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/Store.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/Store.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/Store.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Create/Store.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Creditmemo/Form.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Creditmemo/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Creditmemo/Form.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Creditmemo/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Creditmemo/Form.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Creditmemo/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Creditmemo/Form.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Creditmemo/Form.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Creditmemo/Form.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Creditmemo/Form.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Creditmemo/Form.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Creditmemo/Form.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Creditmemo/Form/Items.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Creditmemo/Form/Items.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Creditmemo/Form/Items.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Creditmemo/Form/Items.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Creditmemo/Form/Items.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Creditmemo/Form/Items.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Creditmemo/Form/Items/Product.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Creditmemo/Form/Items/Product.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Creditmemo/Form/Items/Product.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Creditmemo/Form/Items/Product.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Creditmemo/Form/Items/Product.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Creditmemo/Form/Items/Product.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Creditmemo/Form/Items/Product.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Creditmemo/Form/Items/Product.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Creditmemo/Form/Items/Product.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Creditmemo/Form/Items/Product.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Creditmemo/Form/Items/Product.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Creditmemo/Form/Items/Product.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Creditmemo/Totals.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Creditmemo/Totals.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Creditmemo/Totals.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Creditmemo/Totals.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Creditmemo/Totals.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Creditmemo/Totals.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Invoice/Form.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Invoice/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Invoice/Form.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Invoice/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Invoice/Form.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Invoice/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Invoice/Form.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Invoice/Form.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Invoice/Form.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Invoice/Form.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Invoice/Form.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Invoice/Form.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Invoice/Form/Items.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Invoice/Form/Items.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Invoice/Form/Items.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Invoice/Form/Items.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Invoice/Form/Items.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Invoice/Form/Items.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Invoice/Form/Items/Product.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Invoice/Form/Items/Product.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Invoice/Form/Items/Product.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Invoice/Form/Items/Product.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Invoice/Form/Items/Product.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Invoice/Form/Items/Product.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Invoice/Form/Items/Product.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Invoice/Form/Items/Product.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Invoice/Form/Items/Product.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Invoice/Form/Items/Product.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Invoice/Form/Items/Product.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Invoice/Form/Items/Product.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Invoice/Totals.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Invoice/Totals.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Invoice/Totals.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Invoice/Totals.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Invoice/Totals.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Invoice/Totals.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Shipment/Form.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Shipment/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Shipment/Form.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Shipment/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Shipment/Form.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Shipment/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Shipment/Form.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Shipment/Form.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Shipment/Form.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Shipment/Form.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Shipment/Form.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Shipment/Form.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Shipment/Form/Items.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Shipment/Form/Items.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Shipment/Form/Items.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Shipment/Form/Items.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Shipment/Form/Items.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Shipment/Form/Items.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Shipment/Form/Items/Product.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Shipment/Form/Items/Product.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Shipment/Form/Items/Product.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Shipment/Form/Items/Product.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Shipment/Form/Items/Product.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Shipment/Form/Items/Product.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Shipment/Form/Items/Product.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Shipment/Form/Items/Product.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Shipment/Form/Items/Product.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Shipment/Form/Items/Product.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Shipment/Form/Items/Product.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Shipment/Form/Items/Product.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Shipment/Form/Tracking.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Shipment/Form/Tracking.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Shipment/Form/Tracking.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Shipment/Form/Tracking.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Shipment/Form/Tracking.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Shipment/Form/Tracking.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Shipment/Form/Tracking/Item.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Shipment/Form/Tracking/Item.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Shipment/Form/Tracking/Item.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Shipment/Form/Tracking/Item.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Shipment/Form/Tracking/Item.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Shipment/Form/Tracking/Item.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Shipment/Form/Tracking/Item.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Shipment/Form/Tracking/Item.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Shipment/Form/Tracking/Item.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Shipment/Form/Tracking/Item.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Shipment/Form/Tracking/Item.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Shipment/Form/Tracking/Item.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Title.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Title.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Title.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Title.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Title.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Title.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Totals.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Totals.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Totals.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Totals.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Totals.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/Totals.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/View/AbstractGridTab.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/View/AbstractGridTab.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/View/AbstractGridTab.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/View/AbstractGridTab.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/View/AbstractGridTab.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/View/AbstractGridTab.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/View/Form.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/View/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/View/Form.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/View/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/View/Form.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/View/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/View/Form.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/View/Form.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/View/Form.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/View/Form.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/View/Form.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/View/Form.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/View/Items.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/View/Items.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/View/Items.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/View/Items.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/View/Items.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/View/Items.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/View/Items/Product.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/View/Items/Product.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/View/Items/Product.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/View/Items/Product.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/View/Items/Product.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/View/Items/Product.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/View/Items/Product.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/View/Items/Product.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/View/Items/Product.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/View/Items/Product.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/View/Items/Product.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/View/Items/Product.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/View/Tab/CreditMemos.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/View/Tab/CreditMemos.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/View/Tab/CreditMemos.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/View/Tab/CreditMemos.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/View/Tab/CreditMemos.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/View/Tab/CreditMemos.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/View/Tab/Info.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/View/Tab/Info.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/View/Tab/Info.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/View/Tab/Info.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/View/Tab/Info.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/View/Tab/Info.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/View/Tab/Invoices.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/View/Tab/Invoices.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/View/Tab/Invoices.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/View/Tab/Invoices.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/View/Tab/Invoices.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/View/Tab/Invoices.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/View/Tab/Shipments.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/View/Tab/Shipments.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/View/Tab/Shipments.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/View/Tab/Shipments.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/View/Tab/Shipments.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/View/Tab/Shipments.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/View/Tab/Transactions.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/View/Tab/Transactions.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/View/Tab/Transactions.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/View/Tab/Transactions.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/View/Tab/Transactions.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Order/View/Tab/Transactions.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Shipment/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Shipment/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Shipment/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Shipment/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Shipment/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Shipment/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Transactions/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Transactions/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Transactions/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Transactions/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Transactions/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sales/Transactions/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Shipping/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Shipping/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Shipping/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Shipping/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Shipping/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Shipping/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Shipping/View/Items.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Shipping/View/Items.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Shipping/View/Items.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Shipping/View/Items.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Shipping/View/Items.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Shipping/View/Items.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Shipping/View/Items/Item.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Shipping/View/Items/Item.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Shipping/View/Items/Item.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Shipping/View/Items/Item.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Shipping/View/Items/Item.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Shipping/View/Items/Item.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sitemap/Edit/Form.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sitemap/Edit/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sitemap/Edit/Form.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sitemap/Edit/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sitemap/Edit/Form.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sitemap/Edit/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sitemap/Edit/FormPageActions.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sitemap/Edit/FormPageActions.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sitemap/Edit/FormPageActions.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sitemap/Edit/FormPageActions.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sitemap/Edit/FormPageActions.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sitemap/Edit/FormPageActions.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sitemap/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sitemap/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sitemap/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sitemap/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sitemap/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Sitemap/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Config/Switcher.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Config/Switcher.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Config/Switcher.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Config/Switcher.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Config/Switcher.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Config/Switcher.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Currency/CurrencyGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Currency/CurrencyGrid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Currency/CurrencyGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Currency/CurrencyGrid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Currency/CurrencyGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Currency/CurrencyGrid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Currency/GridPageActions.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Currency/GridPageActions.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Currency/GridPageActions.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Currency/GridPageActions.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Currency/GridPageActions.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Currency/GridPageActions.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/CurrencySymbolForm.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/CurrencySymbolForm.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/CurrencySymbolForm.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/CurrencySymbolForm.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/CurrencySymbolForm.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/CurrencySymbolForm.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/CurrencySymbolForm.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/CurrencySymbolForm.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/CurrencySymbolForm.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/CurrencySymbolForm.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/CurrencySymbolForm.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/CurrencySymbolForm.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/FormPageActions.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/FormPageActions.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/FormPageActions.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/FormPageActions.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/FormPageActions.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/FormPageActions.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Process/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Process/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Process/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Process/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Process/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Process/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Store/Delete/Form/GroupForm.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Store/Delete/Form/GroupForm.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Store/Delete/Form/GroupForm.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Store/Delete/Form/GroupForm.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Store/Delete/Form/GroupForm.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Store/Delete/Form/GroupForm.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Store/Delete/Form/GroupForm.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Store/Delete/Form/GroupForm.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Store/Delete/Form/GroupForm.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Store/Delete/Form/GroupForm.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Store/Delete/Form/GroupForm.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Store/Delete/Form/GroupForm.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Store/Delete/Form/StoreForm.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Store/Delete/Form/StoreForm.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Store/Delete/Form/StoreForm.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Store/Delete/Form/StoreForm.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Store/Delete/Form/StoreForm.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Store/Delete/Form/StoreForm.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Store/Delete/Form/StoreForm.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Store/Delete/Form/StoreForm.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Store/Delete/Form/StoreForm.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Store/Delete/Form/StoreForm.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Store/Delete/Form/StoreForm.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Store/Delete/Form/StoreForm.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Store/Delete/Website.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Store/Delete/Website.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Store/Delete/Website.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Store/Delete/Website.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Store/Delete/Website.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Store/Delete/Website.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Store/Delete/Website.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Store/Delete/Website.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Store/Delete/Website.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Store/Delete/Website.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Store/Delete/Website.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Store/Delete/Website.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Store/Edit/Form/GroupForm.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Store/Edit/Form/GroupForm.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Store/Edit/Form/GroupForm.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Store/Edit/Form/GroupForm.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Store/Edit/Form/GroupForm.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Store/Edit/Form/GroupForm.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Store/Edit/Form/GroupForm.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Store/Edit/Form/GroupForm.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Store/Edit/Form/GroupForm.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Store/Edit/Form/GroupForm.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Store/Edit/Form/GroupForm.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Store/Edit/Form/GroupForm.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Store/Edit/Form/StoreForm.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Store/Edit/Form/StoreForm.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Store/Edit/Form/StoreForm.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Store/Edit/Form/StoreForm.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Store/Edit/Form/StoreForm.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Store/Edit/Form/StoreForm.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Store/Edit/Form/StoreForm.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Store/Edit/Form/StoreForm.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Store/Edit/Form/StoreForm.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Store/Edit/Form/StoreForm.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Store/Edit/Form/StoreForm.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Store/Edit/Form/StoreForm.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Store/Edit/Form/WebsiteForm.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Store/Edit/Form/WebsiteForm.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Store/Edit/Form/WebsiteForm.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Store/Edit/Form/WebsiteForm.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Store/Edit/Form/WebsiteForm.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Store/Edit/Form/WebsiteForm.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Store/Edit/Form/WebsiteForm.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Store/Edit/Form/WebsiteForm.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Store/Edit/Form/WebsiteForm.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Store/Edit/Form/WebsiteForm.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Store/Edit/Form/WebsiteForm.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Store/Edit/Form/WebsiteForm.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Store/GridPageActions.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Store/GridPageActions.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Store/GridPageActions.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Store/GridPageActions.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Store/GridPageActions.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Store/GridPageActions.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Store/StoreGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Store/StoreGrid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Store/StoreGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Store/StoreGrid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Store/StoreGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/System/Store/StoreGrid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Tax/Rate/Edit/Form.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Tax/Rate/Edit/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Tax/Rate/Edit/Form.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Tax/Rate/Edit/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Tax/Rate/Edit/Form.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Tax/Rate/Edit/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Tax/Rate/Edit/Form.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Tax/Rate/Edit/Form.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Tax/Rate/Edit/Form.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Tax/Rate/Edit/Form.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Tax/Rate/Edit/Form.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Tax/Rate/Edit/Form.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Tax/Rate/RatesGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Tax/Rate/RatesGrid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Tax/Rate/RatesGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Tax/Rate/RatesGrid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Tax/Rate/RatesGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Tax/Rate/RatesGrid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Tax/Rule/Edit/Form.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Tax/Rule/Edit/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Tax/Rule/Edit/Form.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Tax/Rule/Edit/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Tax/Rule/Edit/Form.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Tax/Rule/Edit/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Tax/Rule/Edit/Form.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Tax/Rule/Edit/Form.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Tax/Rule/Edit/Form.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Tax/Rule/Edit/Form.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Tax/Rule/Edit/Form.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Tax/Rule/Edit/Form.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Tax/Rule/FormPageActions.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Tax/Rule/FormPageActions.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Tax/Rule/FormPageActions.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Tax/Rule/FormPageActions.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Tax/Rule/FormPageActions.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Tax/Rule/FormPageActions.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Tax/Rule/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Tax/Rule/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Tax/Rule/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Tax/Rule/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Tax/Rule/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Tax/Rule/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Template.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Template.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Template.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Template.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Template.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Template.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Widget/FormTabs.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Widget/FormTabs.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Widget/FormTabs.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Widget/FormTabs.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Widget/FormTabs.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Widget/FormTabs.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Widget/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Widget/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Widget/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Widget/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Widget/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Widget/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Widget/Tab.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Widget/Tab.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Widget/Tab.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Widget/Tab.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Widget/Tab.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Widget/Tab.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Wishlist/Customer/Edit/Tab/Wishlist.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Wishlist/Customer/Edit/Tab/Wishlist.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Wishlist/Customer/Edit/Tab/Wishlist.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Wishlist/Customer/Edit/Tab/Wishlist.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Wishlist/Customer/Edit/Tab/Wishlist.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Wishlist/Customer/Edit/Tab/Wishlist.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Wishlist/Customer/Edit/Tab/Wishlist/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Wishlist/Customer/Edit/Tab/Wishlist/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Wishlist/Customer/Edit/Tab/Wishlist/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Wishlist/Customer/Edit/Tab/Wishlist/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Wishlist/Customer/Edit/Tab/Wishlist/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Block/Wishlist/Customer/Edit/Tab/Wishlist/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Constraint/AssertProductIsPresentOnCustomWebsite.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Constraint/AssertProductIsPresentOnCustomWebsite.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Constraint/AssertProductIsPresentOnCustomWebsite.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Constraint/AssertProductIsPresentOnCustomWebsite.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Constraint/AssertProductIsPresentOnCustomWebsite.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Constraint/AssertProductIsPresentOnCustomWebsite.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Constraint/AssertStoreBackend.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Constraint/AssertStoreBackend.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Constraint/AssertStoreBackend.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Constraint/AssertStoreBackend.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Constraint/AssertStoreBackend.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Constraint/AssertStoreBackend.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Constraint/AssertStoreForm.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Constraint/AssertStoreForm.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Constraint/AssertStoreForm.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Constraint/AssertStoreForm.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Constraint/AssertStoreForm.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Constraint/AssertStoreForm.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Constraint/AssertStoreFrontend.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Constraint/AssertStoreFrontend.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Constraint/AssertStoreFrontend.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Constraint/AssertStoreFrontend.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Constraint/AssertStoreFrontend.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Constraint/AssertStoreFrontend.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Constraint/AssertStoreGroupForm.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Constraint/AssertStoreGroupForm.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Constraint/AssertStoreGroupForm.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Constraint/AssertStoreGroupForm.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Constraint/AssertStoreGroupForm.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Constraint/AssertStoreGroupForm.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Constraint/AssertStoreGroupInGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Constraint/AssertStoreGroupInGrid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Constraint/AssertStoreGroupInGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Constraint/AssertStoreGroupInGrid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Constraint/AssertStoreGroupInGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Constraint/AssertStoreGroupInGrid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Constraint/AssertStoreGroupInPurchasePointDropdown.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Constraint/AssertStoreGroupInPurchasePointDropdown.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Constraint/AssertStoreGroupInPurchasePointDropdown.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Constraint/AssertStoreGroupInPurchasePointDropdown.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Constraint/AssertStoreGroupInPurchasePointDropdown.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Constraint/AssertStoreGroupInPurchasePointDropdown.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Constraint/AssertStoreGroupOnStoreViewForm.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Constraint/AssertStoreGroupOnStoreViewForm.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Constraint/AssertStoreGroupOnStoreViewForm.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Constraint/AssertStoreGroupOnStoreViewForm.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Constraint/AssertStoreGroupOnStoreViewForm.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Constraint/AssertStoreGroupOnStoreViewForm.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Constraint/AssertStoreGroupSuccessSaveMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Constraint/AssertStoreGroupSuccessSaveMessage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Constraint/AssertStoreGroupSuccessSaveMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Constraint/AssertStoreGroupSuccessSaveMessage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Constraint/AssertStoreGroupSuccessSaveMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Constraint/AssertStoreGroupSuccessSaveMessage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Constraint/AssertStoreInGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Constraint/AssertStoreInGrid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Constraint/AssertStoreInGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Constraint/AssertStoreInGrid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Constraint/AssertStoreInGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Constraint/AssertStoreInGrid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Constraint/AssertStoreLocalized.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Constraint/AssertStoreLocalized.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Constraint/AssertStoreLocalized.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Constraint/AssertStoreLocalized.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Constraint/AssertStoreLocalized.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Constraint/AssertStoreLocalized.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Constraint/AssertStoreNotOnFrontend.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Constraint/AssertStoreNotOnFrontend.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Constraint/AssertStoreNotOnFrontend.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Constraint/AssertStoreNotOnFrontend.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Constraint/AssertStoreNotOnFrontend.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Constraint/AssertStoreNotOnFrontend.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Constraint/AssertStoreSuccessSaveMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Constraint/AssertStoreSuccessSaveMessage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Constraint/AssertStoreSuccessSaveMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Constraint/AssertStoreSuccessSaveMessage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Constraint/AssertStoreSuccessSaveMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Constraint/AssertStoreSuccessSaveMessage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Constraint/AssertVersionCorrect.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Constraint/AssertVersionCorrect.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Constraint/AssertVersionCorrect.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Constraint/AssertVersionCorrect.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Constraint/AssertVersionCorrect.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Constraint/AssertVersionCorrect.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Fixture/CustomConfigData.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Fixture/CustomConfigData.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Fixture/CustomConfigData.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Fixture/CustomConfigData.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Fixture/CustomConfigData.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Fixture/CustomConfigData.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Fixture/Store.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Fixture/Store.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Fixture/Store.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Fixture/Store.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Fixture/Store.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Fixture/Store.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Fixture/Store/GroupId.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Fixture/Store/GroupId.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Fixture/Store/GroupId.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Fixture/Store/GroupId.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Fixture/Store/GroupId.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Fixture/Store/GroupId.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Fixture/StoreGroup.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Fixture/StoreGroup.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Fixture/StoreGroup.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Fixture/StoreGroup.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Fixture/StoreGroup.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Fixture/StoreGroup.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Fixture/StoreGroup/CategoryId.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Fixture/StoreGroup/CategoryId.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Fixture/StoreGroup/CategoryId.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Fixture/StoreGroup/CategoryId.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Fixture/StoreGroup/CategoryId.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Fixture/StoreGroup/CategoryId.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Fixture/StoreGroup/WebsiteId.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Fixture/StoreGroup/WebsiteId.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Fixture/StoreGroup/WebsiteId.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Fixture/StoreGroup/WebsiteId.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Fixture/StoreGroup/WebsiteId.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Fixture/StoreGroup/WebsiteId.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Fixture/Website.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Fixture/Website.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Fixture/Website.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Fixture/Website.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Fixture/Website.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Fixture/Website.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Handler/Conditions.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Handler/Conditions.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Handler/Conditions.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Handler/Conditions.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Handler/Conditions.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Handler/Conditions.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Handler/CustomConfigData/Curl.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Handler/CustomConfigData/Curl.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Handler/CustomConfigData/Curl.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Handler/CustomConfigData/Curl.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Handler/CustomConfigData/Curl.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Handler/CustomConfigData/Curl.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Handler/CustomConfigData/CustomConfigDataInterface.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Handler/CustomConfigData/CustomConfigDataInterface.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Handler/CustomConfigData/CustomConfigDataInterface.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Handler/CustomConfigData/CustomConfigDataInterface.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Handler/CustomConfigData/CustomConfigDataInterface.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Handler/CustomConfigData/CustomConfigDataInterface.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Handler/Extractor.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Handler/Extractor.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Handler/Extractor.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Handler/Extractor.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Handler/Extractor.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Handler/Extractor.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Handler/Store/Curl.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Handler/Store/Curl.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Handler/Store/Curl.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Handler/Store/Curl.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Handler/Store/Curl.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Handler/Store/Curl.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Handler/Store/StoreInterface.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Handler/Store/StoreInterface.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Handler/Store/StoreInterface.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Handler/Store/StoreInterface.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Handler/Store/StoreInterface.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Handler/Store/StoreInterface.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Handler/StoreGroup/Curl.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Handler/StoreGroup/Curl.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Handler/StoreGroup/Curl.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Handler/StoreGroup/Curl.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Handler/StoreGroup/Curl.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Handler/StoreGroup/Curl.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Handler/StoreGroup/StoreGroupInterface.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Handler/StoreGroup/StoreGroupInterface.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Handler/StoreGroup/StoreGroupInterface.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Handler/StoreGroup/StoreGroupInterface.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Handler/StoreGroup/StoreGroupInterface.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Handler/StoreGroup/StoreGroupInterface.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Handler/Ui/LoginUser.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Handler/Ui/LoginUser.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Handler/Ui/LoginUser.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Handler/Ui/LoginUser.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Handler/Ui/LoginUser.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Handler/Ui/LoginUser.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Handler/Website/Curl.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Handler/Website/Curl.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Handler/Website/Curl.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Handler/Website/Curl.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Handler/Website/Curl.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Handler/Website/Curl.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Handler/Website/WebsiteInterface.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Handler/Website/WebsiteInterface.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Handler/Website/WebsiteInterface.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Handler/Website/WebsiteInterface.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Handler/Website/WebsiteInterface.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Handler/Website/WebsiteInterface.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/AdminAuthLogin.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/AdminAuthLogin.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/AdminAuthLogin.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/AdminAuthLogin.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/AdminAuthLogin.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/AdminAuthLogin.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/AdminLogout.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/AdminLogout.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/AdminLogout.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/AdminLogout.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/AdminLogout.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/AdminLogout.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/Adminhtml/Cache.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/Adminhtml/Cache.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/Adminhtml/Cache.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/Adminhtml/Cache.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/Adminhtml/Cache.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/Adminhtml/Cache.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/Adminhtml/Dashboard.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/Adminhtml/Dashboard.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/Adminhtml/Dashboard.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/Adminhtml/Dashboard.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/Adminhtml/Dashboard.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/Adminhtml/Dashboard.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/Adminhtml/DeleteGroup.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/Adminhtml/DeleteGroup.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/Adminhtml/DeleteGroup.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/Adminhtml/DeleteGroup.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/Adminhtml/DeleteGroup.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/Adminhtml/DeleteGroup.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/Adminhtml/DeleteStore.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/Adminhtml/DeleteStore.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/Adminhtml/DeleteStore.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/Adminhtml/DeleteStore.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/Adminhtml/DeleteStore.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/Adminhtml/DeleteStore.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/Adminhtml/DeleteWebsite.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/Adminhtml/DeleteWebsite.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/Adminhtml/DeleteWebsite.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/Adminhtml/DeleteWebsite.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/Adminhtml/DeleteWebsite.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/Adminhtml/DeleteWebsite.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/Adminhtml/EditGroup.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/Adminhtml/EditGroup.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/Adminhtml/EditGroup.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/Adminhtml/EditGroup.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/Adminhtml/EditGroup.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/Adminhtml/EditGroup.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/Adminhtml/EditStore.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/Adminhtml/EditStore.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/Adminhtml/EditStore.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/Adminhtml/EditStore.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/Adminhtml/EditStore.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/Adminhtml/EditStore.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/Adminhtml/EditWebsite.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/Adminhtml/EditWebsite.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/Adminhtml/EditWebsite.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/Adminhtml/EditWebsite.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/Adminhtml/EditWebsite.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/Adminhtml/EditWebsite.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/Adminhtml/NewStoreGroup.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/Adminhtml/NewStoreGroup.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/Adminhtml/NewStoreGroup.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/Adminhtml/NewStoreGroup.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/Adminhtml/NewStoreGroup.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/Adminhtml/NewStoreGroup.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/Adminhtml/NewWebsite.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/Adminhtml/NewWebsite.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/Adminhtml/NewWebsite.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/Adminhtml/NewWebsite.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/Adminhtml/NewWebsite.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/Adminhtml/NewWebsite.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/Adminhtml/ProcessList.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/Adminhtml/ProcessList.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/Adminhtml/ProcessList.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/Adminhtml/ProcessList.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/Adminhtml/ProcessList.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/Adminhtml/ProcessList.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/Adminhtml/StoreIndex.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/Adminhtml/StoreIndex.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/Adminhtml/StoreIndex.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/Adminhtml/StoreIndex.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/Adminhtml/StoreIndex.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/Adminhtml/StoreIndex.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/Adminhtml/StoreNew.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/Adminhtml/StoreNew.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/Adminhtml/StoreNew.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/Adminhtml/StoreNew.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/Adminhtml/StoreNew.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/Adminhtml/StoreNew.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/Adminhtml/SystemConfig.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/Adminhtml/SystemConfig.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/Adminhtml/SystemConfig.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/Adminhtml/SystemConfig.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/Adminhtml/SystemConfig.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Page/Adminhtml/SystemConfig.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Repository/ConfigData.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Repository/ConfigData.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Repository/ConfigData.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Repository/ConfigData.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Repository/ConfigData.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Repository/ConfigData.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Repository/Store.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Repository/Store.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Repository/Store.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Repository/Store.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Repository/Store.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Repository/Store.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Repository/StoreGroup.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Repository/StoreGroup.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Repository/StoreGroup.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Repository/StoreGroup.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Repository/StoreGroup.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Repository/StoreGroup.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Repository/Website.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Repository/Website.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Repository/Website.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Repository/Website.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Repository/Website.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/Repository/Website.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/TestCase/CreateStoreEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/TestCase/CreateStoreEntityTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/TestCase/CreateStoreEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/TestCase/CreateStoreEntityTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/TestCase/CreateStoreEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/TestCase/CreateStoreEntityTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/TestCase/CreateStoreEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/TestCase/CreateStoreEntityTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/TestCase/CreateStoreEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/TestCase/CreateStoreEntityTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/TestCase/CreateStoreEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/TestCase/CreateStoreEntityTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/TestCase/CreateStoreGroupEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/TestCase/CreateStoreGroupEntityTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/TestCase/CreateStoreGroupEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/TestCase/CreateStoreGroupEntityTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/TestCase/CreateStoreGroupEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/TestCase/CreateStoreGroupEntityTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/TestCase/CreateStoreGroupEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/TestCase/CreateStoreGroupEntityTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/TestCase/CreateStoreGroupEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/TestCase/CreateStoreGroupEntityTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/TestCase/CreateStoreGroupEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/TestCase/CreateStoreGroupEntityTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/TestCase/CreateWebsiteEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/TestCase/CreateWebsiteEntityTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/TestCase/CreateWebsiteEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/TestCase/CreateWebsiteEntityTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/TestCase/CreateWebsiteEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/TestCase/CreateWebsiteEntityTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/TestCase/CreateWebsiteEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/TestCase/CreateWebsiteEntityTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/TestCase/CreateWebsiteEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/TestCase/CreateWebsiteEntityTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/TestCase/CreateWebsiteEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/TestCase/CreateWebsiteEntityTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/TestStep/DeleteStoreGroupsStep.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/TestStep/DeleteStoreGroupsStep.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/TestStep/DeleteStoreGroupsStep.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/TestStep/DeleteStoreGroupsStep.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/TestStep/DeleteStoreGroupsStep.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/TestStep/DeleteStoreGroupsStep.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/TestStep/DeleteWebsiteStep.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/TestStep/DeleteWebsiteStep.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/TestStep/DeleteWebsiteStep.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/TestStep/DeleteWebsiteStep.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/TestStep/DeleteWebsiteStep.php
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/TestStep/DeleteWebsiteStep.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/etc/curl/di.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/etc/curl/di.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/etc/curl/di.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/etc/curl/di.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/etc/curl/di.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/etc/curl/di.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/etc/fixture.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/etc/fixture.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/etc/fixture.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/etc/fixture.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Adminhtml/Test/etc/fixture.xml
+++ b/dev/tests/functional/tests/app/Mage/Adminhtml/Test/etc/fixture.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Authorizenet/Test/Block/Directpost/Form.php
+++ b/dev/tests/functional/tests/app/Mage/Authorizenet/Test/Block/Directpost/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Authorizenet/Test/Block/Directpost/Form.php
+++ b/dev/tests/functional/tests/app/Mage/Authorizenet/Test/Block/Directpost/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Authorizenet/Test/Block/Directpost/Form.php
+++ b/dev/tests/functional/tests/app/Mage/Authorizenet/Test/Block/Directpost/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Authorizenet/Test/Block/Directpost/Form.xml
+++ b/dev/tests/functional/tests/app/Mage/Authorizenet/Test/Block/Directpost/Form.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Authorizenet/Test/Block/Directpost/Form.xml
+++ b/dev/tests/functional/tests/app/Mage/Authorizenet/Test/Block/Directpost/Form.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Authorizenet/Test/Block/Directpost/Form.xml
+++ b/dev/tests/functional/tests/app/Mage/Authorizenet/Test/Block/Directpost/Form.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Authorizenet/Test/Repository/ConfigData.xml
+++ b/dev/tests/functional/tests/app/Mage/Authorizenet/Test/Repository/ConfigData.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Authorizenet/Test/Repository/ConfigData.xml
+++ b/dev/tests/functional/tests/app/Mage/Authorizenet/Test/Repository/ConfigData.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Authorizenet/Test/Repository/ConfigData.xml
+++ b/dev/tests/functional/tests/app/Mage/Authorizenet/Test/Repository/ConfigData.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Authorizenet/Test/TestCase/CreateOfflineInvoiceForAuthorizenetDirectpostMethodTest.php
+++ b/dev/tests/functional/tests/app/Mage/Authorizenet/Test/TestCase/CreateOfflineInvoiceForAuthorizenetDirectpostMethodTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Authorizenet/Test/TestCase/CreateOfflineInvoiceForAuthorizenetDirectpostMethodTest.php
+++ b/dev/tests/functional/tests/app/Mage/Authorizenet/Test/TestCase/CreateOfflineInvoiceForAuthorizenetDirectpostMethodTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Authorizenet/Test/TestCase/CreateOfflineInvoiceForAuthorizenetDirectpostMethodTest.php
+++ b/dev/tests/functional/tests/app/Mage/Authorizenet/Test/TestCase/CreateOfflineInvoiceForAuthorizenetDirectpostMethodTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Authorizenet/Test/TestCase/CreateOfflineInvoiceForAuthorizenetDirectpostMethodTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Authorizenet/Test/TestCase/CreateOfflineInvoiceForAuthorizenetDirectpostMethodTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Authorizenet/Test/TestCase/CreateOfflineInvoiceForAuthorizenetDirectpostMethodTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Authorizenet/Test/TestCase/CreateOfflineInvoiceForAuthorizenetDirectpostMethodTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Authorizenet/Test/TestCase/CreateOfflineInvoiceForAuthorizenetDirectpostMethodTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Authorizenet/Test/TestCase/CreateOfflineInvoiceForAuthorizenetDirectpostMethodTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Authorizenet/Test/TestCase/CreateOfflineInvoiceForOnlinePaymentsMethodsWithoutIFrameTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Authorizenet/Test/TestCase/CreateOfflineInvoiceForOnlinePaymentsMethodsWithoutIFrameTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Authorizenet/Test/TestCase/CreateOfflineInvoiceForOnlinePaymentsMethodsWithoutIFrameTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Authorizenet/Test/TestCase/CreateOfflineInvoiceForOnlinePaymentsMethodsWithoutIFrameTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Authorizenet/Test/TestCase/CreateOfflineInvoiceForOnlinePaymentsMethodsWithoutIFrameTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Authorizenet/Test/TestCase/CreateOfflineInvoiceForOnlinePaymentsMethodsWithoutIFrameTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Authorizenet/Test/TestCase/CreateOfflineRefundForAuthorizenetDirectpostMethodTest.php
+++ b/dev/tests/functional/tests/app/Mage/Authorizenet/Test/TestCase/CreateOfflineRefundForAuthorizenetDirectpostMethodTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Authorizenet/Test/TestCase/CreateOfflineRefundForAuthorizenetDirectpostMethodTest.php
+++ b/dev/tests/functional/tests/app/Mage/Authorizenet/Test/TestCase/CreateOfflineRefundForAuthorizenetDirectpostMethodTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Authorizenet/Test/TestCase/CreateOfflineRefundForAuthorizenetDirectpostMethodTest.php
+++ b/dev/tests/functional/tests/app/Mage/Authorizenet/Test/TestCase/CreateOfflineRefundForAuthorizenetDirectpostMethodTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Authorizenet/Test/TestCase/CreateOfflineRefundForAuthorizenetDirectpostMethodTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Authorizenet/Test/TestCase/CreateOfflineRefundForAuthorizenetDirectpostMethodTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Authorizenet/Test/TestCase/CreateOfflineRefundForAuthorizenetDirectpostMethodTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Authorizenet/Test/TestCase/CreateOfflineRefundForAuthorizenetDirectpostMethodTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Authorizenet/Test/TestCase/CreateOfflineRefundForAuthorizenetDirectpostMethodTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Authorizenet/Test/TestCase/CreateOfflineRefundForAuthorizenetDirectpostMethodTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Authorizenet/Test/TestCase/CreateOnlineInvoiceForAuthorizenetDirectpostMethodTest.php
+++ b/dev/tests/functional/tests/app/Mage/Authorizenet/Test/TestCase/CreateOnlineInvoiceForAuthorizenetDirectpostMethodTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Authorizenet/Test/TestCase/CreateOnlineInvoiceForAuthorizenetDirectpostMethodTest.php
+++ b/dev/tests/functional/tests/app/Mage/Authorizenet/Test/TestCase/CreateOnlineInvoiceForAuthorizenetDirectpostMethodTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Authorizenet/Test/TestCase/CreateOnlineInvoiceForAuthorizenetDirectpostMethodTest.php
+++ b/dev/tests/functional/tests/app/Mage/Authorizenet/Test/TestCase/CreateOnlineInvoiceForAuthorizenetDirectpostMethodTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Authorizenet/Test/TestCase/CreateOnlineInvoiceForAuthorizenetDirectpostMethodTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Authorizenet/Test/TestCase/CreateOnlineInvoiceForAuthorizenetDirectpostMethodTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Authorizenet/Test/TestCase/CreateOnlineInvoiceForAuthorizenetDirectpostMethodTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Authorizenet/Test/TestCase/CreateOnlineInvoiceForAuthorizenetDirectpostMethodTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Authorizenet/Test/TestCase/CreateOnlineInvoiceForAuthorizenetDirectpostMethodTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Authorizenet/Test/TestCase/CreateOnlineInvoiceForAuthorizenetDirectpostMethodTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Authorizenet/Test/TestCase/CreateOnlineInvoiceForOnlinePaymentsMethodsWithoutIFrameTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Authorizenet/Test/TestCase/CreateOnlineInvoiceForOnlinePaymentsMethodsWithoutIFrameTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Authorizenet/Test/TestCase/CreateOnlineInvoiceForOnlinePaymentsMethodsWithoutIFrameTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Authorizenet/Test/TestCase/CreateOnlineInvoiceForOnlinePaymentsMethodsWithoutIFrameTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Authorizenet/Test/TestCase/CreateOnlineInvoiceForOnlinePaymentsMethodsWithoutIFrameTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Authorizenet/Test/TestCase/CreateOnlineInvoiceForOnlinePaymentsMethodsWithoutIFrameTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Authorizenet/Test/TestCase/CreateOrderWithAuthorizenetDirectpostMethodTest.php
+++ b/dev/tests/functional/tests/app/Mage/Authorizenet/Test/TestCase/CreateOrderWithAuthorizenetDirectpostMethodTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Authorizenet/Test/TestCase/CreateOrderWithAuthorizenetDirectpostMethodTest.php
+++ b/dev/tests/functional/tests/app/Mage/Authorizenet/Test/TestCase/CreateOrderWithAuthorizenetDirectpostMethodTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Authorizenet/Test/TestCase/CreateOrderWithAuthorizenetDirectpostMethodTest.php
+++ b/dev/tests/functional/tests/app/Mage/Authorizenet/Test/TestCase/CreateOrderWithAuthorizenetDirectpostMethodTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Authorizenet/Test/TestCase/CreateOrderWithAuthorizenetDirectpostMethodTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Authorizenet/Test/TestCase/CreateOrderWithAuthorizenetDirectpostMethodTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Authorizenet/Test/TestCase/CreateOrderWithAuthorizenetDirectpostMethodTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Authorizenet/Test/TestCase/CreateOrderWithAuthorizenetDirectpostMethodTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Authorizenet/Test/TestCase/CreateOrderWithAuthorizenetDirectpostMethodTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Authorizenet/Test/TestCase/CreateOrderWithAuthorizenetDirectpostMethodTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Authorizenet/Test/TestCase/CreateOrderWithOnlinePaymentsMethodsWith3DSecureTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Authorizenet/Test/TestCase/CreateOrderWithOnlinePaymentsMethodsWith3DSecureTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Authorizenet/Test/TestCase/CreateOrderWithOnlinePaymentsMethodsWith3DSecureTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Authorizenet/Test/TestCase/CreateOrderWithOnlinePaymentsMethodsWith3DSecureTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Authorizenet/Test/TestCase/CreateOrderWithOnlinePaymentsMethodsWith3DSecureTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Authorizenet/Test/TestCase/CreateOrderWithOnlinePaymentsMethodsWith3DSecureTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Authorizenet/Test/TestCase/CreateOrderWithOnlinePaymentsMethodsWithoutIFrameTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Authorizenet/Test/TestCase/CreateOrderWithOnlinePaymentsMethodsWithoutIFrameTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Authorizenet/Test/TestCase/CreateOrderWithOnlinePaymentsMethodsWithoutIFrameTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Authorizenet/Test/TestCase/CreateOrderWithOnlinePaymentsMethodsWithoutIFrameTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Authorizenet/Test/TestCase/CreateOrderWithOnlinePaymentsMethodsWithoutIFrameTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Authorizenet/Test/TestCase/CreateOrderWithOnlinePaymentsMethodsWithoutIFrameTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Authorizenet/Test/TestCase/CreateShipmentForAuthorizenetDirectpostMethodTest.php
+++ b/dev/tests/functional/tests/app/Mage/Authorizenet/Test/TestCase/CreateShipmentForAuthorizenetDirectpostMethodTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Authorizenet/Test/TestCase/CreateShipmentForAuthorizenetDirectpostMethodTest.php
+++ b/dev/tests/functional/tests/app/Mage/Authorizenet/Test/TestCase/CreateShipmentForAuthorizenetDirectpostMethodTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Authorizenet/Test/TestCase/CreateShipmentForAuthorizenetDirectpostMethodTest.php
+++ b/dev/tests/functional/tests/app/Mage/Authorizenet/Test/TestCase/CreateShipmentForAuthorizenetDirectpostMethodTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Authorizenet/Test/TestCase/CreateShipmentForAuthorizenetDirectpostMethodTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Authorizenet/Test/TestCase/CreateShipmentForAuthorizenetDirectpostMethodTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Authorizenet/Test/TestCase/CreateShipmentForAuthorizenetDirectpostMethodTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Authorizenet/Test/TestCase/CreateShipmentForAuthorizenetDirectpostMethodTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Authorizenet/Test/TestCase/CreateShipmentForAuthorizenetDirectpostMethodTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Authorizenet/Test/TestCase/CreateShipmentForAuthorizenetDirectpostMethodTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Authorizenet/Test/TestStep/FillCreditCardStep.php
+++ b/dev/tests/functional/tests/app/Mage/Authorizenet/Test/TestStep/FillCreditCardStep.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Authorizenet/Test/TestStep/FillCreditCardStep.php
+++ b/dev/tests/functional/tests/app/Mage/Authorizenet/Test/TestStep/FillCreditCardStep.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Authorizenet/Test/TestStep/FillCreditCardStep.php
+++ b/dev/tests/functional/tests/app/Mage/Authorizenet/Test/TestStep/FillCreditCardStep.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Authorizenet/Test/etc/testcase.xml
+++ b/dev/tests/functional/tests/app/Mage/Authorizenet/Test/etc/testcase.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Authorizenet/Test/etc/testcase.xml
+++ b/dev/tests/functional/tests/app/Mage/Authorizenet/Test/etc/testcase.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Authorizenet/Test/etc/testcase.xml
+++ b/dev/tests/functional/tests/app/Mage/Authorizenet/Test/etc/testcase.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle.php
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle.php
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle.php
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle/Option.php
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle/Option.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle/Option.php
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle/Option.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle/Option.php
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle/Option.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle/Option.xml
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle/Option.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle/Option.xml
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle/Option.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle/Option.xml
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle/Option.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle/Option/Search/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle/Option/Search/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle/Option/Search/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle/Option/Search/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle/Option/Search/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle/Option/Search/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle/Option/Selection.php
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle/Option/Selection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle/Option/Selection.php
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle/Option/Selection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle/Option/Selection.php
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle/Option/Selection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle/Option/Selection.xml
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle/Option/Selection.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle/Option/Selection.xml
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle/Option/Selection.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle/Option/Selection.xml
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle/Option/Selection.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Adminhtml/Catalog/Product/ProductForm.xml
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Adminhtml/Catalog/Product/ProductForm.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Adminhtml/Catalog/Product/ProductForm.xml
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Adminhtml/Catalog/Product/ProductForm.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Adminhtml/Catalog/Product/ProductForm.xml
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Adminhtml/Catalog/Product/ProductForm.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Catalog/Product/Price.php
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Catalog/Product/Price.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Catalog/Product/Price.php
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Catalog/Product/Price.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Catalog/Product/Price.php
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Catalog/Product/Price.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Catalog/Product/View.php
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Catalog/Product/View.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Catalog/Product/View.php
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Catalog/Product/View.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Catalog/Product/View.php
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Catalog/Product/View.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Catalog/Product/View/Type/Bundle.php
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Catalog/Product/View/Type/Bundle.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Catalog/Product/View/Type/Bundle.php
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Catalog/Product/View/Type/Bundle.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Catalog/Product/View/Type/Bundle.php
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Catalog/Product/View/Type/Bundle.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Catalog/Product/View/Type/Option.php
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Catalog/Product/View/Type/Option.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Catalog/Product/View/Type/Option.php
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Catalog/Product/View/Type/Option.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Catalog/Product/View/Type/Option.php
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Catalog/Product/View/Type/Option.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Catalog/Product/View/Type/Option/Checkbox.php
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Catalog/Product/View/Type/Option/Checkbox.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Catalog/Product/View/Type/Option/Checkbox.php
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Catalog/Product/View/Type/Option/Checkbox.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Catalog/Product/View/Type/Option/Checkbox.php
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Catalog/Product/View/Type/Option/Checkbox.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Catalog/Product/View/Type/Option/Checkbox.xml
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Catalog/Product/View/Type/Option/Checkbox.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Catalog/Product/View/Type/Option/Checkbox.xml
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Catalog/Product/View/Type/Option/Checkbox.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Catalog/Product/View/Type/Option/Checkbox.xml
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Catalog/Product/View/Type/Option/Checkbox.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Catalog/Product/View/Type/Option/Dropdown.php
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Catalog/Product/View/Type/Option/Dropdown.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Catalog/Product/View/Type/Option/Dropdown.php
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Catalog/Product/View/Type/Option/Dropdown.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Catalog/Product/View/Type/Option/Dropdown.php
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Catalog/Product/View/Type/Option/Dropdown.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Catalog/Product/View/Type/Option/Dropdown.xml
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Catalog/Product/View/Type/Option/Dropdown.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Catalog/Product/View/Type/Option/Dropdown.xml
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Catalog/Product/View/Type/Option/Dropdown.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Catalog/Product/View/Type/Option/Dropdown.xml
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Catalog/Product/View/Type/Option/Dropdown.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Catalog/Product/View/Type/Option/Multipleselect.php
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Catalog/Product/View/Type/Option/Multipleselect.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Catalog/Product/View/Type/Option/Multipleselect.php
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Catalog/Product/View/Type/Option/Multipleselect.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Catalog/Product/View/Type/Option/Multipleselect.php
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Catalog/Product/View/Type/Option/Multipleselect.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Catalog/Product/View/Type/Option/Multipleselect.xml
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Catalog/Product/View/Type/Option/Multipleselect.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Catalog/Product/View/Type/Option/Multipleselect.xml
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Catalog/Product/View/Type/Option/Multipleselect.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Catalog/Product/View/Type/Option/Multipleselect.xml
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Catalog/Product/View/Type/Option/Multipleselect.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Catalog/Product/View/Type/Option/Radiobuttons.php
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Catalog/Product/View/Type/Option/Radiobuttons.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Catalog/Product/View/Type/Option/Radiobuttons.php
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Catalog/Product/View/Type/Option/Radiobuttons.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Catalog/Product/View/Type/Option/Radiobuttons.php
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Catalog/Product/View/Type/Option/Radiobuttons.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Catalog/Product/View/Type/Option/Radiobuttons.xml
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Catalog/Product/View/Type/Option/Radiobuttons.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Catalog/Product/View/Type/Option/Radiobuttons.xml
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Catalog/Product/View/Type/Option/Radiobuttons.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Catalog/Product/View/Type/Option/Radiobuttons.xml
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Block/Catalog/Product/View/Type/Option/Radiobuttons.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Constraint/AssertBundleItemsOnProductPage.php
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Constraint/AssertBundleItemsOnProductPage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Constraint/AssertBundleItemsOnProductPage.php
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Constraint/AssertBundleItemsOnProductPage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Constraint/AssertBundleItemsOnProductPage.php
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Constraint/AssertBundleItemsOnProductPage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Constraint/AssertBundlePriceType.php
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Constraint/AssertBundlePriceType.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Constraint/AssertBundlePriceType.php
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Constraint/AssertBundlePriceType.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Constraint/AssertBundlePriceType.php
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Constraint/AssertBundlePriceType.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Constraint/AssertBundlePriceView.php
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Constraint/AssertBundlePriceView.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Constraint/AssertBundlePriceView.php
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Constraint/AssertBundlePriceView.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Constraint/AssertBundlePriceView.php
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Constraint/AssertBundlePriceView.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Constraint/AssertBundleProductForm.php
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Constraint/AssertBundleProductForm.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Constraint/AssertBundleProductForm.php
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Constraint/AssertBundleProductForm.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Constraint/AssertBundleProductForm.php
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Constraint/AssertBundleProductForm.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Constraint/AssertBundleProductPage.php
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Constraint/AssertBundleProductPage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Constraint/AssertBundleProductPage.php
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Constraint/AssertBundleProductPage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Constraint/AssertBundleProductPage.php
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Constraint/AssertBundleProductPage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Constraint/AssertProductTierPriceOnBundleProductPage.php
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Constraint/AssertProductTierPriceOnBundleProductPage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Constraint/AssertProductTierPriceOnBundleProductPage.php
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Constraint/AssertProductTierPriceOnBundleProductPage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Constraint/AssertProductTierPriceOnBundleProductPage.php
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Constraint/AssertProductTierPriceOnBundleProductPage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Fixture/BundleProduct.xml
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Fixture/BundleProduct.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Fixture/BundleProduct.xml
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Fixture/BundleProduct.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Fixture/BundleProduct.xml
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Fixture/BundleProduct.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Fixture/BundleProduct/BundleSelections.php
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Fixture/BundleProduct/BundleSelections.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Fixture/BundleProduct/BundleSelections.php
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Fixture/BundleProduct/BundleSelections.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Fixture/BundleProduct/BundleSelections.php
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Fixture/BundleProduct/BundleSelections.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Fixture/Cart/Item.php
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Fixture/Cart/Item.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Fixture/Cart/Item.php
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Fixture/Cart/Item.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Fixture/Cart/Item.php
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Fixture/Cart/Item.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Handler/BundleProductInterface.php
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Handler/BundleProductInterface.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Handler/BundleProductInterface.php
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Handler/BundleProductInterface.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Handler/BundleProductInterface.php
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Handler/BundleProductInterface.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Handler/Curl.php
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Handler/Curl.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Handler/Curl.php
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Handler/Curl.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Handler/Curl.php
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Handler/Curl.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Page/Product/CatalogProductView.xml
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Page/Product/CatalogProductView.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Page/Product/CatalogProductView.xml
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Page/Product/CatalogProductView.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Page/Product/CatalogProductView.xml
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Page/Product/CatalogProductView.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Repository/BundleProduct.xml
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Repository/BundleProduct.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Repository/BundleProduct.xml
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Repository/BundleProduct.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Repository/BundleProduct.xml
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Repository/BundleProduct.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Repository/BundleProduct/BundleSelections.xml
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Repository/BundleProduct/BundleSelections.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Repository/BundleProduct/BundleSelections.xml
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Repository/BundleProduct/BundleSelections.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Repository/BundleProduct/BundleSelections.xml
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Repository/BundleProduct/BundleSelections.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Repository/BundleProduct/CheckoutData.xml
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Repository/BundleProduct/CheckoutData.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Repository/BundleProduct/CheckoutData.xml
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Repository/BundleProduct/CheckoutData.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Repository/BundleProduct/CheckoutData.xml
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Repository/BundleProduct/CheckoutData.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Repository/BundleProduct/Price.xml
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Repository/BundleProduct/Price.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Repository/BundleProduct/Price.xml
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Repository/BundleProduct/Price.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/Repository/BundleProduct/Price.xml
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/Repository/BundleProduct/Price.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/TestCase/AddProductToWishlistEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/TestCase/AddProductToWishlistEntityTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/TestCase/AddProductToWishlistEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/TestCase/AddProductToWishlistEntityTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/TestCase/AddProductToWishlistEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/TestCase/AddProductToWishlistEntityTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/TestCase/AddProductsToCartFromCustomerWishlistOnFrontendTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/TestCase/AddProductsToCartFromCustomerWishlistOnFrontendTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/TestCase/AddProductsToCartFromCustomerWishlistOnFrontendTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/TestCase/AddProductsToCartFromCustomerWishlistOnFrontendTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/TestCase/AddProductsToCartFromCustomerWishlistOnFrontendTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/TestCase/AddProductsToCartFromCustomerWishlistOnFrontendTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/TestCase/AddProductsToShoppingCartEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/TestCase/AddProductsToShoppingCartEntityTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/TestCase/AddProductsToShoppingCartEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/TestCase/AddProductsToShoppingCartEntityTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/TestCase/AddProductsToShoppingCartEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/TestCase/AddProductsToShoppingCartEntityTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/TestCase/ConfigureProductInCustomerWishlistOnFrontendTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/TestCase/ConfigureProductInCustomerWishlistOnFrontendTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/TestCase/ConfigureProductInCustomerWishlistOnFrontendTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/TestCase/ConfigureProductInCustomerWishlistOnFrontendTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/TestCase/ConfigureProductInCustomerWishlistOnFrontendTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/TestCase/ConfigureProductInCustomerWishlistOnFrontendTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/TestCase/CreateBundleProductEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/TestCase/CreateBundleProductEntityTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/TestCase/CreateBundleProductEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/TestCase/CreateBundleProductEntityTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/TestCase/CreateBundleProductEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/TestCase/CreateBundleProductEntityTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/TestCase/CreateBundleProductEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/TestCase/CreateBundleProductEntityTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/TestCase/CreateBundleProductEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/TestCase/CreateBundleProductEntityTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/TestCase/CreateBundleProductEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/TestCase/CreateBundleProductEntityTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/TestCase/DeleteBundleProductEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/TestCase/DeleteBundleProductEntityTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/TestCase/DeleteBundleProductEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/TestCase/DeleteBundleProductEntityTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/TestCase/DeleteBundleProductEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/TestCase/DeleteBundleProductEntityTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/TestCase/MoveProductFromShoppingCartToWishlistTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/TestCase/MoveProductFromShoppingCartToWishlistTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/TestCase/MoveProductFromShoppingCartToWishlistTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/TestCase/MoveProductFromShoppingCartToWishlistTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/TestCase/MoveProductFromShoppingCartToWishlistTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/TestCase/MoveProductFromShoppingCartToWishlistTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/etc/curl/di.xml
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/etc/curl/di.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/etc/curl/di.xml
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/etc/curl/di.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/etc/curl/di.xml
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/etc/curl/di.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/etc/fixture.xml
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/etc/fixture.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/etc/fixture.xml
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/etc/fixture.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Bundle/Test/etc/fixture.xml
+++ b/dev/tests/functional/tests/app/Mage/Bundle/Test/etc/fixture.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/AbstractConfigureBlock.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/AbstractConfigureBlock.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/AbstractConfigureBlock.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/AbstractConfigureBlock.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/AbstractConfigureBlock.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/AbstractConfigureBlock.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Category/View.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Category/View.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Category/View.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Category/View.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Category/View.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Category/View.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Layer/View.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Layer/View.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Layer/View.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Layer/View.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Layer/View.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Layer/View.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Msrp/Popup.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Msrp/Popup.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Msrp/Popup.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Msrp/Popup.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Msrp/Popup.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Msrp/Popup.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/Compare/ListCompare.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/Compare/ListCompare.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/Compare/ListCompare.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/Compare/ListCompare.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/Compare/ListCompare.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/Compare/ListCompare.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/Compare/Sidebar.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/Compare/Sidebar.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/Compare/Sidebar.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/Compare/Sidebar.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/Compare/Sidebar.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/Compare/Sidebar.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/ConfigurableProductView.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/ConfigurableProductView.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/ConfigurableProductView.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/ConfigurableProductView.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/ConfigurableProductView.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/ConfigurableProductView.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/GroupedProductView.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/GroupedProductView.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/GroupedProductView.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/GroupedProductView.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/GroupedProductView.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/GroupedProductView.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/ListProduct.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/ListProduct.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/ListProduct.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/ListProduct.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/ListProduct.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/ListProduct.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/Price.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/Price.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/Price.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/Price.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/Price.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/Price.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/ProductList/BottomToolbar.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/ProductList/BottomToolbar.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/ProductList/BottomToolbar.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/ProductList/BottomToolbar.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/ProductList/BottomToolbar.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/ProductList/BottomToolbar.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/ProductList/Compare.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/ProductList/Compare.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/ProductList/Compare.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/ProductList/Compare.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/ProductList/Compare.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/ProductList/Compare.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/ProductList/Crosssell.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/ProductList/Crosssell.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/ProductList/Crosssell.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/ProductList/Crosssell.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/ProductList/Crosssell.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/ProductList/Crosssell.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/ProductList/Crosssell/Item.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/ProductList/Crosssell/Item.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/ProductList/Crosssell/Item.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/ProductList/Crosssell/Item.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/ProductList/Crosssell/Item.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/ProductList/Crosssell/Item.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/ProductList/Related.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/ProductList/Related.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/ProductList/Related.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/ProductList/Related.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/ProductList/Related.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/ProductList/Related.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/ProductList/Related/Item.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/ProductList/Related/Item.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/ProductList/Related/Item.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/ProductList/Related/Item.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/ProductList/Related/Item.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/ProductList/Related/Item.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/ProductList/TopToolbar.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/ProductList/TopToolbar.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/ProductList/TopToolbar.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/ProductList/TopToolbar.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/ProductList/TopToolbar.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/ProductList/TopToolbar.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/ProductList/Upsell.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/ProductList/Upsell.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/ProductList/Upsell.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/ProductList/Upsell.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/ProductList/Upsell.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/ProductList/Upsell.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/ProductList/Upsell/Item.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/ProductList/Upsell/Item.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/ProductList/Upsell/Item.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/ProductList/Upsell/Item.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/ProductList/Upsell/Item.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/ProductList/Upsell/Item.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/View.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/View.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/View.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/View.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/View.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/View.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/View/ConfigurableOptions.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/View/ConfigurableOptions.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/View/ConfigurableOptions.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/View/ConfigurableOptions.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/View/ConfigurableOptions.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/View/ConfigurableOptions.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/View/ConfigurableOptions.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/View/ConfigurableOptions.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/View/ConfigurableOptions.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/View/ConfigurableOptions.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/View/ConfigurableOptions.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/View/ConfigurableOptions.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/View/CustomOptions.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/View/CustomOptions.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/View/CustomOptions.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/View/CustomOptions.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/View/CustomOptions.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/View/CustomOptions.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/View/CustomOptions.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/View/CustomOptions.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/View/CustomOptions.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/View/CustomOptions.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/View/CustomOptions.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/View/CustomOptions.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/View/GroupedItemForm.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/View/GroupedItemForm.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/View/GroupedItemForm.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/View/GroupedItemForm.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/View/GroupedItemForm.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/View/GroupedItemForm.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/View/GroupedItemForm.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/View/GroupedItemForm.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/View/GroupedItemForm.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/View/GroupedItemForm.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/View/GroupedItemForm.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/View/GroupedItemForm.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/View/GroupedProduct.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/View/GroupedProduct.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/View/GroupedProduct.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/View/GroupedProduct.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/View/GroupedProduct.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Product/View/GroupedProduct.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Search.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Search.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Search.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Search.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Search.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Block/Search.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AbstractAssertPriceOnGroupedProductPage.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AbstractAssertPriceOnGroupedProductPage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AbstractAssertPriceOnGroupedProductPage.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AbstractAssertPriceOnGroupedProductPage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AbstractAssertPriceOnGroupedProductPage.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AbstractAssertPriceOnGroupedProductPage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AbstractAssertProductsVisibleOnCategoryPageShopByFilter.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AbstractAssertProductsVisibleOnCategoryPageShopByFilter.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AbstractAssertProductsVisibleOnCategoryPageShopByFilter.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AbstractAssertProductsVisibleOnCategoryPageShopByFilter.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AbstractAssertProductsVisibleOnCategoryPageShopByFilter.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AbstractAssertProductsVisibleOnCategoryPageShopByFilter.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertAddToCartButtonPresent.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertAddToCartButtonPresent.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertAddToCartButtonPresent.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertAddToCartButtonPresent.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertAddToCartButtonPresent.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertAddToCartButtonPresent.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertAddedProductAttributeOnProductForm.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertAddedProductAttributeOnProductForm.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertAddedProductAttributeOnProductForm.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertAddedProductAttributeOnProductForm.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertAddedProductAttributeOnProductForm.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertAddedProductAttributeOnProductForm.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertAttributeForm.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertAttributeForm.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertAttributeForm.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertAttributeForm.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertAttributeForm.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertAttributeForm.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertAttributeOptionsOnProductForm.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertAttributeOptionsOnProductForm.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertAttributeOptionsOnProductForm.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertAttributeOptionsOnProductForm.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertAttributeOptionsOnProductForm.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertAttributeOptionsOnProductForm.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertCategoryAbsenceOnBackend.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertCategoryAbsenceOnBackend.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertCategoryAbsenceOnBackend.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertCategoryAbsenceOnBackend.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertCategoryAbsenceOnBackend.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertCategoryAbsenceOnBackend.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertCategoryAbsenceOnFrontend.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertCategoryAbsenceOnFrontend.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertCategoryAbsenceOnFrontend.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertCategoryAbsenceOnFrontend.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertCategoryAbsenceOnFrontend.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertCategoryAbsenceOnFrontend.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertCategoryForAssignedProducts.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertCategoryForAssignedProducts.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertCategoryForAssignedProducts.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertCategoryForAssignedProducts.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertCategoryForAssignedProducts.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertCategoryForAssignedProducts.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertCategoryForm.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertCategoryForm.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertCategoryForm.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertCategoryForm.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertCategoryForm.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertCategoryForm.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertCategoryPage.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertCategoryPage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertCategoryPage.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertCategoryPage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertCategoryPage.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertCategoryPage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertCategoryRedirect.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertCategoryRedirect.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertCategoryRedirect.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertCategoryRedirect.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertCategoryRedirect.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertCategoryRedirect.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertCategorySaveMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertCategorySaveMessage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertCategorySaveMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertCategorySaveMessage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertCategorySaveMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertCategorySaveMessage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertCategorySuccessDeleteMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertCategorySuccessDeleteMessage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertCategorySuccessDeleteMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertCategorySuccessDeleteMessage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertCategorySuccessDeleteMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertCategorySuccessDeleteMessage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertConfigurableProductForm.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertConfigurableProductForm.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertConfigurableProductForm.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertConfigurableProductForm.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertConfigurableProductForm.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertConfigurableProductForm.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertConfigurableProductInCart.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertConfigurableProductInCart.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertConfigurableProductInCart.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertConfigurableProductInCart.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertConfigurableProductInCart.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertConfigurableProductInCart.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertConfigurableProductPage.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertConfigurableProductPage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertConfigurableProductPage.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertConfigurableProductPage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertConfigurableProductPage.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertConfigurableProductPage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertCrossSellProducts.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertCrossSellProducts.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertCrossSellProducts.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertCrossSellProducts.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertCrossSellProducts.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertCrossSellProducts.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertCrossSellProductsSection.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertCrossSellProductsSection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertCrossSellProductsSection.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertCrossSellProductsSection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertCrossSellProductsSection.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertCrossSellProductsSection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertGroupedPriceOnGroupedProductPage.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertGroupedPriceOnGroupedProductPage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertGroupedPriceOnGroupedProductPage.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertGroupedPriceOnGroupedProductPage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertGroupedPriceOnGroupedProductPage.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertGroupedPriceOnGroupedProductPage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertGroupedProductsDefaultQty.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertGroupedProductsDefaultQty.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertGroupedProductsDefaultQty.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertGroupedProductsDefaultQty.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertGroupedProductsDefaultQty.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertGroupedProductsDefaultQty.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertPriceOnProductPageInterface.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertPriceOnProductPageInterface.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertPriceOnProductPageInterface.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertPriceOnProductPageInterface.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertPriceOnProductPageInterface.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertPriceOnProductPageInterface.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductAbsentCrossSells.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductAbsentCrossSells.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductAbsentCrossSells.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductAbsentCrossSells.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductAbsentCrossSells.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductAbsentCrossSells.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductAbsentRelatedProducts.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductAbsentRelatedProducts.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductAbsentRelatedProducts.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductAbsentRelatedProducts.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductAbsentRelatedProducts.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductAbsentRelatedProducts.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductAbsentUpSells.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductAbsentUpSells.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductAbsentUpSells.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductAbsentUpSells.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductAbsentUpSells.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductAbsentUpSells.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductAttributeDisplayingOnSearchForm.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductAttributeDisplayingOnSearchForm.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductAttributeDisplayingOnSearchForm.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductAttributeDisplayingOnSearchForm.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductAttributeDisplayingOnSearchForm.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductAttributeDisplayingOnSearchForm.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductAttributeInGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductAttributeInGrid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductAttributeInGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductAttributeInGrid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductAttributeInGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductAttributeInGrid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductAttributeIsComparable.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductAttributeIsComparable.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductAttributeIsComparable.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductAttributeIsComparable.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductAttributeIsComparable.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductAttributeIsComparable.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductAttributeIsFilterable.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductAttributeIsFilterable.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductAttributeIsFilterable.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductAttributeIsFilterable.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductAttributeIsFilterable.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductAttributeIsFilterable.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductAttributeIsFilterableInSearch.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductAttributeIsFilterableInSearch.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductAttributeIsFilterableInSearch.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductAttributeIsFilterableInSearch.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductAttributeIsFilterableInSearch.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductAttributeIsFilterableInSearch.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductAttributeIsGlobal.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductAttributeIsGlobal.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductAttributeIsGlobal.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductAttributeIsGlobal.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductAttributeIsGlobal.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductAttributeIsGlobal.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductAttributeIsRequired.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductAttributeIsRequired.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductAttributeIsRequired.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductAttributeIsRequired.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductAttributeIsRequired.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductAttributeIsRequired.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductAttributeIsUnique.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductAttributeIsUnique.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductAttributeIsUnique.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductAttributeIsUnique.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductAttributeIsUnique.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductAttributeIsUnique.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductAttributeIsUsedInSortOnFrontend.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductAttributeIsUsedInSortOnFrontend.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductAttributeIsUsedInSortOnFrontend.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductAttributeIsUsedInSortOnFrontend.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductAttributeIsUsedInSortOnFrontend.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductAttributeIsUsedInSortOnFrontend.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductAttributeSearchableByLabel.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductAttributeSearchableByLabel.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductAttributeSearchableByLabel.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductAttributeSearchableByLabel.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductAttributeSearchableByLabel.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductAttributeSearchableByLabel.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductCanNotAddToCart.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductCanNotAddToCart.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductCanNotAddToCart.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductCanNotAddToCart.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductCanNotAddToCart.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductCanNotAddToCart.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductCompareBlockOnCmsPage.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductCompareBlockOnCmsPage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductCompareBlockOnCmsPage.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductCompareBlockOnCmsPage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductCompareBlockOnCmsPage.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductCompareBlockOnCmsPage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductCompareItemsLink.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductCompareItemsLink.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductCompareItemsLink.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductCompareItemsLink.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductCompareItemsLink.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductCompareItemsLink.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductCompareItemsLinkIsAbsent.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductCompareItemsLinkIsAbsent.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductCompareItemsLinkIsAbsent.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductCompareItemsLinkIsAbsent.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductCompareItemsLinkIsAbsent.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductCompareItemsLinkIsAbsent.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductComparePage.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductComparePage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductComparePage.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductComparePage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductComparePage.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductComparePage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductCompareSuccessAddMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductCompareSuccessAddMessage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductCompareSuccessAddMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductCompareSuccessAddMessage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductCompareSuccessAddMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductCompareSuccessAddMessage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductCompareSuccessRemoveAllProductsMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductCompareSuccessRemoveAllProductsMessage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductCompareSuccessRemoveAllProductsMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductCompareSuccessRemoveAllProductsMessage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductCompareSuccessRemoveAllProductsMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductCompareSuccessRemoveAllProductsMessage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductCrossSells.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductCrossSells.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductCrossSells.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductCrossSells.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductCrossSells.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductCrossSells.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductCustomOptionsOnProductPage.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductCustomOptionsOnProductPage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductCustomOptionsOnProductPage.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductCustomOptionsOnProductPage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductCustomOptionsOnProductPage.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductCustomOptionsOnProductPage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductDuplicateForm.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductDuplicateForm.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductDuplicateForm.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductDuplicateForm.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductDuplicateForm.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductDuplicateForm.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductDuplicateIsNotDisplayingOnFrontend.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductDuplicateIsNotDisplayingOnFrontend.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductDuplicateIsNotDisplayingOnFrontend.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductDuplicateIsNotDisplayingOnFrontend.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductDuplicateIsNotDisplayingOnFrontend.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductDuplicateIsNotDisplayingOnFrontend.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductDuplicateMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductDuplicateMessage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductDuplicateMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductDuplicateMessage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductDuplicateMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductDuplicateMessage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductDuplicatedInGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductDuplicatedInGrid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductDuplicatedInGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductDuplicatedInGrid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductDuplicatedInGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductDuplicatedInGrid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductForm.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductForm.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductForm.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductForm.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductForm.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductForm.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductGroupedPriceOnProductPage.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductGroupedPriceOnProductPage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductGroupedPriceOnProductPage.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductGroupedPriceOnProductPage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductGroupedPriceOnProductPage.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductGroupedPriceOnProductPage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductInCart.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductInCart.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductInCart.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductInCart.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductInCart.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductInCart.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductInCategory.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductInCategory.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductInCategory.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductInCategory.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductInCategory.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductInCategory.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductInGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductInGrid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductInGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductInGrid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductInGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductInGrid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductInStock.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductInStock.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductInStock.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductInStock.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductInStock.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductInStock.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductIsNotDisplayingOnFrontend.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductIsNotDisplayingOnFrontend.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductIsNotDisplayingOnFrontend.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductIsNotDisplayingOnFrontend.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductIsNotDisplayingOnFrontend.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductIsNotDisplayingOnFrontend.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductMapAppliedBeforeCheckout.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductMapAppliedBeforeCheckout.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductMapAppliedBeforeCheckout.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductMapAppliedBeforeCheckout.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductMapAppliedBeforeCheckout.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductMapAppliedBeforeCheckout.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductMapAppliedInCart.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductMapAppliedInCart.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductMapAppliedInCart.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductMapAppliedInCart.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductMapAppliedInCart.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductMapAppliedInCart.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductMapAppliedOnGesture.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductMapAppliedOnGesture.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductMapAppliedOnGesture.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductMapAppliedOnGesture.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductMapAppliedOnGesture.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductMapAppliedOnGesture.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductNotInGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductNotInGrid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductNotInGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductNotInGrid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductNotInGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductNotInGrid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductNotSearchableBySku.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductNotSearchableBySku.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductNotSearchableBySku.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductNotSearchableBySku.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductNotSearchableBySku.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductNotSearchableBySku.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductOutOfStock.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductOutOfStock.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductOutOfStock.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductOutOfStock.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductOutOfStock.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductOutOfStock.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductOutOfStockOnCategory.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductOutOfStockOnCategory.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductOutOfStockOnCategory.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductOutOfStockOnCategory.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductOutOfStockOnCategory.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductOutOfStockOnCategory.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductOutOfStockVisibleInCategory.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductOutOfStockVisibleInCategory.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductOutOfStockVisibleInCategory.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductOutOfStockVisibleInCategory.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductOutOfStockVisibleInCategory.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductOutOfStockVisibleInCategory.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductPage.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductPage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductPage.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductPage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductPage.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductPage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductRelatedProducts.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductRelatedProducts.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductRelatedProducts.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductRelatedProducts.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductRelatedProducts.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductRelatedProducts.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductSaveMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductSaveMessage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductSaveMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductSaveMessage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductSaveMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductSaveMessage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductSearchable.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductSearchable.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductSearchable.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductSearchable.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductSearchable.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductSearchable.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductSpecialPriceNotLargerActual.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductSpecialPriceNotLargerActual.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductSpecialPriceNotLargerActual.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductSpecialPriceNotLargerActual.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductSpecialPriceNotLargerActual.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductSpecialPriceNotLargerActual.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductSpecialPriceOnProductPage.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductSpecialPriceOnProductPage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductSpecialPriceOnProductPage.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductSpecialPriceOnProductPage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductSpecialPriceOnProductPage.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductSpecialPriceOnProductPage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductTemplateForm.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductTemplateForm.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductTemplateForm.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductTemplateForm.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductTemplateForm.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductTemplateForm.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductTemplateInGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductTemplateInGrid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductTemplateInGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductTemplateInGrid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductTemplateInGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductTemplateInGrid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductTemplateOnProductForm.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductTemplateOnProductForm.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductTemplateOnProductForm.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductTemplateOnProductForm.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductTemplateOnProductForm.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductTemplateOnProductForm.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductTemplateSuccessSaveMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductTemplateSuccessSaveMessage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductTemplateSuccessSaveMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductTemplateSuccessSaveMessage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductTemplateSuccessSaveMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductTemplateSuccessSaveMessage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductTierPriceOnProductPage.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductTierPriceOnProductPage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductTierPriceOnProductPage.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductTierPriceOnProductPage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductTierPriceOnProductPage.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductTierPriceOnProductPage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductVisibleInCategory.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductVisibleInCategory.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductVisibleInCategory.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductVisibleInCategory.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductVisibleInCategory.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductVisibleInCategory.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductsIsNotDisplayingOnFrontend.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductsIsNotDisplayingOnFrontend.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductsIsNotDisplayingOnFrontend.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductsIsNotDisplayingOnFrontend.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductsIsNotDisplayingOnFrontend.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductsIsNotDisplayingOnFrontend.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductsNotInGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductsNotInGrid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductsNotInGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductsNotInGrid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductsNotInGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductsNotInGrid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductsNotVisibleInCategory.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductsNotVisibleInCategory.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductsNotVisibleInCategory.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductsNotVisibleInCategory.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductsNotVisibleInCategory.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductsNotVisibleInCategory.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductsSuccessDeleteMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductsSuccessDeleteMessage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductsSuccessDeleteMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductsSuccessDeleteMessage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductsSuccessDeleteMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductsSuccessDeleteMessage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductsVisibleOnCategoryPageShopByAttribute.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductsVisibleOnCategoryPageShopByAttribute.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductsVisibleOnCategoryPageShopByAttribute.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductsVisibleOnCategoryPageShopByAttribute.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductsVisibleOnCategoryPageShopByAttribute.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductsVisibleOnCategoryPageShopByAttribute.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductsVisibleOnCategoryPageShopByPrice.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductsVisibleOnCategoryPageShopByPrice.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductsVisibleOnCategoryPageShopByPrice.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductsVisibleOnCategoryPageShopByPrice.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductsVisibleOnCategoryPageShopByPrice.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertProductsVisibleOnCategoryPageShopByPrice.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertRelatedProducts.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertRelatedProducts.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertRelatedProducts.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertRelatedProducts.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertRelatedProducts.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertRelatedProducts.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertRelatedProductsSection.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertRelatedProductsSection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertRelatedProductsSection.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertRelatedProductsSection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertRelatedProductsSection.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertRelatedProductsSection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertSpecialPriceOnGroupedProductPage.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertSpecialPriceOnGroupedProductPage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertSpecialPriceOnGroupedProductPage.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertSpecialPriceOnGroupedProductPage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertSpecialPriceOnGroupedProductPage.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertSpecialPriceOnGroupedProductPage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertTierPriceOnGroupedProductPage.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertTierPriceOnGroupedProductPage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertTierPriceOnGroupedProductPage.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertTierPriceOnGroupedProductPage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertTierPriceOnGroupedProductPage.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertTierPriceOnGroupedProductPage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertUpSellProducts.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertUpSellProducts.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertUpSellProducts.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertUpSellProducts.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertUpSellProducts.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertUpSellProducts.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertUpSellProductsSection.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertUpSellProductsSection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertUpSellProductsSection.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertUpSellProductsSection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertUpSellProductsSection.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/AssertUpSellProductsSection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/ProductConfigurableHandler.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/ProductConfigurableHandler.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/ProductConfigurableHandler.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/ProductConfigurableHandler.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/ProductConfigurableHandler.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/ProductConfigurableHandler.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/ProductHandler.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/ProductHandler.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/ProductHandler.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/ProductHandler.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/ProductHandler.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Constraint/ProductHandler.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/Cart/Item.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/Cart/Item.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/Cart/Item.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/Cart/Item.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/Cart/Item.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/Cart/Item.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogAttributeSet.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogAttributeSet.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogAttributeSet.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogAttributeSet.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogAttributeSet.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogAttributeSet.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogAttributeSet/AssignedAttributes.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogAttributeSet/AssignedAttributes.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogAttributeSet/AssignedAttributes.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogAttributeSet/AssignedAttributes.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogAttributeSet/AssignedAttributes.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogAttributeSet/AssignedAttributes.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogAttributeSet/SkeletonSet.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogAttributeSet/SkeletonSet.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogAttributeSet/SkeletonSet.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogAttributeSet/SkeletonSet.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogAttributeSet/SkeletonSet.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogAttributeSet/SkeletonSet.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogCategory.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogCategory.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogCategory.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogCategory.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogCategory.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogCategory.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogCategory/CategoryProducts.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogCategory/CategoryProducts.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogCategory/CategoryProducts.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogCategory/CategoryProducts.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogCategory/CategoryProducts.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogCategory/CategoryProducts.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogCategory/ParentId.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogCategory/ParentId.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogCategory/ParentId.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogCategory/ParentId.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogCategory/ParentId.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogCategory/ParentId.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductAttribute.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductAttribute.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductAttribute.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductAttribute.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductAttribute.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductAttribute.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductAttribute/Options.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductAttribute/Options.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductAttribute/Options.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductAttribute/Options.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductAttribute/Options.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductAttribute/Options.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductSimple.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductSimple.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductSimple.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductSimple.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductSimple.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductSimple.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductSimple/AbstractRelatedProducts.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductSimple/AbstractRelatedProducts.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductSimple/AbstractRelatedProducts.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductSimple/AbstractRelatedProducts.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductSimple/AbstractRelatedProducts.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductSimple/AbstractRelatedProducts.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductSimple/AttributeSetId.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductSimple/AttributeSetId.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductSimple/AttributeSetId.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductSimple/AttributeSetId.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductSimple/AttributeSetId.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductSimple/AttributeSetId.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductSimple/Attributes.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductSimple/Attributes.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductSimple/Attributes.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductSimple/Attributes.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductSimple/Attributes.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductSimple/Attributes.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductSimple/CategoryIds.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductSimple/CategoryIds.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductSimple/CategoryIds.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductSimple/CategoryIds.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductSimple/CategoryIds.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductSimple/CategoryIds.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductSimple/CrossSellProducts.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductSimple/CrossSellProducts.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductSimple/CrossSellProducts.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductSimple/CrossSellProducts.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductSimple/CrossSellProducts.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductSimple/CrossSellProducts.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductSimple/CustomOptions.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductSimple/CustomOptions.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductSimple/CustomOptions.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductSimple/CustomOptions.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductSimple/CustomOptions.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductSimple/CustomOptions.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductSimple/Fpt.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductSimple/Fpt.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductSimple/Fpt.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductSimple/Fpt.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductSimple/Fpt.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductSimple/Fpt.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductSimple/Price.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductSimple/Price.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductSimple/Price.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductSimple/Price.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductSimple/Price.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductSimple/Price.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductSimple/RelatedProducts.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductSimple/RelatedProducts.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductSimple/RelatedProducts.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductSimple/RelatedProducts.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductSimple/RelatedProducts.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductSimple/RelatedProducts.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductSimple/TaxClass.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductSimple/TaxClass.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductSimple/TaxClass.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductSimple/TaxClass.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductSimple/TaxClass.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductSimple/TaxClass.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductSimple/UpSellProducts.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductSimple/UpSellProducts.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductSimple/UpSellProducts.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductSimple/UpSellProducts.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductSimple/UpSellProducts.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductSimple/UpSellProducts.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductSimple/WebsiteIds.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductSimple/WebsiteIds.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductSimple/WebsiteIds.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductSimple/WebsiteIds.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductSimple/WebsiteIds.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductSimple/WebsiteIds.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductVirtual.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductVirtual.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductVirtual.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductVirtual.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductVirtual.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/CatalogProductVirtual.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/ConfigurableProduct.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/ConfigurableProduct.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/ConfigurableProduct.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/ConfigurableProduct.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/ConfigurableProduct.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/ConfigurableProduct.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/ConfigurableProduct/Cart/Item.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/ConfigurableProduct/Cart/Item.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/ConfigurableProduct/Cart/Item.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/ConfigurableProduct/Cart/Item.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/ConfigurableProduct/Cart/Item.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/ConfigurableProduct/Cart/Item.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/ConfigurableProduct/ConfigurableOptions.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/ConfigurableProduct/ConfigurableOptions.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/ConfigurableProduct/ConfigurableOptions.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/ConfigurableProduct/ConfigurableOptions.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/ConfigurableProduct/ConfigurableOptions.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/ConfigurableProduct/ConfigurableOptions.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/GroupedProduct.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/GroupedProduct.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/GroupedProduct.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/GroupedProduct.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/GroupedProduct.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/GroupedProduct.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/GroupedProduct/Associated.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/GroupedProduct/Associated.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/GroupedProduct/Associated.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/GroupedProduct/Associated.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/GroupedProduct/Associated.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/GroupedProduct/Associated.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/GroupedProduct/Cart/Item.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/GroupedProduct/Cart/Item.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/GroupedProduct/Cart/Item.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/GroupedProduct/Cart/Item.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/GroupedProduct/Cart/Item.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Fixture/GroupedProduct/Cart/Item.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Handler/CatalogAttributeSet/CatalogAttributeSetInterface.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Handler/CatalogAttributeSet/CatalogAttributeSetInterface.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Handler/CatalogAttributeSet/CatalogAttributeSetInterface.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Handler/CatalogAttributeSet/CatalogAttributeSetInterface.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Handler/CatalogAttributeSet/CatalogAttributeSetInterface.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Handler/CatalogAttributeSet/CatalogAttributeSetInterface.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Handler/CatalogAttributeSet/Curl.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Handler/CatalogAttributeSet/Curl.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Handler/CatalogAttributeSet/Curl.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Handler/CatalogAttributeSet/Curl.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Handler/CatalogAttributeSet/Curl.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Handler/CatalogAttributeSet/Curl.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Handler/CatalogCategory/CatalogCategoryInterface.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Handler/CatalogCategory/CatalogCategoryInterface.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Handler/CatalogCategory/CatalogCategoryInterface.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Handler/CatalogCategory/CatalogCategoryInterface.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Handler/CatalogCategory/CatalogCategoryInterface.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Handler/CatalogCategory/CatalogCategoryInterface.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Handler/CatalogCategory/Curl.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Handler/CatalogCategory/Curl.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Handler/CatalogCategory/Curl.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Handler/CatalogCategory/Curl.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Handler/CatalogCategory/Curl.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Handler/CatalogCategory/Curl.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Handler/CatalogProductAttribute/CatalogProductAttributeInterface.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Handler/CatalogProductAttribute/CatalogProductAttributeInterface.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Handler/CatalogProductAttribute/CatalogProductAttributeInterface.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Handler/CatalogProductAttribute/CatalogProductAttributeInterface.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Handler/CatalogProductAttribute/CatalogProductAttributeInterface.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Handler/CatalogProductAttribute/CatalogProductAttributeInterface.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Handler/CatalogProductAttribute/Curl.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Handler/CatalogProductAttribute/Curl.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Handler/CatalogProductAttribute/Curl.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Handler/CatalogProductAttribute/Curl.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Handler/CatalogProductAttribute/Curl.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Handler/CatalogProductAttribute/Curl.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Handler/CatalogProductSimple/CatalogProductSimpleInterface.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Handler/CatalogProductSimple/CatalogProductSimpleInterface.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Handler/CatalogProductSimple/CatalogProductSimpleInterface.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Handler/CatalogProductSimple/CatalogProductSimpleInterface.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Handler/CatalogProductSimple/CatalogProductSimpleInterface.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Handler/CatalogProductSimple/CatalogProductSimpleInterface.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Handler/CatalogProductSimple/Curl.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Handler/CatalogProductSimple/Curl.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Handler/CatalogProductSimple/Curl.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Handler/CatalogProductSimple/Curl.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Handler/CatalogProductSimple/Curl.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Handler/CatalogProductSimple/Curl.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Handler/CatalogProductVirtual/CatalogProductVirtualInterface.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Handler/CatalogProductVirtual/CatalogProductVirtualInterface.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Handler/CatalogProductVirtual/CatalogProductVirtualInterface.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Handler/CatalogProductVirtual/CatalogProductVirtualInterface.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Handler/CatalogProductVirtual/CatalogProductVirtualInterface.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Handler/CatalogProductVirtual/CatalogProductVirtualInterface.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Handler/CatalogProductVirtual/Curl.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Handler/CatalogProductVirtual/Curl.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Handler/CatalogProductVirtual/Curl.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Handler/CatalogProductVirtual/Curl.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Handler/CatalogProductVirtual/Curl.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Handler/CatalogProductVirtual/Curl.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Handler/ConfigurableProduct/ConfigurableProductInterface.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Handler/ConfigurableProduct/ConfigurableProductInterface.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Handler/ConfigurableProduct/ConfigurableProductInterface.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Handler/ConfigurableProduct/ConfigurableProductInterface.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Handler/ConfigurableProduct/ConfigurableProductInterface.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Handler/ConfigurableProduct/ConfigurableProductInterface.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Handler/ConfigurableProduct/Curl.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Handler/ConfigurableProduct/Curl.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Handler/ConfigurableProduct/Curl.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Handler/ConfigurableProduct/Curl.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Handler/ConfigurableProduct/Curl.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Handler/ConfigurableProduct/Curl.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Handler/GroupedProduct/Curl.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Handler/GroupedProduct/Curl.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Handler/GroupedProduct/Curl.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Handler/GroupedProduct/Curl.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Handler/GroupedProduct/Curl.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Handler/GroupedProduct/Curl.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Handler/GroupedProduct/GroupedProductInterface.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Handler/GroupedProduct/GroupedProductInterface.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Handler/GroupedProduct/GroupedProductInterface.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Handler/GroupedProduct/GroupedProductInterface.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Handler/GroupedProduct/GroupedProductInterface.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Handler/GroupedProduct/GroupedProductInterface.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Page/Adminhtml/CatalogCategoryIndex.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Page/Adminhtml/CatalogCategoryIndex.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Page/Adminhtml/CatalogCategoryIndex.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Page/Adminhtml/CatalogCategoryIndex.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Page/Adminhtml/CatalogCategoryIndex.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Page/Adminhtml/CatalogCategoryIndex.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Page/Adminhtml/CatalogProduct.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Page/Adminhtml/CatalogProduct.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Page/Adminhtml/CatalogProduct.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Page/Adminhtml/CatalogProduct.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Page/Adminhtml/CatalogProduct.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Page/Adminhtml/CatalogProduct.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Page/Adminhtml/CatalogProductAttributeEdit.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Page/Adminhtml/CatalogProductAttributeEdit.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Page/Adminhtml/CatalogProductAttributeEdit.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Page/Adminhtml/CatalogProductAttributeEdit.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Page/Adminhtml/CatalogProductAttributeEdit.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Page/Adminhtml/CatalogProductAttributeEdit.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Page/Adminhtml/CatalogProductAttributeIndex.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Page/Adminhtml/CatalogProductAttributeIndex.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Page/Adminhtml/CatalogProductAttributeIndex.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Page/Adminhtml/CatalogProductAttributeIndex.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Page/Adminhtml/CatalogProductAttributeIndex.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Page/Adminhtml/CatalogProductAttributeIndex.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Page/Adminhtml/CatalogProductAttributeNew.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Page/Adminhtml/CatalogProductAttributeNew.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Page/Adminhtml/CatalogProductAttributeNew.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Page/Adminhtml/CatalogProductAttributeNew.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Page/Adminhtml/CatalogProductAttributeNew.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Page/Adminhtml/CatalogProductAttributeNew.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Page/Adminhtml/CatalogProductEdit.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Page/Adminhtml/CatalogProductEdit.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Page/Adminhtml/CatalogProductEdit.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Page/Adminhtml/CatalogProductEdit.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Page/Adminhtml/CatalogProductEdit.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Page/Adminhtml/CatalogProductEdit.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Page/Adminhtml/CatalogProductNew.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Page/Adminhtml/CatalogProductNew.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Page/Adminhtml/CatalogProductNew.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Page/Adminhtml/CatalogProductNew.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Page/Adminhtml/CatalogProductNew.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Page/Adminhtml/CatalogProductNew.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Page/Adminhtml/CatalogProductSetAdd.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Page/Adminhtml/CatalogProductSetAdd.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Page/Adminhtml/CatalogProductSetAdd.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Page/Adminhtml/CatalogProductSetAdd.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Page/Adminhtml/CatalogProductSetAdd.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Page/Adminhtml/CatalogProductSetAdd.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Page/Adminhtml/CatalogProductSetEdit.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Page/Adminhtml/CatalogProductSetEdit.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Page/Adminhtml/CatalogProductSetEdit.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Page/Adminhtml/CatalogProductSetEdit.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Page/Adminhtml/CatalogProductSetEdit.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Page/Adminhtml/CatalogProductSetEdit.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Page/Adminhtml/CatalogProductSetIndex.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Page/Adminhtml/CatalogProductSetIndex.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Page/Adminhtml/CatalogProductSetIndex.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Page/Adminhtml/CatalogProductSetIndex.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Page/Adminhtml/CatalogProductSetIndex.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Page/Adminhtml/CatalogProductSetIndex.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Page/Category/CatalogCategoryView.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Page/Category/CatalogCategoryView.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Page/Category/CatalogCategoryView.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Page/Category/CatalogCategoryView.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Page/Category/CatalogCategoryView.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Page/Category/CatalogCategoryView.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Page/Product/CatalogProductCompare.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Page/Product/CatalogProductCompare.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Page/Product/CatalogProductCompare.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Page/Product/CatalogProductCompare.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Page/Product/CatalogProductCompare.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Page/Product/CatalogProductCompare.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Page/Product/CatalogProductView.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Page/Product/CatalogProductView.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Page/Product/CatalogProductView.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Page/Product/CatalogProductView.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Page/Product/CatalogProductView.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Page/Product/CatalogProductView.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogAttributeSet.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogAttributeSet.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogAttributeSet.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogAttributeSet.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogAttributeSet.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogAttributeSet.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogCategory.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogCategory.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogCategory.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogCategory.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogCategory.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogCategory.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductAttribute.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductAttribute.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductAttribute.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductAttribute.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductAttribute.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductAttribute.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductAttribute/Options.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductAttribute/Options.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductAttribute/Options.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductAttribute/Options.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductAttribute/Options.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductAttribute/Options.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductConfigurable/CheckoutData.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductConfigurable/CheckoutData.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductConfigurable/CheckoutData.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductConfigurable/CheckoutData.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductConfigurable/CheckoutData.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductConfigurable/CheckoutData.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductConfigurable/ConfigurableOptions.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductConfigurable/ConfigurableOptions.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductConfigurable/ConfigurableOptions.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductConfigurable/ConfigurableOptions.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductConfigurable/ConfigurableOptions.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductConfigurable/ConfigurableOptions.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductConfigurable/Price.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductConfigurable/Price.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductConfigurable/Price.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductConfigurable/Price.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductConfigurable/Price.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductConfigurable/Price.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductSimple.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductSimple.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductSimple.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductSimple.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductSimple.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductSimple.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductSimple/Attributes.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductSimple/Attributes.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductSimple/Attributes.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductSimple/Attributes.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductSimple/Attributes.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductSimple/Attributes.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductSimple/CheckoutData.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductSimple/CheckoutData.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductSimple/CheckoutData.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductSimple/CheckoutData.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductSimple/CheckoutData.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductSimple/CheckoutData.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductSimple/CustomOptions.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductSimple/CustomOptions.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductSimple/CustomOptions.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductSimple/CustomOptions.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductSimple/CustomOptions.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductSimple/CustomOptions.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductSimple/Fpt.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductSimple/Fpt.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductSimple/Fpt.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductSimple/Fpt.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductSimple/Fpt.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductSimple/Fpt.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductSimple/GroupPriceOptions.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductSimple/GroupPriceOptions.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductSimple/GroupPriceOptions.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductSimple/GroupPriceOptions.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductSimple/GroupPriceOptions.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductSimple/GroupPriceOptions.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductSimple/Price.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductSimple/Price.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductSimple/Price.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductSimple/Price.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductSimple/Price.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductSimple/Price.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductSimple/TierPriceOptions.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductSimple/TierPriceOptions.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductSimple/TierPriceOptions.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductSimple/TierPriceOptions.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductSimple/TierPriceOptions.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductSimple/TierPriceOptions.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductVirtual.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductVirtual.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductVirtual.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductVirtual.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductVirtual.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductVirtual.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductVirtual/CheckoutData.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductVirtual/CheckoutData.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductVirtual/CheckoutData.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductVirtual/CheckoutData.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductVirtual/CheckoutData.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductVirtual/CheckoutData.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductVirtual/Price.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductVirtual/Price.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductVirtual/Price.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductVirtual/Price.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductVirtual/Price.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/CatalogProductVirtual/Price.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/ConfigData.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/ConfigData.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/ConfigData.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/ConfigData.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/ConfigData.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/ConfigData.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/ConfigurableProduct.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/ConfigurableProduct.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/ConfigurableProduct.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/ConfigurableProduct.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/ConfigurableProduct.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/ConfigurableProduct.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/GroupedProduct.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/GroupedProduct.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/GroupedProduct.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/GroupedProduct.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/GroupedProduct.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/GroupedProduct.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/GroupedProduct/Associated.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/GroupedProduct/Associated.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/GroupedProduct/Associated.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/GroupedProduct/Associated.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/GroupedProduct/Associated.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/GroupedProduct/Associated.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/GroupedProduct/CheckoutData.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/GroupedProduct/CheckoutData.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/GroupedProduct/CheckoutData.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/GroupedProduct/CheckoutData.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/GroupedProduct/CheckoutData.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/GroupedProduct/CheckoutData.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/GroupedProduct/Price.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/GroupedProduct/Price.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/GroupedProduct/Price.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/GroupedProduct/Price.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/GroupedProduct/Price.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/Repository/GroupedProduct/Price.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Category/CreateCategoryEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Category/CreateCategoryEntityTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Category/CreateCategoryEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Category/CreateCategoryEntityTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Category/CreateCategoryEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Category/CreateCategoryEntityTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Category/CreateCategoryEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Category/CreateCategoryEntityTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Category/CreateCategoryEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Category/CreateCategoryEntityTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Category/CreateCategoryEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Category/CreateCategoryEntityTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Category/DeleteCategoryEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Category/DeleteCategoryEntityTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Category/DeleteCategoryEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Category/DeleteCategoryEntityTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Category/DeleteCategoryEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Category/DeleteCategoryEntityTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Category/DeleteCategoryEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Category/DeleteCategoryEntityTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Category/DeleteCategoryEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Category/DeleteCategoryEntityTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Category/DeleteCategoryEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Category/DeleteCategoryEntityTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Category/UpdateCategoryEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Category/UpdateCategoryEntityTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Category/UpdateCategoryEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Category/UpdateCategoryEntityTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Category/UpdateCategoryEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Category/UpdateCategoryEntityTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Category/UpdateCategoryEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Category/UpdateCategoryEntityTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Category/UpdateCategoryEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Category/UpdateCategoryEntityTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Category/UpdateCategoryEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Category/UpdateCategoryEntityTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Layer/FilterProductListTest.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Layer/FilterProductListTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Layer/FilterProductListTest.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Layer/FilterProductListTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Layer/FilterProductListTest.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Layer/FilterProductListTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Layer/FilterProductListTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Layer/FilterProductListTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Layer/FilterProductListTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Layer/FilterProductListTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Layer/FilterProductListTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Layer/FilterProductListTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/AbstractAddAppurtenantProductsEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/AbstractAddAppurtenantProductsEntityTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/AbstractAddAppurtenantProductsEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/AbstractAddAppurtenantProductsEntityTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/AbstractAddAppurtenantProductsEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/AbstractAddAppurtenantProductsEntityTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/AbstractProductsCompareTest.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/AbstractProductsCompareTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/AbstractProductsCompareTest.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/AbstractProductsCompareTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/AbstractProductsCompareTest.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/AbstractProductsCompareTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/AbstractPromoteAppurtenantProductsEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/AbstractPromoteAppurtenantProductsEntityTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/AbstractPromoteAppurtenantProductsEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/AbstractPromoteAppurtenantProductsEntityTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/AbstractPromoteAppurtenantProductsEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/AbstractPromoteAppurtenantProductsEntityTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/AddCrossSellProductsEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/AddCrossSellProductsEntityTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/AddCrossSellProductsEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/AddCrossSellProductsEntityTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/AddCrossSellProductsEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/AddCrossSellProductsEntityTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/AddCrossSellProductsEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/AddCrossSellProductsEntityTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/AddCrossSellProductsEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/AddCrossSellProductsEntityTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/AddCrossSellProductsEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/AddCrossSellProductsEntityTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/AddProductsToCompareTest.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/AddProductsToCompareTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/AddProductsToCompareTest.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/AddProductsToCompareTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/AddProductsToCompareTest.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/AddProductsToCompareTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/AddProductsToCompareTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/AddProductsToCompareTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/AddProductsToCompareTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/AddProductsToCompareTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/AddProductsToCompareTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/AddProductsToCompareTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/AddRelatedProductsEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/AddRelatedProductsEntityTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/AddRelatedProductsEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/AddRelatedProductsEntityTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/AddRelatedProductsEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/AddRelatedProductsEntityTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/AddRelatedProductsEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/AddRelatedProductsEntityTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/AddRelatedProductsEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/AddRelatedProductsEntityTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/AddRelatedProductsEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/AddRelatedProductsEntityTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/AddUpSellProductsEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/AddUpSellProductsEntityTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/AddUpSellProductsEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/AddUpSellProductsEntityTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/AddUpSellProductsEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/AddUpSellProductsEntityTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/AddUpSellProductsEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/AddUpSellProductsEntityTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/AddUpSellProductsEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/AddUpSellProductsEntityTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/AddUpSellProductsEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/AddUpSellProductsEntityTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/ApplyMapTest.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/ApplyMapTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/ApplyMapTest.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/ApplyMapTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/ApplyMapTest.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/ApplyMapTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/ApplyMapTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/ApplyMapTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/ApplyMapTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/ApplyMapTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/ApplyMapTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/ApplyMapTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/ClearAllCompareProductsTest.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/ClearAllCompareProductsTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/ClearAllCompareProductsTest.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/ClearAllCompareProductsTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/ClearAllCompareProductsTest.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/ClearAllCompareProductsTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/ClearAllCompareProductsTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/ClearAllCompareProductsTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/ClearAllCompareProductsTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/ClearAllCompareProductsTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/ClearAllCompareProductsTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/ClearAllCompareProductsTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/CreateConfigurableProductEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/CreateConfigurableProductEntityTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/CreateConfigurableProductEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/CreateConfigurableProductEntityTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/CreateConfigurableProductEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/CreateConfigurableProductEntityTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/CreateConfigurableProductEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/CreateConfigurableProductEntityTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/CreateConfigurableProductEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/CreateConfigurableProductEntityTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/CreateConfigurableProductEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/CreateConfigurableProductEntityTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/CreateGroupedProductEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/CreateGroupedProductEntityTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/CreateGroupedProductEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/CreateGroupedProductEntityTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/CreateGroupedProductEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/CreateGroupedProductEntityTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/CreateGroupedProductEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/CreateGroupedProductEntityTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/CreateGroupedProductEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/CreateGroupedProductEntityTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/CreateGroupedProductEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/CreateGroupedProductEntityTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/CreateSimpleProductEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/CreateSimpleProductEntityTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/CreateSimpleProductEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/CreateSimpleProductEntityTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/CreateSimpleProductEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/CreateSimpleProductEntityTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/CreateSimpleProductEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/CreateSimpleProductEntityTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/CreateSimpleProductEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/CreateSimpleProductEntityTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/CreateSimpleProductEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/CreateSimpleProductEntityTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/CreateVirtualProductEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/CreateVirtualProductEntityTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/CreateVirtualProductEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/CreateVirtualProductEntityTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/CreateVirtualProductEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/CreateVirtualProductEntityTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/CreateVirtualProductEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/CreateVirtualProductEntityTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/CreateVirtualProductEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/CreateVirtualProductEntityTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/CreateVirtualProductEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/CreateVirtualProductEntityTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/DeleteProductEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/DeleteProductEntityTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/DeleteProductEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/DeleteProductEntityTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/DeleteProductEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/DeleteProductEntityTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/DeleteProductEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/DeleteProductEntityTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/DeleteProductEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/DeleteProductEntityTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/DeleteProductEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/DeleteProductEntityTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/DuplicateProductEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/DuplicateProductEntityTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/DuplicateProductEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/DuplicateProductEntityTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/DuplicateProductEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/DuplicateProductEntityTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/DuplicateProductEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/DuplicateProductEntityTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/DuplicateProductEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/DuplicateProductEntityTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/DuplicateProductEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/DuplicateProductEntityTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/PromoteProductsAsCrossSellsTest.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/PromoteProductsAsCrossSellsTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/PromoteProductsAsCrossSellsTest.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/PromoteProductsAsCrossSellsTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/PromoteProductsAsCrossSellsTest.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/PromoteProductsAsCrossSellsTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/PromoteProductsAsCrossSellsTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/PromoteProductsAsCrossSellsTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/PromoteProductsAsCrossSellsTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/PromoteProductsAsCrossSellsTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/PromoteProductsAsCrossSellsTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/PromoteProductsAsCrossSellsTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/PromoteProductsAsRelatedTest.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/PromoteProductsAsRelatedTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/PromoteProductsAsRelatedTest.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/PromoteProductsAsRelatedTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/PromoteProductsAsRelatedTest.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/PromoteProductsAsRelatedTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/PromoteProductsAsRelatedTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/PromoteProductsAsRelatedTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/PromoteProductsAsRelatedTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/PromoteProductsAsRelatedTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/PromoteProductsAsRelatedTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/PromoteProductsAsRelatedTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/PromoteProductsAsUpSellsTest.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/PromoteProductsAsUpSellsTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/PromoteProductsAsUpSellsTest.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/PromoteProductsAsUpSellsTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/PromoteProductsAsUpSellsTest.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/PromoteProductsAsUpSellsTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/PromoteProductsAsUpSellsTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/PromoteProductsAsUpSellsTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/PromoteProductsAsUpSellsTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/PromoteProductsAsUpSellsTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/PromoteProductsAsUpSellsTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/PromoteProductsAsUpSellsTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/UpdateConfigurableProductEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/UpdateConfigurableProductEntityTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/UpdateConfigurableProductEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/UpdateConfigurableProductEntityTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/UpdateConfigurableProductEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/UpdateConfigurableProductEntityTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/UpdateConfigurableProductEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/UpdateConfigurableProductEntityTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/UpdateConfigurableProductEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/UpdateConfigurableProductEntityTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/UpdateConfigurableProductEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/UpdateConfigurableProductEntityTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/UpdateSimpleProductEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/UpdateSimpleProductEntityTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/UpdateSimpleProductEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/UpdateSimpleProductEntityTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/UpdateSimpleProductEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/UpdateSimpleProductEntityTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/UpdateSimpleProductEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/UpdateSimpleProductEntityTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/UpdateSimpleProductEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/UpdateSimpleProductEntityTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/UpdateSimpleProductEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/Product/UpdateSimpleProductEntityTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/ProductAttribute/CreateAttributeSetEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/ProductAttribute/CreateAttributeSetEntityTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/ProductAttribute/CreateAttributeSetEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/ProductAttribute/CreateAttributeSetEntityTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/ProductAttribute/CreateAttributeSetEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/ProductAttribute/CreateAttributeSetEntityTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/ProductAttribute/CreateAttributeSetEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/ProductAttribute/CreateAttributeSetEntityTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/ProductAttribute/CreateAttributeSetEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/ProductAttribute/CreateAttributeSetEntityTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/ProductAttribute/CreateAttributeSetEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/ProductAttribute/CreateAttributeSetEntityTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/ProductAttribute/CreateProductAttributeEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/ProductAttribute/CreateProductAttributeEntityTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/ProductAttribute/CreateProductAttributeEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/ProductAttribute/CreateProductAttributeEntityTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/ProductAttribute/CreateProductAttributeEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/ProductAttribute/CreateProductAttributeEntityTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/ProductAttribute/CreateProductAttributeEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/ProductAttribute/CreateProductAttributeEntityTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/ProductAttribute/CreateProductAttributeEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/ProductAttribute/CreateProductAttributeEntityTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/ProductAttribute/CreateProductAttributeEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestCase/ProductAttribute/CreateProductAttributeEntityTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestStep/CreateProductAttributeStep.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestStep/CreateProductAttributeStep.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestStep/CreateProductAttributeStep.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestStep/CreateProductAttributeStep.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestStep/CreateProductAttributeStep.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestStep/CreateProductAttributeStep.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestStep/CreateProductStep.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestStep/CreateProductStep.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestStep/CreateProductStep.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestStep/CreateProductStep.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestStep/CreateProductStep.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestStep/CreateProductStep.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestStep/CreateProductTemplateStep.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestStep/CreateProductTemplateStep.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestStep/CreateProductTemplateStep.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestStep/CreateProductTemplateStep.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestStep/CreateProductTemplateStep.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestStep/CreateProductTemplateStep.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestStep/CreateProductsStep.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestStep/CreateProductsStep.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestStep/CreateProductsStep.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestStep/CreateProductsStep.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestStep/CreateProductsStep.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestStep/CreateProductsStep.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestStep/OpenProductOnBackendStep.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestStep/OpenProductOnBackendStep.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestStep/OpenProductOnBackendStep.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestStep/OpenProductOnBackendStep.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestStep/OpenProductOnBackendStep.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestStep/OpenProductOnBackendStep.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestStep/SaveProductStep.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestStep/SaveProductStep.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestStep/SaveProductStep.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestStep/SaveProductStep.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestStep/SaveProductStep.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestStep/SaveProductStep.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestStep/UpdateConfigurableProductStep.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestStep/UpdateConfigurableProductStep.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestStep/UpdateConfigurableProductStep.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestStep/UpdateConfigurableProductStep.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestStep/UpdateConfigurableProductStep.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestStep/UpdateConfigurableProductStep.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestStep/UpdateConfigurableProductStep/AbstractSubStep.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestStep/UpdateConfigurableProductStep/AbstractSubStep.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestStep/UpdateConfigurableProductStep/AbstractSubStep.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestStep/UpdateConfigurableProductStep/AbstractSubStep.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestStep/UpdateConfigurableProductStep/AbstractSubStep.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestStep/UpdateConfigurableProductStep/AbstractSubStep.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestStep/UpdateConfigurableProductStep/AddOptionsSubStep.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestStep/UpdateConfigurableProductStep/AddOptionsSubStep.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestStep/UpdateConfigurableProductStep/AddOptionsSubStep.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestStep/UpdateConfigurableProductStep/AddOptionsSubStep.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestStep/UpdateConfigurableProductStep/AddOptionsSubStep.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestStep/UpdateConfigurableProductStep/AddOptionsSubStep.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestStep/UpdateConfigurableProductStep/CreateProductSubStep.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestStep/UpdateConfigurableProductStep/CreateProductSubStep.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestStep/UpdateConfigurableProductStep/CreateProductSubStep.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestStep/UpdateConfigurableProductStep/CreateProductSubStep.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestStep/UpdateConfigurableProductStep/CreateProductSubStep.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestStep/UpdateConfigurableProductStep/CreateProductSubStep.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestStep/UpdateConfigurableProductStep/DeleteOptionsSubStep.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestStep/UpdateConfigurableProductStep/DeleteOptionsSubStep.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestStep/UpdateConfigurableProductStep/DeleteOptionsSubStep.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestStep/UpdateConfigurableProductStep/DeleteOptionsSubStep.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestStep/UpdateConfigurableProductStep/DeleteOptionsSubStep.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestStep/UpdateConfigurableProductStep/DeleteOptionsSubStep.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestStep/UpdateConfigurableProductStep/UpdateOptionsSubStep.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestStep/UpdateConfigurableProductStep/UpdateOptionsSubStep.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestStep/UpdateConfigurableProductStep/UpdateOptionsSubStep.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestStep/UpdateConfigurableProductStep/UpdateOptionsSubStep.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/TestStep/UpdateConfigurableProductStep/UpdateOptionsSubStep.php
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/TestStep/UpdateConfigurableProductStep/UpdateOptionsSubStep.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/etc/curl/di.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/etc/curl/di.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/etc/curl/di.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/etc/curl/di.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/etc/curl/di.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/etc/curl/di.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/etc/fixture.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/etc/fixture.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/etc/fixture.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/etc/fixture.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/etc/fixture.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/etc/fixture.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/etc/testcase.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/etc/testcase.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/etc/testcase.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/etc/testcase.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Catalog/Test/etc/testcase.xml
+++ b/dev/tests/functional/tests/app/Mage/Catalog/Test/etc/testcase.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Constraint/AssertCatalogPriceRuleAppliedInCatalogPage.php
+++ b/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Constraint/AssertCatalogPriceRuleAppliedInCatalogPage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Constraint/AssertCatalogPriceRuleAppliedInCatalogPage.php
+++ b/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Constraint/AssertCatalogPriceRuleAppliedInCatalogPage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Constraint/AssertCatalogPriceRuleAppliedInCatalogPage.php
+++ b/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Constraint/AssertCatalogPriceRuleAppliedInCatalogPage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Constraint/AssertCatalogPriceRuleAppliedInProductPage.php
+++ b/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Constraint/AssertCatalogPriceRuleAppliedInProductPage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Constraint/AssertCatalogPriceRuleAppliedInProductPage.php
+++ b/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Constraint/AssertCatalogPriceRuleAppliedInProductPage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Constraint/AssertCatalogPriceRuleAppliedInProductPage.php
+++ b/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Constraint/AssertCatalogPriceRuleAppliedInProductPage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Constraint/AssertCatalogPriceRuleAppliedInShoppingCart.php
+++ b/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Constraint/AssertCatalogPriceRuleAppliedInShoppingCart.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Constraint/AssertCatalogPriceRuleAppliedInShoppingCart.php
+++ b/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Constraint/AssertCatalogPriceRuleAppliedInShoppingCart.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Constraint/AssertCatalogPriceRuleAppliedInShoppingCart.php
+++ b/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Constraint/AssertCatalogPriceRuleAppliedInShoppingCart.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Constraint/AssertCatalogPriceRuleForm.php
+++ b/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Constraint/AssertCatalogPriceRuleForm.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Constraint/AssertCatalogPriceRuleForm.php
+++ b/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Constraint/AssertCatalogPriceRuleForm.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Constraint/AssertCatalogPriceRuleForm.php
+++ b/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Constraint/AssertCatalogPriceRuleForm.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Constraint/AssertCatalogPriceRuleInGrid.php
+++ b/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Constraint/AssertCatalogPriceRuleInGrid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Constraint/AssertCatalogPriceRuleInGrid.php
+++ b/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Constraint/AssertCatalogPriceRuleInGrid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Constraint/AssertCatalogPriceRuleInGrid.php
+++ b/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Constraint/AssertCatalogPriceRuleInGrid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Constraint/AssertCatalogPriceRuleNotInGrid.php
+++ b/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Constraint/AssertCatalogPriceRuleNotInGrid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Constraint/AssertCatalogPriceRuleNotInGrid.php
+++ b/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Constraint/AssertCatalogPriceRuleNotInGrid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Constraint/AssertCatalogPriceRuleNotInGrid.php
+++ b/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Constraint/AssertCatalogPriceRuleNotInGrid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Constraint/AssertCatalogPriceRuleNotInProductPage.php
+++ b/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Constraint/AssertCatalogPriceRuleNotInProductPage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Constraint/AssertCatalogPriceRuleNotInProductPage.php
+++ b/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Constraint/AssertCatalogPriceRuleNotInProductPage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Constraint/AssertCatalogPriceRuleNotInProductPage.php
+++ b/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Constraint/AssertCatalogPriceRuleNotInProductPage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Constraint/AssertCatalogPriceRuleNoticeMessage.php
+++ b/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Constraint/AssertCatalogPriceRuleNoticeMessage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Constraint/AssertCatalogPriceRuleNoticeMessage.php
+++ b/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Constraint/AssertCatalogPriceRuleNoticeMessage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Constraint/AssertCatalogPriceRuleNoticeMessage.php
+++ b/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Constraint/AssertCatalogPriceRuleNoticeMessage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Constraint/AssertCatalogPriceRuleSuccessDeleteMessage.php
+++ b/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Constraint/AssertCatalogPriceRuleSuccessDeleteMessage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Constraint/AssertCatalogPriceRuleSuccessDeleteMessage.php
+++ b/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Constraint/AssertCatalogPriceRuleSuccessDeleteMessage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Constraint/AssertCatalogPriceRuleSuccessDeleteMessage.php
+++ b/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Constraint/AssertCatalogPriceRuleSuccessDeleteMessage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Constraint/AssertCatalogPriceRuleSuccessSaveMessage.php
+++ b/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Constraint/AssertCatalogPriceRuleSuccessSaveMessage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Constraint/AssertCatalogPriceRuleSuccessSaveMessage.php
+++ b/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Constraint/AssertCatalogPriceRuleSuccessSaveMessage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Constraint/AssertCatalogPriceRuleSuccessSaveMessage.php
+++ b/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Constraint/AssertCatalogPriceRuleSuccessSaveMessage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Fixture/CatalogRule.xml
+++ b/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Fixture/CatalogRule.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Fixture/CatalogRule.xml
+++ b/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Fixture/CatalogRule.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Fixture/CatalogRule.xml
+++ b/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Fixture/CatalogRule.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Handler/CatalogRule/CatalogRuleInterface.php
+++ b/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Handler/CatalogRule/CatalogRuleInterface.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Handler/CatalogRule/CatalogRuleInterface.php
+++ b/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Handler/CatalogRule/CatalogRuleInterface.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Handler/CatalogRule/CatalogRuleInterface.php
+++ b/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Handler/CatalogRule/CatalogRuleInterface.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Handler/CatalogRule/Curl.php
+++ b/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Handler/CatalogRule/Curl.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Handler/CatalogRule/Curl.php
+++ b/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Handler/CatalogRule/Curl.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Handler/CatalogRule/Curl.php
+++ b/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Handler/CatalogRule/Curl.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Page/Adminhtml/CatalogRuleEdit.xml
+++ b/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Page/Adminhtml/CatalogRuleEdit.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Page/Adminhtml/CatalogRuleEdit.xml
+++ b/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Page/Adminhtml/CatalogRuleEdit.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Page/Adminhtml/CatalogRuleEdit.xml
+++ b/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Page/Adminhtml/CatalogRuleEdit.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Page/Adminhtml/CatalogRuleIndex.xml
+++ b/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Page/Adminhtml/CatalogRuleIndex.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Page/Adminhtml/CatalogRuleIndex.xml
+++ b/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Page/Adminhtml/CatalogRuleIndex.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Page/Adminhtml/CatalogRuleIndex.xml
+++ b/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Page/Adminhtml/CatalogRuleIndex.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Repository/CatalogRule.xml
+++ b/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Repository/CatalogRule.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Repository/CatalogRule.xml
+++ b/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Repository/CatalogRule.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Repository/CatalogRule.xml
+++ b/dev/tests/functional/tests/app/Mage/CatalogRule/Test/Repository/CatalogRule.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CatalogRule/Test/TestCase/AbstractCatalogRuleEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/CatalogRule/Test/TestCase/AbstractCatalogRuleEntityTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/CatalogRule/Test/TestCase/AbstractCatalogRuleEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/CatalogRule/Test/TestCase/AbstractCatalogRuleEntityTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CatalogRule/Test/TestCase/AbstractCatalogRuleEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/CatalogRule/Test/TestCase/AbstractCatalogRuleEntityTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CatalogRule/Test/TestCase/ApplySeveralCatalogPriceRuleEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/CatalogRule/Test/TestCase/ApplySeveralCatalogPriceRuleEntityTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/CatalogRule/Test/TestCase/ApplySeveralCatalogPriceRuleEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/CatalogRule/Test/TestCase/ApplySeveralCatalogPriceRuleEntityTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CatalogRule/Test/TestCase/ApplySeveralCatalogPriceRuleEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/CatalogRule/Test/TestCase/ApplySeveralCatalogPriceRuleEntityTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CatalogRule/Test/TestCase/ApplySeveralCatalogPriceRuleEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/CatalogRule/Test/TestCase/ApplySeveralCatalogPriceRuleEntityTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/CatalogRule/Test/TestCase/ApplySeveralCatalogPriceRuleEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/CatalogRule/Test/TestCase/ApplySeveralCatalogPriceRuleEntityTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CatalogRule/Test/TestCase/ApplySeveralCatalogPriceRuleEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/CatalogRule/Test/TestCase/ApplySeveralCatalogPriceRuleEntityTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CatalogRule/Test/TestCase/CreateCatalogPriceRuleEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/CatalogRule/Test/TestCase/CreateCatalogPriceRuleEntityTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/CatalogRule/Test/TestCase/CreateCatalogPriceRuleEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/CatalogRule/Test/TestCase/CreateCatalogPriceRuleEntityTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CatalogRule/Test/TestCase/CreateCatalogPriceRuleEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/CatalogRule/Test/TestCase/CreateCatalogPriceRuleEntityTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CatalogRule/Test/TestCase/CreateCatalogPriceRuleEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/CatalogRule/Test/TestCase/CreateCatalogPriceRuleEntityTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/CatalogRule/Test/TestCase/CreateCatalogPriceRuleEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/CatalogRule/Test/TestCase/CreateCatalogPriceRuleEntityTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CatalogRule/Test/TestCase/CreateCatalogPriceRuleEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/CatalogRule/Test/TestCase/CreateCatalogPriceRuleEntityTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CatalogRule/Test/TestCase/DeleteCatalogPriceRuleEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/CatalogRule/Test/TestCase/DeleteCatalogPriceRuleEntityTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/CatalogRule/Test/TestCase/DeleteCatalogPriceRuleEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/CatalogRule/Test/TestCase/DeleteCatalogPriceRuleEntityTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CatalogRule/Test/TestCase/DeleteCatalogPriceRuleEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/CatalogRule/Test/TestCase/DeleteCatalogPriceRuleEntityTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CatalogRule/Test/TestCase/DeleteCatalogPriceRuleEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/CatalogRule/Test/TestCase/DeleteCatalogPriceRuleEntityTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/CatalogRule/Test/TestCase/DeleteCatalogPriceRuleEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/CatalogRule/Test/TestCase/DeleteCatalogPriceRuleEntityTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CatalogRule/Test/TestCase/DeleteCatalogPriceRuleEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/CatalogRule/Test/TestCase/DeleteCatalogPriceRuleEntityTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CatalogRule/Test/TestStep/CreateCatalogRuleStep.php
+++ b/dev/tests/functional/tests/app/Mage/CatalogRule/Test/TestStep/CreateCatalogRuleStep.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/CatalogRule/Test/TestStep/CreateCatalogRuleStep.php
+++ b/dev/tests/functional/tests/app/Mage/CatalogRule/Test/TestStep/CreateCatalogRuleStep.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CatalogRule/Test/TestStep/CreateCatalogRuleStep.php
+++ b/dev/tests/functional/tests/app/Mage/CatalogRule/Test/TestStep/CreateCatalogRuleStep.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CatalogRule/Test/TestStep/DeleteAllCatalogRulesStep.php
+++ b/dev/tests/functional/tests/app/Mage/CatalogRule/Test/TestStep/DeleteAllCatalogRulesStep.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/CatalogRule/Test/TestStep/DeleteAllCatalogRulesStep.php
+++ b/dev/tests/functional/tests/app/Mage/CatalogRule/Test/TestStep/DeleteAllCatalogRulesStep.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CatalogRule/Test/TestStep/DeleteAllCatalogRulesStep.php
+++ b/dev/tests/functional/tests/app/Mage/CatalogRule/Test/TestStep/DeleteAllCatalogRulesStep.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CatalogRule/Test/TestStep/SaveAndApplyCatalogRuleStep.php
+++ b/dev/tests/functional/tests/app/Mage/CatalogRule/Test/TestStep/SaveAndApplyCatalogRuleStep.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/CatalogRule/Test/TestStep/SaveAndApplyCatalogRuleStep.php
+++ b/dev/tests/functional/tests/app/Mage/CatalogRule/Test/TestStep/SaveAndApplyCatalogRuleStep.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CatalogRule/Test/TestStep/SaveAndApplyCatalogRuleStep.php
+++ b/dev/tests/functional/tests/app/Mage/CatalogRule/Test/TestStep/SaveAndApplyCatalogRuleStep.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CatalogRule/Test/etc/curl/di.xml
+++ b/dev/tests/functional/tests/app/Mage/CatalogRule/Test/etc/curl/di.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/CatalogRule/Test/etc/curl/di.xml
+++ b/dev/tests/functional/tests/app/Mage/CatalogRule/Test/etc/curl/di.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CatalogRule/Test/etc/curl/di.xml
+++ b/dev/tests/functional/tests/app/Mage/CatalogRule/Test/etc/curl/di.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CatalogRule/Test/etc/fixture.xml
+++ b/dev/tests/functional/tests/app/Mage/CatalogRule/Test/etc/fixture.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/CatalogRule/Test/etc/fixture.xml
+++ b/dev/tests/functional/tests/app/Mage/CatalogRule/Test/etc/fixture.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CatalogRule/Test/etc/fixture.xml
+++ b/dev/tests/functional/tests/app/Mage/CatalogRule/Test/etc/fixture.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/Block/Advanced/Form.php
+++ b/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/Block/Advanced/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/Block/Advanced/Form.php
+++ b/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/Block/Advanced/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/Block/Advanced/Form.php
+++ b/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/Block/Advanced/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/Constraint/AssertSearchTermForm.php
+++ b/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/Constraint/AssertSearchTermForm.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/Constraint/AssertSearchTermForm.php
+++ b/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/Constraint/AssertSearchTermForm.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/Constraint/AssertSearchTermForm.php
+++ b/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/Constraint/AssertSearchTermForm.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/Constraint/AssertSearchTermInGrid.php
+++ b/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/Constraint/AssertSearchTermInGrid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/Constraint/AssertSearchTermInGrid.php
+++ b/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/Constraint/AssertSearchTermInGrid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/Constraint/AssertSearchTermInGrid.php
+++ b/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/Constraint/AssertSearchTermInGrid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/Constraint/AssertSearchTermOnFrontend.php
+++ b/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/Constraint/AssertSearchTermOnFrontend.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/Constraint/AssertSearchTermOnFrontend.php
+++ b/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/Constraint/AssertSearchTermOnFrontend.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/Constraint/AssertSearchTermOnFrontend.php
+++ b/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/Constraint/AssertSearchTermOnFrontend.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/Constraint/AssertSearchTermSuccessSaveMessage.php
+++ b/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/Constraint/AssertSearchTermSuccessSaveMessage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/Constraint/AssertSearchTermSuccessSaveMessage.php
+++ b/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/Constraint/AssertSearchTermSuccessSaveMessage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/Constraint/AssertSearchTermSuccessSaveMessage.php
+++ b/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/Constraint/AssertSearchTermSuccessSaveMessage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/Constraint/AssertSearchTermSynonymOnFrontend.php
+++ b/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/Constraint/AssertSearchTermSynonymOnFrontend.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/Constraint/AssertSearchTermSynonymOnFrontend.php
+++ b/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/Constraint/AssertSearchTermSynonymOnFrontend.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/Constraint/AssertSearchTermSynonymOnFrontend.php
+++ b/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/Constraint/AssertSearchTermSynonymOnFrontend.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/Constraint/AssertSuggestSearchingResult.php
+++ b/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/Constraint/AssertSuggestSearchingResult.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/Constraint/AssertSuggestSearchingResult.php
+++ b/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/Constraint/AssertSuggestSearchingResult.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/Constraint/AssertSuggestSearchingResult.php
+++ b/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/Constraint/AssertSuggestSearchingResult.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/Fixture/CatalogSearchQuery.xml
+++ b/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/Fixture/CatalogSearchQuery.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/Fixture/CatalogSearchQuery.xml
+++ b/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/Fixture/CatalogSearchQuery.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/Fixture/CatalogSearchQuery.xml
+++ b/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/Fixture/CatalogSearchQuery.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/Fixture/CatalogSearchQuery/QueryText.php
+++ b/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/Fixture/CatalogSearchQuery/QueryText.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/Fixture/CatalogSearchQuery/QueryText.php
+++ b/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/Fixture/CatalogSearchQuery/QueryText.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/Fixture/CatalogSearchQuery/QueryText.php
+++ b/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/Fixture/CatalogSearchQuery/QueryText.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/Page/Adminhtml/CatalogSearchEdit.xml
+++ b/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/Page/Adminhtml/CatalogSearchEdit.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/Page/Adminhtml/CatalogSearchEdit.xml
+++ b/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/Page/Adminhtml/CatalogSearchEdit.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/Page/Adminhtml/CatalogSearchEdit.xml
+++ b/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/Page/Adminhtml/CatalogSearchEdit.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/Page/Adminhtml/CatalogSearchIndex.xml
+++ b/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/Page/Adminhtml/CatalogSearchIndex.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/Page/Adminhtml/CatalogSearchIndex.xml
+++ b/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/Page/Adminhtml/CatalogSearchIndex.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/Page/Adminhtml/CatalogSearchIndex.xml
+++ b/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/Page/Adminhtml/CatalogSearchIndex.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/Page/CatalogsearchAdvanced.xml
+++ b/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/Page/CatalogsearchAdvanced.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/Page/CatalogsearchAdvanced.xml
+++ b/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/Page/CatalogsearchAdvanced.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/Page/CatalogsearchAdvanced.xml
+++ b/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/Page/CatalogsearchAdvanced.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/Page/CatalogsearchResult.xml
+++ b/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/Page/CatalogsearchResult.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/Page/CatalogsearchResult.xml
+++ b/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/Page/CatalogsearchResult.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/Page/CatalogsearchResult.xml
+++ b/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/Page/CatalogsearchResult.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/TestCase/CreateSearchTermEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/TestCase/CreateSearchTermEntityTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/TestCase/CreateSearchTermEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/TestCase/CreateSearchTermEntityTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/TestCase/CreateSearchTermEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/TestCase/CreateSearchTermEntityTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/TestCase/CreateSearchTermEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/TestCase/CreateSearchTermEntityTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/TestCase/CreateSearchTermEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/TestCase/CreateSearchTermEntityTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/TestCase/CreateSearchTermEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/TestCase/CreateSearchTermEntityTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/TestCase/SuggestSearchingResultEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/TestCase/SuggestSearchingResultEntityTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/TestCase/SuggestSearchingResultEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/TestCase/SuggestSearchingResultEntityTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/TestCase/SuggestSearchingResultEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/TestCase/SuggestSearchingResultEntityTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/TestCase/SuggestSearchingResultEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/TestCase/SuggestSearchingResultEntityTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/TestCase/SuggestSearchingResultEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/TestCase/SuggestSearchingResultEntityTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/TestCase/SuggestSearchingResultEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/CatalogSearch/Test/TestCase/SuggestSearchingResultEntityTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/AbstractItem.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/AbstractItem.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/AbstractItem.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/AbstractItem.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/AbstractItem.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/AbstractItem.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Cart.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Cart.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Cart.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Cart.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Cart.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Cart.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Cart/CartItem.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Cart/CartItem.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Cart/CartItem.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Cart/CartItem.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Cart/CartItem.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Cart/CartItem.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Cart/DiscountCodes.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Cart/DiscountCodes.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Cart/DiscountCodes.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Cart/DiscountCodes.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Cart/DiscountCodes.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Cart/DiscountCodes.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Cart/Shipping.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Cart/Shipping.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Cart/Shipping.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Cart/Shipping.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Cart/Shipping.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Cart/Shipping.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Cart/Shipping.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Cart/Shipping.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Cart/Shipping.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Cart/Shipping.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Cart/Shipping.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Cart/Shipping.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Cart/Sidebar.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Cart/Sidebar.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Cart/Sidebar.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Cart/Sidebar.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Cart/Sidebar.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Cart/Sidebar.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Cart/Sidebar/CartItem.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Cart/Sidebar/CartItem.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Cart/Sidebar/CartItem.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Cart/Sidebar/CartItem.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Cart/Sidebar/CartItem.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Cart/Sidebar/CartItem.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Cart/Totals.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Cart/Totals.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Cart/Totals.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Cart/Totals.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Cart/Totals.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Cart/Totals.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/GroupedProductCart.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/GroupedProductCart.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/GroupedProductCart.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/GroupedProductCart.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/GroupedProductCart.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/GroupedProductCart.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/GroupedProductCart/CartItem.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/GroupedProductCart/CartItem.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/GroupedProductCart/CartItem.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/GroupedProductCart/CartItem.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/GroupedProductCart/CartItem.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/GroupedProductCart/CartItem.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Multishipping/AbstractMultishipping.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Multishipping/AbstractMultishipping.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Multishipping/AbstractMultishipping.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Multishipping/AbstractMultishipping.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Multishipping/AbstractMultishipping.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Multishipping/AbstractMultishipping.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Multishipping/AbstractMultishipping/AbstractItems.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Multishipping/AbstractMultishipping/AbstractItems.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Multishipping/AbstractMultishipping/AbstractItems.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Multishipping/AbstractMultishipping/AbstractItems.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Multishipping/AbstractMultishipping/AbstractItems.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Multishipping/AbstractMultishipping/AbstractItems.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Multishipping/Addresses.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Multishipping/Addresses.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Multishipping/Addresses.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Multishipping/Addresses.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Multishipping/Addresses.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Multishipping/Addresses.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Multishipping/Addresses/Items.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Multishipping/Addresses/Items.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Multishipping/Addresses/Items.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Multishipping/Addresses/Items.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Multishipping/Addresses/Items.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Multishipping/Addresses/Items.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Multishipping/Addresses/Items/Item.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Multishipping/Addresses/Items/Item.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Multishipping/Addresses/Items/Item.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Multishipping/Addresses/Items/Item.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Multishipping/Addresses/Items/Item.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Multishipping/Addresses/Items/Item.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Multishipping/Billing.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Multishipping/Billing.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Multishipping/Billing.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Multishipping/Billing.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Multishipping/Billing.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Multishipping/Billing.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Multishipping/Overview.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Multishipping/Overview.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Multishipping/Overview.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Multishipping/Overview.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Multishipping/Overview.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Multishipping/Overview.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Multishipping/Register.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Multishipping/Register.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Multishipping/Register.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Multishipping/Register.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Multishipping/Register.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Multishipping/Register.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Multishipping/Register.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Multishipping/Register.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Multishipping/Register.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Multishipping/Register.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Multishipping/Register.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Multishipping/Register.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Multishipping/Shipping.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Multishipping/Shipping.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Multishipping/Shipping.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Multishipping/Shipping.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Multishipping/Shipping.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Multishipping/Shipping.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Multishipping/Shipping/Items.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Multishipping/Shipping/Items.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Multishipping/Shipping/Items.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Multishipping/Shipping/Items.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Multishipping/Shipping/Items.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Multishipping/Shipping/Items.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Multishipping/Shipping/Items/Item.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Multishipping/Shipping/Items/Item.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Multishipping/Shipping/Items/Item.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Multishipping/Shipping/Items/Item.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Multishipping/Shipping/Items/Item.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Multishipping/Shipping/Items/Item.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Multishipping/Success.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Multishipping/Success.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Multishipping/Success.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Multishipping/Success.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Multishipping/Success.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Multishipping/Success.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Onepage/AbstractOnepage.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Onepage/AbstractOnepage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Onepage/AbstractOnepage.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Onepage/AbstractOnepage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Onepage/AbstractOnepage.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Onepage/AbstractOnepage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Onepage/Billing.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Onepage/Billing.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Onepage/Billing.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Onepage/Billing.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Onepage/Billing.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Onepage/Billing.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Onepage/Billing.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Onepage/Billing.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Onepage/Billing.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Onepage/Billing.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Onepage/Billing.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Onepage/Billing.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Onepage/Link.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Onepage/Link.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Onepage/Link.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Onepage/Link.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Onepage/Link.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Onepage/Link.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Onepage/Login.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Onepage/Login.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Onepage/Login.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Onepage/Login.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Onepage/Login.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Onepage/Login.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Onepage/Login.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Onepage/Login.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Onepage/Login.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Onepage/Login.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Onepage/Login.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Onepage/Login.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Onepage/Payment/Methods.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Onepage/Payment/Methods.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Onepage/Payment/Methods.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Onepage/Payment/Methods.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Onepage/Payment/Methods.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Onepage/Payment/Methods.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Onepage/Review.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Onepage/Review.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Onepage/Review.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Onepage/Review.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Onepage/Review.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Onepage/Review.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Onepage/Review/Items.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Onepage/Review/Items.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Onepage/Review/Items.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Onepage/Review/Items.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Onepage/Review/Items.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Onepage/Review/Items.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Onepage/Review/Items/Product.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Onepage/Review/Items/Product.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Onepage/Review/Items/Product.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Onepage/Review/Items/Product.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Onepage/Review/Items/Product.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Onepage/Review/Items/Product.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Onepage/Review/Totals.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Onepage/Review/Totals.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Onepage/Review/Totals.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Onepage/Review/Totals.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Onepage/Review/Totals.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Onepage/Review/Totals.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Onepage/Shipping/Method.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Onepage/Shipping/Method.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Onepage/Shipping/Method.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Onepage/Shipping/Method.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Onepage/Shipping/Method.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Onepage/Shipping/Method.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Onepage/Success.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Onepage/Success.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Onepage/Success.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Onepage/Success.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Onepage/Success.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Block/Onepage/Success.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AbstractAssertProductInShoppingCart.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AbstractAssertProductInShoppingCart.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AbstractAssertProductInShoppingCart.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AbstractAssertProductInShoppingCart.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AbstractAssertProductInShoppingCart.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AbstractAssertProductInShoppingCart.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertAbstractOrderAddressSameAsPaypal.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertAbstractOrderAddressSameAsPaypal.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertAbstractOrderAddressSameAsPaypal.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertAbstractOrderAddressSameAsPaypal.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertAbstractOrderAddressSameAsPaypal.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertAbstractOrderAddressSameAsPaypal.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertCartIsEmpty.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertCartIsEmpty.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertCartIsEmpty.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertCartIsEmpty.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertCartIsEmpty.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertCartIsEmpty.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertCartItemsOptions.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertCartItemsOptions.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertCartItemsOptions.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertCartItemsOptions.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertCartItemsOptions.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertCartItemsOptions.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertGrandTotalInShoppingCart.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertGrandTotalInShoppingCart.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertGrandTotalInShoppingCart.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertGrandTotalInShoppingCart.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertGrandTotalInShoppingCart.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertGrandTotalInShoppingCart.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertOrderBillingAddressSameAsPaypalShipping.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertOrderBillingAddressSameAsPaypalShipping.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertOrderBillingAddressSameAsPaypalShipping.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertOrderBillingAddressSameAsPaypalShipping.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertOrderBillingAddressSameAsPaypalShipping.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertOrderBillingAddressSameAsPaypalShipping.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertOrderShippingAddressSameAsPaypalBilling.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertOrderShippingAddressSameAsPaypalBilling.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertOrderShippingAddressSameAsPaypalBilling.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertOrderShippingAddressSameAsPaypalBilling.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertOrderShippingAddressSameAsPaypalBilling.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertOrderShippingAddressSameAsPaypalBilling.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertOrderSuccessPlacedMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertOrderSuccessPlacedMessage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertOrderSuccessPlacedMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertOrderSuccessPlacedMessage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertOrderSuccessPlacedMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertOrderSuccessPlacedMessage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertOrderWithMultishippingSuccessPlacedMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertOrderWithMultishippingSuccessPlacedMessage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertOrderWithMultishippingSuccessPlacedMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertOrderWithMultishippingSuccessPlacedMessage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertOrderWithMultishippingSuccessPlacedMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertOrderWithMultishippingSuccessPlacedMessage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertPriceInShoppingCart.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertPriceInShoppingCart.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertPriceInShoppingCart.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertPriceInShoppingCart.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertPriceInShoppingCart.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertPriceInShoppingCart.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertProductIsNotEditable.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertProductIsNotEditable.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertProductIsNotEditable.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertProductIsNotEditable.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertProductIsNotEditable.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertProductIsNotEditable.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertProductQtyInMiniShoppingCart.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertProductQtyInMiniShoppingCart.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertProductQtyInMiniShoppingCart.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertProductQtyInMiniShoppingCart.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertProductQtyInMiniShoppingCart.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertProductQtyInMiniShoppingCart.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertProductQtyInShoppingCart.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertProductQtyInShoppingCart.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertProductQtyInShoppingCart.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertProductQtyInShoppingCart.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertProductQtyInShoppingCart.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertProductQtyInShoppingCart.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertProductsPresentInShoppingCart.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertProductsPresentInShoppingCart.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertProductsPresentInShoppingCart.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertProductsPresentInShoppingCart.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertProductsPresentInShoppingCart.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertProductsPresentInShoppingCart.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertSubtotalInShoppingCart.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertSubtotalInShoppingCart.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertSubtotalInShoppingCart.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertSubtotalInShoppingCart.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertSubtotalInShoppingCart.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertSubtotalInShoppingCart.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertTermInGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertTermInGrid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertTermInGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertTermInGrid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertTermInGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertTermInGrid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertTermOnCheckout.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertTermOnCheckout.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertTermOnCheckout.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertTermOnCheckout.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertTermOnCheckout.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertTermOnCheckout.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertTermRequireMessageOnMultishippingCheckout.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertTermRequireMessageOnMultishippingCheckout.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertTermRequireMessageOnMultishippingCheckout.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertTermRequireMessageOnMultishippingCheckout.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertTermRequireMessageOnMultishippingCheckout.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertTermRequireMessageOnMultishippingCheckout.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertTermSuccessSaveMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertTermSuccessSaveMessage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertTermSuccessSaveMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertTermSuccessSaveMessage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertTermSuccessSaveMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Constraint/AssertTermSuccessSaveMessage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Fixture/Cart.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Fixture/Cart.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Fixture/Cart.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Fixture/Cart.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Fixture/Cart.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Fixture/Cart.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Fixture/Cart/Items.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Fixture/Cart/Items.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Fixture/Cart/Items.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Fixture/Cart/Items.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Fixture/Cart/Items.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Fixture/Cart/Items.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Fixture/CheckoutAgreement.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Fixture/CheckoutAgreement.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Fixture/CheckoutAgreement.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Fixture/CheckoutAgreement.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Fixture/CheckoutAgreement.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Fixture/CheckoutAgreement.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Fixture/CheckoutAgreement/Stores.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Fixture/CheckoutAgreement/Stores.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Fixture/CheckoutAgreement/Stores.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Fixture/CheckoutAgreement/Stores.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Fixture/CheckoutAgreement/Stores.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Fixture/CheckoutAgreement/Stores.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Page/Adminhtml/CheckoutAgreementEdit.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Page/Adminhtml/CheckoutAgreementEdit.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Page/Adminhtml/CheckoutAgreementEdit.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Page/Adminhtml/CheckoutAgreementEdit.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Page/Adminhtml/CheckoutAgreementEdit.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Page/Adminhtml/CheckoutAgreementEdit.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Page/Adminhtml/CheckoutAgreementIndex.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Page/Adminhtml/CheckoutAgreementIndex.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Page/Adminhtml/CheckoutAgreementIndex.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Page/Adminhtml/CheckoutAgreementIndex.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Page/Adminhtml/CheckoutAgreementIndex.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Page/Adminhtml/CheckoutAgreementIndex.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Page/Adminhtml/CheckoutAgreementNew.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Page/Adminhtml/CheckoutAgreementNew.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Page/Adminhtml/CheckoutAgreementNew.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Page/Adminhtml/CheckoutAgreementNew.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Page/Adminhtml/CheckoutAgreementNew.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Page/Adminhtml/CheckoutAgreementNew.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Page/CheckoutCart.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Page/CheckoutCart.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Page/CheckoutCart.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Page/CheckoutCart.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Page/CheckoutCart.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Page/CheckoutCart.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Page/CheckoutMultishippingAddressNewShipping.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Page/CheckoutMultishippingAddressNewShipping.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Page/CheckoutMultishippingAddressNewShipping.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Page/CheckoutMultishippingAddressNewShipping.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Page/CheckoutMultishippingAddressNewShipping.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Page/CheckoutMultishippingAddressNewShipping.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Page/CheckoutMultishippingAddresses.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Page/CheckoutMultishippingAddresses.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Page/CheckoutMultishippingAddresses.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Page/CheckoutMultishippingAddresses.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Page/CheckoutMultishippingAddresses.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Page/CheckoutMultishippingAddresses.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Page/CheckoutMultishippingBilling.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Page/CheckoutMultishippingBilling.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Page/CheckoutMultishippingBilling.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Page/CheckoutMultishippingBilling.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Page/CheckoutMultishippingBilling.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Page/CheckoutMultishippingBilling.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Page/CheckoutMultishippingLogin.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Page/CheckoutMultishippingLogin.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Page/CheckoutMultishippingLogin.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Page/CheckoutMultishippingLogin.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Page/CheckoutMultishippingLogin.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Page/CheckoutMultishippingLogin.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Page/CheckoutMultishippingOverview.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Page/CheckoutMultishippingOverview.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Page/CheckoutMultishippingOverview.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Page/CheckoutMultishippingOverview.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Page/CheckoutMultishippingOverview.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Page/CheckoutMultishippingOverview.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Page/CheckoutMultishippingRegister.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Page/CheckoutMultishippingRegister.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Page/CheckoutMultishippingRegister.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Page/CheckoutMultishippingRegister.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Page/CheckoutMultishippingRegister.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Page/CheckoutMultishippingRegister.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Page/CheckoutMultishippingShipping.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Page/CheckoutMultishippingShipping.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Page/CheckoutMultishippingShipping.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Page/CheckoutMultishippingShipping.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Page/CheckoutMultishippingShipping.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Page/CheckoutMultishippingShipping.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Page/CheckoutMultishippingSuccess.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Page/CheckoutMultishippingSuccess.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Page/CheckoutMultishippingSuccess.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Page/CheckoutMultishippingSuccess.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Page/CheckoutMultishippingSuccess.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Page/CheckoutMultishippingSuccess.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Page/CheckoutOnepage.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Page/CheckoutOnepage.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Page/CheckoutOnepage.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Page/CheckoutOnepage.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Page/CheckoutOnepage.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Page/CheckoutOnepage.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Page/CheckoutOnepageSuccess.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Page/CheckoutOnepageSuccess.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Page/CheckoutOnepageSuccess.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Page/CheckoutOnepageSuccess.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Page/CheckoutOnepageSuccess.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Page/CheckoutOnepageSuccess.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Page/CmsIndex.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Page/CmsIndex.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Page/CmsIndex.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Page/CmsIndex.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Page/CmsIndex.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Page/CmsIndex.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Repository/CheckoutAgreement.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Repository/CheckoutAgreement.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Repository/CheckoutAgreement.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Repository/CheckoutAgreement.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Repository/CheckoutAgreement.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Repository/CheckoutAgreement.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Repository/ConfigData.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Repository/ConfigData.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Repository/ConfigData.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Repository/ConfigData.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/Repository/ConfigData.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/Repository/ConfigData.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/AddProductsToShoppingCartEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/AddProductsToShoppingCartEntityTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/AddProductsToShoppingCartEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/AddProductsToShoppingCartEntityTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/AddProductsToShoppingCartEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/AddProductsToShoppingCartEntityTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/AddProductsToShoppingCartEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/AddProductsToShoppingCartEntityTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/AddProductsToShoppingCartEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/AddProductsToShoppingCartEntityTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/AddProductsToShoppingCartEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/AddProductsToShoppingCartEntityTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/CheckoutWithMultishippingTest.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/CheckoutWithMultishippingTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/CheckoutWithMultishippingTest.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/CheckoutWithMultishippingTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/CheckoutWithMultishippingTest.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/CheckoutWithMultishippingTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/CheckoutWithMultishippingTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/CheckoutWithMultishippingTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/CheckoutWithMultishippingTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/CheckoutWithMultishippingTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/CheckoutWithMultishippingTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/CheckoutWithMultishippingTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/CreateTermEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/CreateTermEntityTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/CreateTermEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/CreateTermEntityTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/CreateTermEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/CreateTermEntityTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/CreateTermEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/CreateTermEntityTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/CreateTermEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/CreateTermEntityTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/CreateTermEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/CreateTermEntityTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/DeleteProductsFromShoppingCartTest.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/DeleteProductsFromShoppingCartTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/DeleteProductsFromShoppingCartTest.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/DeleteProductsFromShoppingCartTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/DeleteProductsFromShoppingCartTest.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/DeleteProductsFromShoppingCartTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/DeleteProductsFromShoppingCartTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/DeleteProductsFromShoppingCartTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/DeleteProductsFromShoppingCartTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/DeleteProductsFromShoppingCartTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/DeleteProductsFromShoppingCartTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/DeleteProductsFromShoppingCartTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/OnePageCheckoutTest.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/OnePageCheckoutTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/OnePageCheckoutTest.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/OnePageCheckoutTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/OnePageCheckoutTest.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/OnePageCheckoutTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/OnePageCheckoutTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/OnePageCheckoutTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/OnePageCheckoutTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/OnePageCheckoutTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/OnePageCheckoutTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/OnePageCheckoutTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/OnePageCheckoutWithinDhlShippingMethod.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/OnePageCheckoutWithinDhlShippingMethod.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/OnePageCheckoutWithinDhlShippingMethod.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/OnePageCheckoutWithinDhlShippingMethod.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/OnePageCheckoutWithinDhlShippingMethod.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/OnePageCheckoutWithinDhlShippingMethod.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/OnePageCheckoutWithinDhlShippingMethod.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/OnePageCheckoutWithinDhlShippingMethod.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/OnePageCheckoutWithinDhlShippingMethod.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/OnePageCheckoutWithinDhlShippingMethod.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/OnePageCheckoutWithinDhlShippingMethod.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/OnePageCheckoutWithinDhlShippingMethod.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/OnePageCheckoutWithinOnlineShippingMethods.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/OnePageCheckoutWithinOnlineShippingMethods.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/OnePageCheckoutWithinOnlineShippingMethods.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/OnePageCheckoutWithinOnlineShippingMethods.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/OnePageCheckoutWithinOnlineShippingMethods.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/OnePageCheckoutWithinOnlineShippingMethods.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/OnePageCheckoutWithinOnlineShippingMethods.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/OnePageCheckoutWithinOnlineShippingMethods.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/OnePageCheckoutWithinOnlineShippingMethods.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/OnePageCheckoutWithinOnlineShippingMethods.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/OnePageCheckoutWithinOnlineShippingMethods.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/OnePageCheckoutWithinOnlineShippingMethods.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/UpdateShoppingCartTest.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/UpdateShoppingCartTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/UpdateShoppingCartTest.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/UpdateShoppingCartTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/UpdateShoppingCartTest.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/UpdateShoppingCartTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/UpdateShoppingCartTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/UpdateShoppingCartTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/UpdateShoppingCartTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/UpdateShoppingCartTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/UpdateShoppingCartTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestCase/UpdateShoppingCartTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/AddNewCheckoutAgreementStep.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/AddNewCheckoutAgreementStep.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/AddNewCheckoutAgreementStep.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/AddNewCheckoutAgreementStep.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/AddNewCheckoutAgreementStep.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/AddNewCheckoutAgreementStep.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/AddProductsToTheCartStep.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/AddProductsToTheCartStep.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/AddProductsToTheCartStep.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/AddProductsToTheCartStep.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/AddProductsToTheCartStep.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/AddProductsToTheCartStep.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/CreateCartItemStep.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/CreateCartItemStep.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/CreateCartItemStep.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/CreateCartItemStep.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/CreateCartItemStep.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/CreateCartItemStep.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/DeleteAllTermsEntityStep.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/DeleteAllTermsEntityStep.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/DeleteAllTermsEntityStep.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/DeleteAllTermsEntityStep.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/DeleteAllTermsEntityStep.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/DeleteAllTermsEntityStep.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/EnterNewAddressesStep.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/EnterNewAddressesStep.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/EnterNewAddressesStep.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/EnterNewAddressesStep.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/EnterNewAddressesStep.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/EnterNewAddressesStep.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/FillAndSaveCheckoutAgreementStep.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/FillAndSaveCheckoutAgreementStep.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/FillAndSaveCheckoutAgreementStep.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/FillAndSaveCheckoutAgreementStep.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/FillAndSaveCheckoutAgreementStep.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/FillAndSaveCheckoutAgreementStep.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/FillBillingInformationStep.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/FillBillingInformationStep.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/FillBillingInformationStep.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/FillBillingInformationStep.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/FillBillingInformationStep.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/FillBillingInformationStep.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/FillShippingMethodStep.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/FillShippingMethodStep.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/FillShippingMethodStep.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/FillShippingMethodStep.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/FillShippingMethodStep.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/FillShippingMethodStep.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/FillShippingMethodWithMultishippingStep.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/FillShippingMethodWithMultishippingStep.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/FillShippingMethodWithMultishippingStep.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/FillShippingMethodWithMultishippingStep.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/FillShippingMethodWithMultishippingStep.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/FillShippingMethodWithMultishippingStep.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/PlaceOrderStep.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/PlaceOrderStep.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/PlaceOrderStep.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/PlaceOrderStep.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/PlaceOrderStep.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/PlaceOrderStep.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/PlaceOrderWithMultishippingStep.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/PlaceOrderWithMultishippingStep.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/PlaceOrderWithMultishippingStep.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/PlaceOrderWithMultishippingStep.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/PlaceOrderWithMultishippingStep.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/PlaceOrderWithMultishippingStep.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/ProceedToCheckoutStep.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/ProceedToCheckoutStep.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/ProceedToCheckoutStep.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/ProceedToCheckoutStep.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/ProceedToCheckoutStep.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/ProceedToCheckoutStep.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/ProceedToCheckoutWithMultishippingStep.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/ProceedToCheckoutWithMultishippingStep.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/ProceedToCheckoutWithMultishippingStep.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/ProceedToCheckoutWithMultishippingStep.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/ProceedToCheckoutWithMultishippingStep.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/ProceedToCheckoutWithMultishippingStep.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/SelectAddressesStep.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/SelectAddressesStep.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/SelectAddressesStep.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/SelectAddressesStep.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/SelectAddressesStep.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/SelectAddressesStep.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/SelectCheckoutMethodStep.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/SelectCheckoutMethodStep.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/SelectCheckoutMethodStep.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/SelectCheckoutMethodStep.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/SelectCheckoutMethodStep.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/SelectCheckoutMethodStep.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/SelectCheckoutMethodWithMultishippingStep.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/SelectCheckoutMethodWithMultishippingStep.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/SelectCheckoutMethodWithMultishippingStep.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/SelectCheckoutMethodWithMultishippingStep.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/SelectCheckoutMethodWithMultishippingStep.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/SelectCheckoutMethodWithMultishippingStep.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/SelectPaymentMethodStep.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/SelectPaymentMethodStep.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/SelectPaymentMethodStep.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/SelectPaymentMethodStep.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/SelectPaymentMethodStep.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/SelectPaymentMethodStep.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/SelectPaymentMethodWithMultishippingStep.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/SelectPaymentMethodWithMultishippingStep.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/SelectPaymentMethodWithMultishippingStep.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/SelectPaymentMethodWithMultishippingStep.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/SelectPaymentMethodWithMultishippingStep.php
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/TestStep/SelectPaymentMethodWithMultishippingStep.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/etc/fixture.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/etc/fixture.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/etc/fixture.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/etc/fixture.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/etc/fixture.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/etc/fixture.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/etc/testcase.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/etc/testcase.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/etc/testcase.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/etc/testcase.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Checkout/Test/etc/testcase.xml
+++ b/dev/tests/functional/tests/app/Mage/Checkout/Test/etc/testcase.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Block/Page.php
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Block/Page.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Block/Page.php
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Block/Page.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Block/Page.php
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Block/Page.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Constraint/AssertCmsBlockInGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Constraint/AssertCmsBlockInGrid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Constraint/AssertCmsBlockInGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Constraint/AssertCmsBlockInGrid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Constraint/AssertCmsBlockInGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Constraint/AssertCmsBlockInGrid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Constraint/AssertCmsBlockNotOnCategoryPage.php
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Constraint/AssertCmsBlockNotOnCategoryPage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Constraint/AssertCmsBlockNotOnCategoryPage.php
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Constraint/AssertCmsBlockNotOnCategoryPage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Constraint/AssertCmsBlockNotOnCategoryPage.php
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Constraint/AssertCmsBlockNotOnCategoryPage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Constraint/AssertCmsBlockOnCategoryPage.php
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Constraint/AssertCmsBlockOnCategoryPage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Constraint/AssertCmsBlockOnCategoryPage.php
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Constraint/AssertCmsBlockOnCategoryPage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Constraint/AssertCmsBlockOnCategoryPage.php
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Constraint/AssertCmsBlockOnCategoryPage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Constraint/AssertCmsBlockSuccessSaveMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Constraint/AssertCmsBlockSuccessSaveMessage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Constraint/AssertCmsBlockSuccessSaveMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Constraint/AssertCmsBlockSuccessSaveMessage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Constraint/AssertCmsBlockSuccessSaveMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Constraint/AssertCmsBlockSuccessSaveMessage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Constraint/AssertCmsPageDeleteMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Constraint/AssertCmsPageDeleteMessage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Constraint/AssertCmsPageDeleteMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Constraint/AssertCmsPageDeleteMessage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Constraint/AssertCmsPageDeleteMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Constraint/AssertCmsPageDeleteMessage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Constraint/AssertCmsPageDisabledOnFrontend.php
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Constraint/AssertCmsPageDisabledOnFrontend.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Constraint/AssertCmsPageDisabledOnFrontend.php
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Constraint/AssertCmsPageDisabledOnFrontend.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Constraint/AssertCmsPageDisabledOnFrontend.php
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Constraint/AssertCmsPageDisabledOnFrontend.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Constraint/AssertCmsPageDisabledOnUnassignedStoreView.php
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Constraint/AssertCmsPageDisabledOnUnassignedStoreView.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Constraint/AssertCmsPageDisabledOnUnassignedStoreView.php
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Constraint/AssertCmsPageDisabledOnUnassignedStoreView.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Constraint/AssertCmsPageDisabledOnUnassignedStoreView.php
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Constraint/AssertCmsPageDisabledOnUnassignedStoreView.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Constraint/AssertCmsPageForm.php
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Constraint/AssertCmsPageForm.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Constraint/AssertCmsPageForm.php
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Constraint/AssertCmsPageForm.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Constraint/AssertCmsPageForm.php
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Constraint/AssertCmsPageForm.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Constraint/AssertCmsPageInGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Constraint/AssertCmsPageInGrid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Constraint/AssertCmsPageInGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Constraint/AssertCmsPageInGrid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Constraint/AssertCmsPageInGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Constraint/AssertCmsPageInGrid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Constraint/AssertCmsPageNotInGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Constraint/AssertCmsPageNotInGrid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Constraint/AssertCmsPageNotInGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Constraint/AssertCmsPageNotInGrid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Constraint/AssertCmsPageNotInGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Constraint/AssertCmsPageNotInGrid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Constraint/AssertCmsPagePreview.php
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Constraint/AssertCmsPagePreview.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Constraint/AssertCmsPagePreview.php
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Constraint/AssertCmsPagePreview.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Constraint/AssertCmsPagePreview.php
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Constraint/AssertCmsPagePreview.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Constraint/AssertCmsPageSuccessSaveMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Constraint/AssertCmsPageSuccessSaveMessage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Constraint/AssertCmsPageSuccessSaveMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Constraint/AssertCmsPageSuccessSaveMessage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Constraint/AssertCmsPageSuccessSaveMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Constraint/AssertCmsPageSuccessSaveMessage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Fixture/CmsBlock.xml
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Fixture/CmsBlock.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Fixture/CmsBlock.xml
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Fixture/CmsBlock.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Fixture/CmsBlock.xml
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Fixture/CmsBlock.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Fixture/CmsBlock/Stores.php
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Fixture/CmsBlock/Stores.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Fixture/CmsBlock/Stores.php
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Fixture/CmsBlock/Stores.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Fixture/CmsBlock/Stores.php
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Fixture/CmsBlock/Stores.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Fixture/CmsBlockMultiStore.xml
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Fixture/CmsBlockMultiStore.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Fixture/CmsBlockMultiStore.xml
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Fixture/CmsBlockMultiStore.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Fixture/CmsBlockMultiStore.xml
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Fixture/CmsBlockMultiStore.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Fixture/CmsPage.xml
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Fixture/CmsPage.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Fixture/CmsPage.xml
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Fixture/CmsPage.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Fixture/CmsPage.xml
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Fixture/CmsPage.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Fixture/CmsPage/Content.php
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Fixture/CmsPage/Content.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Fixture/CmsPage/Content.php
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Fixture/CmsPage/Content.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Fixture/CmsPage/Content.php
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Fixture/CmsPage/Content.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Fixture/CmsPage/StoreId.php
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Fixture/CmsPage/StoreId.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Fixture/CmsPage/StoreId.php
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Fixture/CmsPage/StoreId.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Fixture/CmsPage/StoreId.php
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Fixture/CmsPage/StoreId.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Fixture/CmsPageMultiStore.xml
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Fixture/CmsPageMultiStore.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Fixture/CmsPageMultiStore.xml
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Fixture/CmsPageMultiStore.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Fixture/CmsPageMultiStore.xml
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Fixture/CmsPageMultiStore.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Handler/CmsPage/CmsPageInterface.php
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Handler/CmsPage/CmsPageInterface.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Handler/CmsPage/CmsPageInterface.php
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Handler/CmsPage/CmsPageInterface.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Handler/CmsPage/CmsPageInterface.php
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Handler/CmsPage/CmsPageInterface.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Handler/CmsPage/Curl.php
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Handler/CmsPage/Curl.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Handler/CmsPage/Curl.php
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Handler/CmsPage/Curl.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Handler/CmsPage/Curl.php
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Handler/CmsPage/Curl.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Page/Adminhtml/CmsBlockEdit.xml
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Page/Adminhtml/CmsBlockEdit.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Page/Adminhtml/CmsBlockEdit.xml
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Page/Adminhtml/CmsBlockEdit.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Page/Adminhtml/CmsBlockEdit.xml
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Page/Adminhtml/CmsBlockEdit.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Page/Adminhtml/CmsBlockIndex.xml
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Page/Adminhtml/CmsBlockIndex.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Page/Adminhtml/CmsBlockIndex.xml
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Page/Adminhtml/CmsBlockIndex.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Page/Adminhtml/CmsBlockIndex.xml
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Page/Adminhtml/CmsBlockIndex.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Page/Adminhtml/CmsBlockNew.xml
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Page/Adminhtml/CmsBlockNew.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Page/Adminhtml/CmsBlockNew.xml
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Page/Adminhtml/CmsBlockNew.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Page/Adminhtml/CmsBlockNew.xml
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Page/Adminhtml/CmsBlockNew.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Page/Adminhtml/CmsPageEdit.xml
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Page/Adminhtml/CmsPageEdit.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Page/Adminhtml/CmsPageEdit.xml
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Page/Adminhtml/CmsPageEdit.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Page/Adminhtml/CmsPageEdit.xml
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Page/Adminhtml/CmsPageEdit.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Page/Adminhtml/CmsPageIndex.xml
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Page/Adminhtml/CmsPageIndex.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Page/Adminhtml/CmsPageIndex.xml
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Page/Adminhtml/CmsPageIndex.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Page/Adminhtml/CmsPageIndex.xml
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Page/Adminhtml/CmsPageIndex.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Page/Adminhtml/CmsPageNew.xml
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Page/Adminhtml/CmsPageNew.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Page/Adminhtml/CmsPageNew.xml
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Page/Adminhtml/CmsPageNew.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Page/Adminhtml/CmsPageNew.xml
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Page/Adminhtml/CmsPageNew.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Page/CmsIndex.xml
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Page/CmsIndex.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Page/CmsIndex.xml
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Page/CmsIndex.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Page/CmsIndex.xml
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Page/CmsIndex.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Page/CmsPage.xml
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Page/CmsPage.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Page/CmsPage.xml
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Page/CmsPage.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Page/CmsPage.xml
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Page/CmsPage.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Repository/CmsBlock.xml
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Repository/CmsBlock.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Repository/CmsBlock.xml
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Repository/CmsBlock.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Repository/CmsBlock.xml
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Repository/CmsBlock.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Repository/CmsPage.xml
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Repository/CmsPage.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Repository/CmsPage.xml
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Repository/CmsPage.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/Repository/CmsPage.xml
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/Repository/CmsPage.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/TestCase/CreateCmsBlockEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/TestCase/CreateCmsBlockEntityTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/TestCase/CreateCmsBlockEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/TestCase/CreateCmsBlockEntityTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/TestCase/CreateCmsBlockEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/TestCase/CreateCmsBlockEntityTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/TestCase/CreateCmsBlockEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/TestCase/CreateCmsBlockEntityTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/TestCase/CreateCmsBlockEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/TestCase/CreateCmsBlockEntityTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/TestCase/CreateCmsBlockEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/TestCase/CreateCmsBlockEntityTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/TestCase/CreateCmsPageEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/TestCase/CreateCmsPageEntityTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/TestCase/CreateCmsPageEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/TestCase/CreateCmsPageEntityTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/TestCase/CreateCmsPageEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/TestCase/CreateCmsPageEntityTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/TestCase/CreateCmsPageEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/TestCase/CreateCmsPageEntityTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/TestCase/CreateCmsPageEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/TestCase/CreateCmsPageEntityTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/TestCase/CreateCmsPageEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/TestCase/CreateCmsPageEntityTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/TestCase/DeleteCmsPageEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/TestCase/DeleteCmsPageEntityTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/TestCase/DeleteCmsPageEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/TestCase/DeleteCmsPageEntityTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/TestCase/DeleteCmsPageEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/TestCase/DeleteCmsPageEntityTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/TestCase/DeleteCmsPageEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/TestCase/DeleteCmsPageEntityTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/TestCase/DeleteCmsPageEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/TestCase/DeleteCmsPageEntityTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/TestCase/DeleteCmsPageEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/TestCase/DeleteCmsPageEntityTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/TestCase/UpdateCmsPageEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/TestCase/UpdateCmsPageEntityTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/TestCase/UpdateCmsPageEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/TestCase/UpdateCmsPageEntityTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/TestCase/UpdateCmsPageEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/TestCase/UpdateCmsPageEntityTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/TestCase/UpdateCmsPageEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/TestCase/UpdateCmsPageEntityTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/TestCase/UpdateCmsPageEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/TestCase/UpdateCmsPageEntityTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/TestCase/UpdateCmsPageEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/TestCase/UpdateCmsPageEntityTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/etc/curl/di.xml
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/etc/curl/di.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/etc/curl/di.xml
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/etc/curl/di.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/etc/curl/di.xml
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/etc/curl/di.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/etc/fixture.xml
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/etc/fixture.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/etc/fixture.xml
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/etc/fixture.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Cms/Test/etc/fixture.xml
+++ b/dev/tests/functional/tests/app/Mage/Cms/Test/etc/fixture.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Core/Test/Block/Messages.php
+++ b/dev/tests/functional/tests/app/Mage/Core/Test/Block/Messages.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Core/Test/Block/Messages.php
+++ b/dev/tests/functional/tests/app/Mage/Core/Test/Block/Messages.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Core/Test/Block/Messages.php
+++ b/dev/tests/functional/tests/app/Mage/Core/Test/Block/Messages.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Core/Test/Fixture/ConfigData.xml
+++ b/dev/tests/functional/tests/app/Mage/Core/Test/Fixture/ConfigData.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Core/Test/Fixture/ConfigData.xml
+++ b/dev/tests/functional/tests/app/Mage/Core/Test/Fixture/ConfigData.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Core/Test/Fixture/ConfigData.xml
+++ b/dev/tests/functional/tests/app/Mage/Core/Test/Fixture/ConfigData.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Core/Test/Fixture/Date.php
+++ b/dev/tests/functional/tests/app/Mage/Core/Test/Fixture/Date.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Core/Test/Fixture/Date.php
+++ b/dev/tests/functional/tests/app/Mage/Core/Test/Fixture/Date.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Core/Test/Fixture/Date.php
+++ b/dev/tests/functional/tests/app/Mage/Core/Test/Fixture/Date.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Core/Test/Handler/ConfigData/ConfigDataInterface.php
+++ b/dev/tests/functional/tests/app/Mage/Core/Test/Handler/ConfigData/ConfigDataInterface.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Core/Test/Handler/ConfigData/ConfigDataInterface.php
+++ b/dev/tests/functional/tests/app/Mage/Core/Test/Handler/ConfigData/ConfigDataInterface.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Core/Test/Handler/ConfigData/ConfigDataInterface.php
+++ b/dev/tests/functional/tests/app/Mage/Core/Test/Handler/ConfigData/ConfigDataInterface.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Core/Test/Handler/ConfigData/Curl.php
+++ b/dev/tests/functional/tests/app/Mage/Core/Test/Handler/ConfigData/Curl.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Core/Test/Handler/ConfigData/Curl.php
+++ b/dev/tests/functional/tests/app/Mage/Core/Test/Handler/ConfigData/Curl.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Core/Test/Handler/ConfigData/Curl.php
+++ b/dev/tests/functional/tests/app/Mage/Core/Test/Handler/ConfigData/Curl.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Core/Test/Repository/ConfigData.xml
+++ b/dev/tests/functional/tests/app/Mage/Core/Test/Repository/ConfigData.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Core/Test/Repository/ConfigData.xml
+++ b/dev/tests/functional/tests/app/Mage/Core/Test/Repository/ConfigData.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Core/Test/Repository/ConfigData.xml
+++ b/dev/tests/functional/tests/app/Mage/Core/Test/Repository/ConfigData.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Core/Test/TestStep/SetupConfigurationStep.php
+++ b/dev/tests/functional/tests/app/Mage/Core/Test/TestStep/SetupConfigurationStep.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Core/Test/TestStep/SetupConfigurationStep.php
+++ b/dev/tests/functional/tests/app/Mage/Core/Test/TestStep/SetupConfigurationStep.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Core/Test/TestStep/SetupConfigurationStep.php
+++ b/dev/tests/functional/tests/app/Mage/Core/Test/TestStep/SetupConfigurationStep.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Core/Test/etc/curl/di.xml
+++ b/dev/tests/functional/tests/app/Mage/Core/Test/etc/curl/di.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Core/Test/etc/curl/di.xml
+++ b/dev/tests/functional/tests/app/Mage/Core/Test/etc/curl/di.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Core/Test/etc/curl/di.xml
+++ b/dev/tests/functional/tests/app/Mage/Core/Test/etc/curl/di.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Core/Test/etc/fixture.xml
+++ b/dev/tests/functional/tests/app/Mage/Core/Test/etc/fixture.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Core/Test/etc/fixture.xml
+++ b/dev/tests/functional/tests/app/Mage/Core/Test/etc/fixture.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Core/Test/etc/fixture.xml
+++ b/dev/tests/functional/tests/app/Mage/Core/Test/etc/fixture.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CurrencySymbol/Test/Constraint/AssertCurrencySymbolOnCatalogPage.php
+++ b/dev/tests/functional/tests/app/Mage/CurrencySymbol/Test/Constraint/AssertCurrencySymbolOnCatalogPage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/CurrencySymbol/Test/Constraint/AssertCurrencySymbolOnCatalogPage.php
+++ b/dev/tests/functional/tests/app/Mage/CurrencySymbol/Test/Constraint/AssertCurrencySymbolOnCatalogPage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CurrencySymbol/Test/Constraint/AssertCurrencySymbolOnCatalogPage.php
+++ b/dev/tests/functional/tests/app/Mage/CurrencySymbol/Test/Constraint/AssertCurrencySymbolOnCatalogPage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CurrencySymbol/Test/Constraint/AssertCurrencySymbolOnProductPage.php
+++ b/dev/tests/functional/tests/app/Mage/CurrencySymbol/Test/Constraint/AssertCurrencySymbolOnProductPage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/CurrencySymbol/Test/Constraint/AssertCurrencySymbolOnProductPage.php
+++ b/dev/tests/functional/tests/app/Mage/CurrencySymbol/Test/Constraint/AssertCurrencySymbolOnProductPage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CurrencySymbol/Test/Constraint/AssertCurrencySymbolOnProductPage.php
+++ b/dev/tests/functional/tests/app/Mage/CurrencySymbol/Test/Constraint/AssertCurrencySymbolOnProductPage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CurrencySymbol/Test/Constraint/AssertCurrencySymbolSuccessSaveMessage.php
+++ b/dev/tests/functional/tests/app/Mage/CurrencySymbol/Test/Constraint/AssertCurrencySymbolSuccessSaveMessage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/CurrencySymbol/Test/Constraint/AssertCurrencySymbolSuccessSaveMessage.php
+++ b/dev/tests/functional/tests/app/Mage/CurrencySymbol/Test/Constraint/AssertCurrencySymbolSuccessSaveMessage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CurrencySymbol/Test/Constraint/AssertCurrencySymbolSuccessSaveMessage.php
+++ b/dev/tests/functional/tests/app/Mage/CurrencySymbol/Test/Constraint/AssertCurrencySymbolSuccessSaveMessage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CurrencySymbol/Test/Fixture/CurrencySymbolEntity.xml
+++ b/dev/tests/functional/tests/app/Mage/CurrencySymbol/Test/Fixture/CurrencySymbolEntity.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/CurrencySymbol/Test/Fixture/CurrencySymbolEntity.xml
+++ b/dev/tests/functional/tests/app/Mage/CurrencySymbol/Test/Fixture/CurrencySymbolEntity.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CurrencySymbol/Test/Fixture/CurrencySymbolEntity.xml
+++ b/dev/tests/functional/tests/app/Mage/CurrencySymbol/Test/Fixture/CurrencySymbolEntity.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CurrencySymbol/Test/Page/Adminhtml/SystemCurrencyIndex.xml
+++ b/dev/tests/functional/tests/app/Mage/CurrencySymbol/Test/Page/Adminhtml/SystemCurrencyIndex.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/CurrencySymbol/Test/Page/Adminhtml/SystemCurrencyIndex.xml
+++ b/dev/tests/functional/tests/app/Mage/CurrencySymbol/Test/Page/Adminhtml/SystemCurrencyIndex.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CurrencySymbol/Test/Page/Adminhtml/SystemCurrencyIndex.xml
+++ b/dev/tests/functional/tests/app/Mage/CurrencySymbol/Test/Page/Adminhtml/SystemCurrencyIndex.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CurrencySymbol/Test/Page/Adminhtml/SystemCurrencySymbolIndex.xml
+++ b/dev/tests/functional/tests/app/Mage/CurrencySymbol/Test/Page/Adminhtml/SystemCurrencySymbolIndex.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/CurrencySymbol/Test/Page/Adminhtml/SystemCurrencySymbolIndex.xml
+++ b/dev/tests/functional/tests/app/Mage/CurrencySymbol/Test/Page/Adminhtml/SystemCurrencySymbolIndex.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CurrencySymbol/Test/Page/Adminhtml/SystemCurrencySymbolIndex.xml
+++ b/dev/tests/functional/tests/app/Mage/CurrencySymbol/Test/Page/Adminhtml/SystemCurrencySymbolIndex.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CurrencySymbol/Test/Repository/ConfigData.xml
+++ b/dev/tests/functional/tests/app/Mage/CurrencySymbol/Test/Repository/ConfigData.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/CurrencySymbol/Test/Repository/ConfigData.xml
+++ b/dev/tests/functional/tests/app/Mage/CurrencySymbol/Test/Repository/ConfigData.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CurrencySymbol/Test/Repository/ConfigData.xml
+++ b/dev/tests/functional/tests/app/Mage/CurrencySymbol/Test/Repository/ConfigData.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CurrencySymbol/Test/TestCase/EditCurrencySymbolEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/CurrencySymbol/Test/TestCase/EditCurrencySymbolEntityTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/CurrencySymbol/Test/TestCase/EditCurrencySymbolEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/CurrencySymbol/Test/TestCase/EditCurrencySymbolEntityTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CurrencySymbol/Test/TestCase/EditCurrencySymbolEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/CurrencySymbol/Test/TestCase/EditCurrencySymbolEntityTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CurrencySymbol/Test/TestCase/EditCurrencySymbolEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/CurrencySymbol/Test/TestCase/EditCurrencySymbolEntityTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/CurrencySymbol/Test/TestCase/EditCurrencySymbolEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/CurrencySymbol/Test/TestCase/EditCurrencySymbolEntityTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CurrencySymbol/Test/TestCase/EditCurrencySymbolEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/CurrencySymbol/Test/TestCase/EditCurrencySymbolEntityTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CurrencySymbol/Test/TestStep/ApplyCurrencyInConfigStep.php
+++ b/dev/tests/functional/tests/app/Mage/CurrencySymbol/Test/TestStep/ApplyCurrencyInConfigStep.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/CurrencySymbol/Test/TestStep/ApplyCurrencyInConfigStep.php
+++ b/dev/tests/functional/tests/app/Mage/CurrencySymbol/Test/TestStep/ApplyCurrencyInConfigStep.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CurrencySymbol/Test/TestStep/ApplyCurrencyInConfigStep.php
+++ b/dev/tests/functional/tests/app/Mage/CurrencySymbol/Test/TestStep/ApplyCurrencyInConfigStep.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CurrencySymbol/Test/TestStep/ImportCurrencyRatesStep.php
+++ b/dev/tests/functional/tests/app/Mage/CurrencySymbol/Test/TestStep/ImportCurrencyRatesStep.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/CurrencySymbol/Test/TestStep/ImportCurrencyRatesStep.php
+++ b/dev/tests/functional/tests/app/Mage/CurrencySymbol/Test/TestStep/ImportCurrencyRatesStep.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CurrencySymbol/Test/TestStep/ImportCurrencyRatesStep.php
+++ b/dev/tests/functional/tests/app/Mage/CurrencySymbol/Test/TestStep/ImportCurrencyRatesStep.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CurrencySymbol/Test/TestStep/SetupCurrencyRatesStep.php
+++ b/dev/tests/functional/tests/app/Mage/CurrencySymbol/Test/TestStep/SetupCurrencyRatesStep.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/CurrencySymbol/Test/TestStep/SetupCurrencyRatesStep.php
+++ b/dev/tests/functional/tests/app/Mage/CurrencySymbol/Test/TestStep/SetupCurrencyRatesStep.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CurrencySymbol/Test/TestStep/SetupCurrencyRatesStep.php
+++ b/dev/tests/functional/tests/app/Mage/CurrencySymbol/Test/TestStep/SetupCurrencyRatesStep.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CurrencySymbol/Test/etc/fixture.xml
+++ b/dev/tests/functional/tests/app/Mage/CurrencySymbol/Test/etc/fixture.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/CurrencySymbol/Test/etc/fixture.xml
+++ b/dev/tests/functional/tests/app/Mage/CurrencySymbol/Test/etc/fixture.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/CurrencySymbol/Test/etc/fixture.xml
+++ b/dev/tests/functional/tests/app/Mage/CurrencySymbol/Test/etc/fixture.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Block/Account/Address/AdditionalAddress.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Block/Account/Address/AdditionalAddress.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Block/Account/Address/AdditionalAddress.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Block/Account/Address/AdditionalAddress.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Block/Account/Address/AdditionalAddress.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Block/Account/Address/AdditionalAddress.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Block/Account/Address/Book.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Block/Account/Address/Book.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Block/Account/Address/Book.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Block/Account/Address/Book.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Block/Account/Address/Book.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Block/Account/Address/Book.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Block/Account/Dashboard/Info.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Block/Account/Dashboard/Info.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Block/Account/Dashboard/Info.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Block/Account/Dashboard/Info.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Block/Account/Dashboard/Info.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Block/Account/Dashboard/Info.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Block/Account/Navigation.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Block/Account/Navigation.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Block/Account/Navigation.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Block/Account/Navigation.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Block/Account/Navigation.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Block/Account/Navigation.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Block/Address/Edit.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Block/Address/Edit.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Block/Address/Edit.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Block/Address/Edit.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Block/Address/Edit.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Block/Address/Edit.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Block/Address/Edit.xml
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Block/Address/Edit.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Block/Address/Edit.xml
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Block/Address/Edit.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Block/Address/Edit.xml
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Block/Address/Edit.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Block/Address/Renderer.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Block/Address/Renderer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Block/Address/Renderer.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Block/Address/Renderer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Block/Address/Renderer.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Block/Address/Renderer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Block/Form/CustomerForm.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Block/Form/CustomerForm.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Block/Form/CustomerForm.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Block/Form/CustomerForm.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Block/Form/CustomerForm.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Block/Form/CustomerForm.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Block/Form/CustomerForm.xml
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Block/Form/CustomerForm.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Block/Form/CustomerForm.xml
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Block/Form/CustomerForm.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Block/Form/CustomerForm.xml
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Block/Form/CustomerForm.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Block/Form/Login.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Block/Form/Login.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Block/Form/Login.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Block/Form/Login.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Block/Form/Login.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Block/Form/Login.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Block/Form/Login.xml
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Block/Form/Login.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Block/Form/Login.xml
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Block/Form/Login.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Block/Form/Login.xml
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Block/Form/Login.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Block/Form/Register.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Block/Form/Register.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Block/Form/Register.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Block/Form/Register.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Block/Form/Register.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Block/Form/Register.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Block/Form/Register.xml
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Block/Form/Register.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Block/Form/Register.xml
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Block/Form/Register.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Block/Form/Register.xml
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Block/Form/Register.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertAddressDeletedBackend.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertAddressDeletedBackend.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertAddressDeletedBackend.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertAddressDeletedBackend.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertAddressDeletedBackend.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertAddressDeletedBackend.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertAddressDeletedFrontend.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertAddressDeletedFrontend.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertAddressDeletedFrontend.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertAddressDeletedFrontend.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertAddressDeletedFrontend.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertAddressDeletedFrontend.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertChangePasswordFailMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertChangePasswordFailMessage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertChangePasswordFailMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertChangePasswordFailMessage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertChangePasswordFailMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertChangePasswordFailMessage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertCustomerFailRegisterMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertCustomerFailRegisterMessage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertCustomerFailRegisterMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertCustomerFailRegisterMessage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertCustomerFailRegisterMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertCustomerFailRegisterMessage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertCustomerForm.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertCustomerForm.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertCustomerForm.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertCustomerForm.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertCustomerForm.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertCustomerForm.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertCustomerGroupAlreadyExists.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertCustomerGroupAlreadyExists.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertCustomerGroupAlreadyExists.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertCustomerGroupAlreadyExists.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertCustomerGroupAlreadyExists.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertCustomerGroupAlreadyExists.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertCustomerGroupInGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertCustomerGroupInGrid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertCustomerGroupInGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertCustomerGroupInGrid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertCustomerGroupInGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertCustomerGroupInGrid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertCustomerGroupOnCustomerForm.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertCustomerGroupOnCustomerForm.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertCustomerGroupOnCustomerForm.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertCustomerGroupOnCustomerForm.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertCustomerGroupOnCustomerForm.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertCustomerGroupOnCustomerForm.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertCustomerGroupSuccessSaveMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertCustomerGroupSuccessSaveMessage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertCustomerGroupSuccessSaveMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertCustomerGroupSuccessSaveMessage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertCustomerGroupSuccessSaveMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertCustomerGroupSuccessSaveMessage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertCustomerInGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertCustomerInGrid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertCustomerInGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertCustomerInGrid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertCustomerInGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertCustomerInGrid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertCustomerInfoSuccessSavedMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertCustomerInfoSuccessSavedMessage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertCustomerInfoSuccessSavedMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertCustomerInfoSuccessSavedMessage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertCustomerInfoSuccessSavedMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertCustomerInfoSuccessSavedMessage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertCustomerInvalidEmail.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertCustomerInvalidEmail.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertCustomerInvalidEmail.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertCustomerInvalidEmail.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertCustomerInvalidEmail.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertCustomerInvalidEmail.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertCustomerPasswordChanged.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertCustomerPasswordChanged.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertCustomerPasswordChanged.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertCustomerPasswordChanged.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertCustomerPasswordChanged.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertCustomerPasswordChanged.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertCustomerSuccessRegisterMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertCustomerSuccessRegisterMessage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertCustomerSuccessRegisterMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertCustomerSuccessRegisterMessage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertCustomerSuccessRegisterMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertCustomerSuccessRegisterMessage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertCustomerSuccessSaveMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertCustomerSuccessSaveMessage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertCustomerSuccessSaveMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertCustomerSuccessSaveMessage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertCustomerSuccessSaveMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertCustomerSuccessSaveMessage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertWrongPassConfirmationMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertWrongPassConfirmationMessage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertWrongPassConfirmationMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertWrongPassConfirmationMessage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertWrongPassConfirmationMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/AssertWrongPassConfirmationMessage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/FrontendActionsForCustomer.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/FrontendActionsForCustomer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/FrontendActionsForCustomer.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/FrontendActionsForCustomer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/FrontendActionsForCustomer.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Constraint/FrontendActionsForCustomer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Fixture/Address.xml
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Fixture/Address.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Fixture/Address.xml
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Fixture/Address.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Fixture/Address.xml
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Fixture/Address.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Fixture/Customer.xml
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Fixture/Customer.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Fixture/Customer.xml
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Fixture/Customer.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Fixture/Customer.xml
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Fixture/Customer.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Fixture/Customer/Address.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Fixture/Customer/Address.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Fixture/Customer/Address.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Fixture/Customer/Address.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Fixture/Customer/Address.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Fixture/Customer/Address.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Fixture/Customer/GroupId.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Fixture/Customer/GroupId.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Fixture/Customer/GroupId.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Fixture/Customer/GroupId.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Fixture/Customer/GroupId.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Fixture/Customer/GroupId.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Fixture/CustomerGroup.xml
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Fixture/CustomerGroup.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Fixture/CustomerGroup.xml
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Fixture/CustomerGroup.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Fixture/CustomerGroup.xml
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Fixture/CustomerGroup.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Fixture/CustomerGroup/TaxClassIds.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Fixture/CustomerGroup/TaxClassIds.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Fixture/CustomerGroup/TaxClassIds.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Fixture/CustomerGroup/TaxClassIds.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Fixture/CustomerGroup/TaxClassIds.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Fixture/CustomerGroup/TaxClassIds.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Handler/Customer/Curl.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Handler/Customer/Curl.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Handler/Customer/Curl.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Handler/Customer/Curl.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Handler/Customer/Curl.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Handler/Customer/Curl.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Handler/Customer/CustomerInterface.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Handler/Customer/CustomerInterface.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Handler/Customer/CustomerInterface.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Handler/Customer/CustomerInterface.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Handler/Customer/CustomerInterface.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Handler/Customer/CustomerInterface.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Handler/CustomerGroup/Curl.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Handler/CustomerGroup/Curl.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Handler/CustomerGroup/Curl.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Handler/CustomerGroup/Curl.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Handler/CustomerGroup/Curl.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Handler/CustomerGroup/Curl.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Handler/CustomerGroup/CustomerGroupInterface.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Handler/CustomerGroup/CustomerGroupInterface.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Handler/CustomerGroup/CustomerGroupInterface.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Handler/CustomerGroup/CustomerGroupInterface.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Handler/CustomerGroup/CustomerGroupInterface.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Handler/CustomerGroup/CustomerGroupInterface.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Page/Adminhtml/CustomerEdit.xml
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Page/Adminhtml/CustomerEdit.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Page/Adminhtml/CustomerEdit.xml
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Page/Adminhtml/CustomerEdit.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Page/Adminhtml/CustomerEdit.xml
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Page/Adminhtml/CustomerEdit.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Page/Adminhtml/CustomerGroupIndex.xml
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Page/Adminhtml/CustomerGroupIndex.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Page/Adminhtml/CustomerGroupIndex.xml
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Page/Adminhtml/CustomerGroupIndex.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Page/Adminhtml/CustomerGroupIndex.xml
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Page/Adminhtml/CustomerGroupIndex.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Page/Adminhtml/CustomerGroupNew.xml
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Page/Adminhtml/CustomerGroupNew.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Page/Adminhtml/CustomerGroupNew.xml
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Page/Adminhtml/CustomerGroupNew.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Page/Adminhtml/CustomerGroupNew.xml
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Page/Adminhtml/CustomerGroupNew.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Page/Adminhtml/CustomerIndex.xml
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Page/Adminhtml/CustomerIndex.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Page/Adminhtml/CustomerIndex.xml
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Page/Adminhtml/CustomerIndex.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Page/Adminhtml/CustomerIndex.xml
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Page/Adminhtml/CustomerIndex.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Page/Adminhtml/CustomerNew.xml
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Page/Adminhtml/CustomerNew.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Page/Adminhtml/CustomerNew.xml
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Page/Adminhtml/CustomerNew.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Page/Adminhtml/CustomerNew.xml
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Page/Adminhtml/CustomerNew.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Page/CustomerAccountCreate.xml
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Page/CustomerAccountCreate.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Page/CustomerAccountCreate.xml
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Page/CustomerAccountCreate.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Page/CustomerAccountCreate.xml
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Page/CustomerAccountCreate.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Page/CustomerAccountEdit.xml
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Page/CustomerAccountEdit.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Page/CustomerAccountEdit.xml
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Page/CustomerAccountEdit.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Page/CustomerAccountEdit.xml
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Page/CustomerAccountEdit.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Page/CustomerAccountIndex.xml
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Page/CustomerAccountIndex.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Page/CustomerAccountIndex.xml
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Page/CustomerAccountIndex.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Page/CustomerAccountIndex.xml
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Page/CustomerAccountIndex.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Page/CustomerAccountLogin.xml
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Page/CustomerAccountLogin.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Page/CustomerAccountLogin.xml
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Page/CustomerAccountLogin.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Page/CustomerAccountLogin.xml
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Page/CustomerAccountLogin.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Page/CustomerAccountLogout.xml
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Page/CustomerAccountLogout.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Page/CustomerAccountLogout.xml
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Page/CustomerAccountLogout.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Page/CustomerAccountLogout.xml
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Page/CustomerAccountLogout.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Page/CustomerAddress.xml
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Page/CustomerAddress.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Page/CustomerAddress.xml
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Page/CustomerAddress.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Page/CustomerAddress.xml
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Page/CustomerAddress.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Repository/Address.xml
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Repository/Address.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Repository/Address.xml
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Repository/Address.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Repository/Address.xml
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Repository/Address.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Repository/ConfigData.xml
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Repository/ConfigData.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Repository/ConfigData.xml
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Repository/ConfigData.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Repository/ConfigData.xml
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Repository/ConfigData.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Repository/Customer.xml
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Repository/Customer.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Repository/Customer.xml
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Repository/Customer.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Repository/Customer.xml
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Repository/Customer.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Repository/CustomerGroup.xml
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Repository/CustomerGroup.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Repository/CustomerGroup.xml
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Repository/CustomerGroup.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/Repository/CustomerGroup.xml
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/Repository/CustomerGroup.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/TestCase/ChangeCustomerPasswordTest.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/TestCase/ChangeCustomerPasswordTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/TestCase/ChangeCustomerPasswordTest.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/TestCase/ChangeCustomerPasswordTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/TestCase/ChangeCustomerPasswordTest.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/TestCase/ChangeCustomerPasswordTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/TestCase/ChangeCustomerPasswordTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/TestCase/ChangeCustomerPasswordTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/TestCase/ChangeCustomerPasswordTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/TestCase/ChangeCustomerPasswordTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/TestCase/ChangeCustomerPasswordTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/TestCase/ChangeCustomerPasswordTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/TestCase/CreateCustomerFromBackendTest.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/TestCase/CreateCustomerFromBackendTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/TestCase/CreateCustomerFromBackendTest.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/TestCase/CreateCustomerFromBackendTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/TestCase/CreateCustomerFromBackendTest.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/TestCase/CreateCustomerFromBackendTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/TestCase/CreateCustomerFromBackendTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/TestCase/CreateCustomerFromBackendTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/TestCase/CreateCustomerFromBackendTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/TestCase/CreateCustomerFromBackendTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/TestCase/CreateCustomerFromBackendTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/TestCase/CreateCustomerFromBackendTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/TestCase/CreateCustomerGroupEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/TestCase/CreateCustomerGroupEntityTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/TestCase/CreateCustomerGroupEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/TestCase/CreateCustomerGroupEntityTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/TestCase/CreateCustomerGroupEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/TestCase/CreateCustomerGroupEntityTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/TestCase/CreateCustomerGroupEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/TestCase/CreateCustomerGroupEntityTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/TestCase/CreateCustomerGroupEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/TestCase/CreateCustomerGroupEntityTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/TestCase/CreateCustomerGroupEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/TestCase/CreateCustomerGroupEntityTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/TestCase/CreateExistingCustomerFrontendEntity.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/TestCase/CreateExistingCustomerFrontendEntity.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/TestCase/CreateExistingCustomerFrontendEntity.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/TestCase/CreateExistingCustomerFrontendEntity.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/TestCase/CreateExistingCustomerFrontendEntity.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/TestCase/CreateExistingCustomerFrontendEntity.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/TestCase/CreateExistingCustomerFrontendEntity.xml
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/TestCase/CreateExistingCustomerFrontendEntity.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/TestCase/CreateExistingCustomerFrontendEntity.xml
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/TestCase/CreateExistingCustomerFrontendEntity.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/TestCase/CreateExistingCustomerFrontendEntity.xml
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/TestCase/CreateExistingCustomerFrontendEntity.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/TestCase/DeleteCustomerAddressEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/TestCase/DeleteCustomerAddressEntityTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/TestCase/DeleteCustomerAddressEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/TestCase/DeleteCustomerAddressEntityTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/TestCase/DeleteCustomerAddressEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/TestCase/DeleteCustomerAddressEntityTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/TestCase/DeleteCustomerAddressEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/TestCase/DeleteCustomerAddressEntityTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/TestCase/DeleteCustomerAddressEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/TestCase/DeleteCustomerAddressEntityTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/TestCase/DeleteCustomerAddressEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/TestCase/DeleteCustomerAddressEntityTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/TestCase/RegisterCustomerFrontendEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/TestCase/RegisterCustomerFrontendEntityTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/TestCase/RegisterCustomerFrontendEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/TestCase/RegisterCustomerFrontendEntityTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/TestCase/RegisterCustomerFrontendEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/TestCase/RegisterCustomerFrontendEntityTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/TestCase/RegisterCustomerFrontendEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/TestCase/RegisterCustomerFrontendEntityTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/TestCase/RegisterCustomerFrontendEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/TestCase/RegisterCustomerFrontendEntityTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/TestCase/RegisterCustomerFrontendEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/TestCase/RegisterCustomerFrontendEntityTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/TestStep/CreateCustomerStep.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/TestStep/CreateCustomerStep.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/TestStep/CreateCustomerStep.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/TestStep/CreateCustomerStep.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/TestStep/CreateCustomerStep.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/TestStep/CreateCustomerStep.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/TestStep/CreateNewAddressesFixturesStep.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/TestStep/CreateNewAddressesFixturesStep.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/TestStep/CreateNewAddressesFixturesStep.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/TestStep/CreateNewAddressesFixturesStep.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/TestStep/CreateNewAddressesFixturesStep.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/TestStep/CreateNewAddressesFixturesStep.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/TestStep/CreateOrderFromCustomerAccountStep.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/TestStep/CreateOrderFromCustomerAccountStep.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/TestStep/CreateOrderFromCustomerAccountStep.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/TestStep/CreateOrderFromCustomerAccountStep.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/TestStep/CreateOrderFromCustomerAccountStep.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/TestStep/CreateOrderFromCustomerAccountStep.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/TestStep/LoginCustomerOnFrontendStep.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/TestStep/LoginCustomerOnFrontendStep.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/TestStep/LoginCustomerOnFrontendStep.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/TestStep/LoginCustomerOnFrontendStep.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/TestStep/LoginCustomerOnFrontendStep.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/TestStep/LoginCustomerOnFrontendStep.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/TestStep/LogoutCustomerStep.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/TestStep/LogoutCustomerStep.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/TestStep/LogoutCustomerStep.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/TestStep/LogoutCustomerStep.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/TestStep/LogoutCustomerStep.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/TestStep/LogoutCustomerStep.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/TestStep/OpenCustomerOnBackendStep.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/TestStep/OpenCustomerOnBackendStep.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/TestStep/OpenCustomerOnBackendStep.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/TestStep/OpenCustomerOnBackendStep.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/TestStep/OpenCustomerOnBackendStep.php
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/TestStep/OpenCustomerOnBackendStep.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/etc/curl/di.xml
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/etc/curl/di.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/etc/curl/di.xml
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/etc/curl/di.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/etc/curl/di.xml
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/etc/curl/di.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/etc/fixture.xml
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/etc/fixture.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/etc/fixture.xml
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/etc/fixture.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Customer/Test/etc/fixture.xml
+++ b/dev/tests/functional/tests/app/Mage/Customer/Test/etc/fixture.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Directory/Test/Block/Currency/Switcher.php
+++ b/dev/tests/functional/tests/app/Mage/Directory/Test/Block/Currency/Switcher.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Directory/Test/Block/Currency/Switcher.php
+++ b/dev/tests/functional/tests/app/Mage/Directory/Test/Block/Currency/Switcher.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Directory/Test/Block/Currency/Switcher.php
+++ b/dev/tests/functional/tests/app/Mage/Directory/Test/Block/Currency/Switcher.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable.php
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable.php
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable.php
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/LinkRow.php
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/LinkRow.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/LinkRow.php
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/LinkRow.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/LinkRow.php
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/LinkRow.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/LinkRow.xml
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/LinkRow.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/LinkRow.xml
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/LinkRow.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/LinkRow.xml
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/LinkRow.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/Links.php
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/Links.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/Links.php
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/Links.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/Links.php
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/Links.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/Links.xml
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/Links.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/Links.xml
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/Links.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/Links.xml
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/Links.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/SampleRow.php
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/SampleRow.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/SampleRow.php
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/SampleRow.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/SampleRow.php
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/SampleRow.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/SampleRow.xml
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/SampleRow.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/SampleRow.xml
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/SampleRow.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/SampleRow.xml
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/SampleRow.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/Samples.php
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/Samples.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/Samples.php
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/Samples.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/Samples.php
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/Samples.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/Samples.xml
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/Samples.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/Samples.xml
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/Samples.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/Samples.xml
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/Samples.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Adminhtml/Catalog/Product/ProductForm.xml
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Adminhtml/Catalog/Product/ProductForm.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Adminhtml/Catalog/Product/ProductForm.xml
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Adminhtml/Catalog/Product/ProductForm.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Adminhtml/Catalog/Product/ProductForm.xml
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Adminhtml/Catalog/Product/ProductForm.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Catalog/Product/View.php
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Catalog/Product/View.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Catalog/Product/View.php
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Catalog/Product/View.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Catalog/Product/View.php
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Catalog/Product/View.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Catalog/Product/View/Links.php
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Catalog/Product/View/Links.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Catalog/Product/View/Links.php
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Catalog/Product/View/Links.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Catalog/Product/View/Links.php
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Catalog/Product/View/Links.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Catalog/Product/View/Samples.php
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Catalog/Product/View/Samples.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Catalog/Product/View/Samples.php
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Catalog/Product/View/Samples.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Catalog/Product/View/Samples.php
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Catalog/Product/View/Samples.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Checkout/Onepage/Review.php
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Checkout/Onepage/Review.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Checkout/Onepage/Review.php
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Checkout/Onepage/Review.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Checkout/Onepage/Review.php
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Checkout/Onepage/Review.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Checkout/Onepage/Review/Items.php
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Checkout/Onepage/Review/Items.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Checkout/Onepage/Review/Items.php
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Checkout/Onepage/Review/Items.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Checkout/Onepage/Review/Items.php
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Checkout/Onepage/Review/Items.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Checkout/Onepage/Review/Items/Product.php
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Checkout/Onepage/Review/Items/Product.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Checkout/Onepage/Review/Items/Product.php
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Checkout/Onepage/Review/Items/Product.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Checkout/Onepage/Review/Items/Product.php
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Block/Checkout/Onepage/Review/Items/Product.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Constraint/AssertDownloadableLinksData.php
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Constraint/AssertDownloadableLinksData.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Constraint/AssertDownloadableLinksData.php
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Constraint/AssertDownloadableLinksData.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Constraint/AssertDownloadableLinksData.php
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Constraint/AssertDownloadableLinksData.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Constraint/AssertDownloadableProductDetailsInWishlist.php
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Constraint/AssertDownloadableProductDetailsInWishlist.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Constraint/AssertDownloadableProductDetailsInWishlist.php
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Constraint/AssertDownloadableProductDetailsInWishlist.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Constraint/AssertDownloadableProductDetailsInWishlist.php
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Constraint/AssertDownloadableProductDetailsInWishlist.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Constraint/AssertDownloadableProductForm.php
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Constraint/AssertDownloadableProductForm.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Constraint/AssertDownloadableProductForm.php
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Constraint/AssertDownloadableProductForm.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Constraint/AssertDownloadableProductForm.php
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Constraint/AssertDownloadableProductForm.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Constraint/AssertDownloadableSamplesData.php
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Constraint/AssertDownloadableSamplesData.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Constraint/AssertDownloadableSamplesData.php
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Constraint/AssertDownloadableSamplesData.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Constraint/AssertDownloadableSamplesData.php
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Constraint/AssertDownloadableSamplesData.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Constraint/AssertOrderTaxOnBackendDownloadableExcludingIncludingTax.php
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Constraint/AssertOrderTaxOnBackendDownloadableExcludingIncludingTax.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Constraint/AssertOrderTaxOnBackendDownloadableExcludingIncludingTax.php
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Constraint/AssertOrderTaxOnBackendDownloadableExcludingIncludingTax.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Constraint/AssertOrderTaxOnBackendDownloadableExcludingIncludingTax.php
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Constraint/AssertOrderTaxOnBackendDownloadableExcludingIncludingTax.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Constraint/AssertOrderTaxOnBackendDownloadableExcludingTax.php
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Constraint/AssertOrderTaxOnBackendDownloadableExcludingTax.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Constraint/AssertOrderTaxOnBackendDownloadableExcludingTax.php
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Constraint/AssertOrderTaxOnBackendDownloadableExcludingTax.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Constraint/AssertOrderTaxOnBackendDownloadableExcludingTax.php
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Constraint/AssertOrderTaxOnBackendDownloadableExcludingTax.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Constraint/AssertOrderTaxOnBackendDownloadableIncludingTax.php
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Constraint/AssertOrderTaxOnBackendDownloadableIncludingTax.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Constraint/AssertOrderTaxOnBackendDownloadableIncludingTax.php
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Constraint/AssertOrderTaxOnBackendDownloadableIncludingTax.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Constraint/AssertOrderTaxOnBackendDownloadableIncludingTax.php
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Constraint/AssertOrderTaxOnBackendDownloadableIncludingTax.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Constraint/AssertTaxCalculationAfterCheckoutDownloadableExcludingIncludingTax.php
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Constraint/AssertTaxCalculationAfterCheckoutDownloadableExcludingIncludingTax.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Constraint/AssertTaxCalculationAfterCheckoutDownloadableExcludingIncludingTax.php
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Constraint/AssertTaxCalculationAfterCheckoutDownloadableExcludingIncludingTax.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Constraint/AssertTaxCalculationAfterCheckoutDownloadableExcludingIncludingTax.php
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Constraint/AssertTaxCalculationAfterCheckoutDownloadableExcludingIncludingTax.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Constraint/AssertTaxCalculationAfterCheckoutDownloadableExcludingTax.php
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Constraint/AssertTaxCalculationAfterCheckoutDownloadableExcludingTax.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Constraint/AssertTaxCalculationAfterCheckoutDownloadableExcludingTax.php
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Constraint/AssertTaxCalculationAfterCheckoutDownloadableExcludingTax.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Constraint/AssertTaxCalculationAfterCheckoutDownloadableExcludingTax.php
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Constraint/AssertTaxCalculationAfterCheckoutDownloadableExcludingTax.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Constraint/AssertTaxCalculationAfterCheckoutDownloadableIncludingTax.php
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Constraint/AssertTaxCalculationAfterCheckoutDownloadableIncludingTax.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Constraint/AssertTaxCalculationAfterCheckoutDownloadableIncludingTax.php
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Constraint/AssertTaxCalculationAfterCheckoutDownloadableIncludingTax.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Constraint/AssertTaxCalculationAfterCheckoutDownloadableIncludingTax.php
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Constraint/AssertTaxCalculationAfterCheckoutDownloadableIncludingTax.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Constraint/AssertTaxRuleIsAppliedToAllPricesDownloadableExcludingIncludingTax.php
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Constraint/AssertTaxRuleIsAppliedToAllPricesDownloadableExcludingIncludingTax.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Constraint/AssertTaxRuleIsAppliedToAllPricesDownloadableExcludingIncludingTax.php
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Constraint/AssertTaxRuleIsAppliedToAllPricesDownloadableExcludingIncludingTax.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Constraint/AssertTaxRuleIsAppliedToAllPricesDownloadableExcludingIncludingTax.php
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Constraint/AssertTaxRuleIsAppliedToAllPricesDownloadableExcludingIncludingTax.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Constraint/AssertTaxRuleIsAppliedToAllPricesDownloadableExcludingTax.php
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Constraint/AssertTaxRuleIsAppliedToAllPricesDownloadableExcludingTax.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Constraint/AssertTaxRuleIsAppliedToAllPricesDownloadableExcludingTax.php
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Constraint/AssertTaxRuleIsAppliedToAllPricesDownloadableExcludingTax.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Constraint/AssertTaxRuleIsAppliedToAllPricesDownloadableExcludingTax.php
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Constraint/AssertTaxRuleIsAppliedToAllPricesDownloadableExcludingTax.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Constraint/AssertTaxRuleIsAppliedToAllPricesDownloadableIncludingTax.php
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Constraint/AssertTaxRuleIsAppliedToAllPricesDownloadableIncludingTax.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Constraint/AssertTaxRuleIsAppliedToAllPricesDownloadableIncludingTax.php
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Constraint/AssertTaxRuleIsAppliedToAllPricesDownloadableIncludingTax.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Constraint/AssertTaxRuleIsAppliedToAllPricesDownloadableIncludingTax.php
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Constraint/AssertTaxRuleIsAppliedToAllPricesDownloadableIncludingTax.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Fixture/Cart/Item.php
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Fixture/Cart/Item.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Fixture/Cart/Item.php
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Fixture/Cart/Item.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Fixture/Cart/Item.php
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Fixture/Cart/Item.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Fixture/DownloadableProduct.xml
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Fixture/DownloadableProduct.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Fixture/DownloadableProduct.xml
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Fixture/DownloadableProduct.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Fixture/DownloadableProduct.xml
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Fixture/DownloadableProduct.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Handler/Curl.php
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Handler/Curl.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Handler/Curl.php
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Handler/Curl.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Handler/Curl.php
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Handler/Curl.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Handler/DownloadableProductInterface.php
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Handler/DownloadableProductInterface.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Handler/DownloadableProductInterface.php
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Handler/DownloadableProductInterface.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Handler/DownloadableProductInterface.php
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Handler/DownloadableProductInterface.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Page/CheckoutOnepage.xml
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Page/CheckoutOnepage.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Page/CheckoutOnepage.xml
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Page/CheckoutOnepage.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Page/CheckoutOnepage.xml
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Page/CheckoutOnepage.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Page/Product/CatalogProductView.xml
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Page/Product/CatalogProductView.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Page/Product/CatalogProductView.xml
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Page/Product/CatalogProductView.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Page/Product/CatalogProductView.xml
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Page/Product/CatalogProductView.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Repository/DownloadableProduct.xml
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Repository/DownloadableProduct.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Repository/DownloadableProduct.xml
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Repository/DownloadableProduct.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Repository/DownloadableProduct.xml
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Repository/DownloadableProduct.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Repository/DownloadableProduct/CheckoutData.xml
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Repository/DownloadableProduct/CheckoutData.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Repository/DownloadableProduct/CheckoutData.xml
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Repository/DownloadableProduct/CheckoutData.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Repository/DownloadableProduct/CheckoutData.xml
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Repository/DownloadableProduct/CheckoutData.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Repository/DownloadableProduct/GroupPriceOptions.xml
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Repository/DownloadableProduct/GroupPriceOptions.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Repository/DownloadableProduct/GroupPriceOptions.xml
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Repository/DownloadableProduct/GroupPriceOptions.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Repository/DownloadableProduct/GroupPriceOptions.xml
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Repository/DownloadableProduct/GroupPriceOptions.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Repository/DownloadableProduct/Links.xml
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Repository/DownloadableProduct/Links.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Repository/DownloadableProduct/Links.xml
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Repository/DownloadableProduct/Links.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Repository/DownloadableProduct/Links.xml
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Repository/DownloadableProduct/Links.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Repository/DownloadableProduct/Price.xml
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Repository/DownloadableProduct/Price.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Repository/DownloadableProduct/Price.xml
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Repository/DownloadableProduct/Price.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Repository/DownloadableProduct/Price.xml
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Repository/DownloadableProduct/Price.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Repository/DownloadableProduct/Samples.xml
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Repository/DownloadableProduct/Samples.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Repository/DownloadableProduct/Samples.xml
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Repository/DownloadableProduct/Samples.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/Repository/DownloadableProduct/Samples.xml
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/Repository/DownloadableProduct/Samples.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/TestCase/AddProductToWishlistEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/TestCase/AddProductToWishlistEntityTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/TestCase/AddProductToWishlistEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/TestCase/AddProductToWishlistEntityTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/TestCase/AddProductToWishlistEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/TestCase/AddProductToWishlistEntityTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/TestCase/AddProductsToCartFromCustomerWishlistOnFrontendTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/TestCase/AddProductsToCartFromCustomerWishlistOnFrontendTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/TestCase/AddProductsToCartFromCustomerWishlistOnFrontendTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/TestCase/AddProductsToCartFromCustomerWishlistOnFrontendTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/TestCase/AddProductsToCartFromCustomerWishlistOnFrontendTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/TestCase/AddProductsToCartFromCustomerWishlistOnFrontendTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/TestCase/ConfigureProductInCustomerWishlistOnFrontendTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/TestCase/ConfigureProductInCustomerWishlistOnFrontendTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/TestCase/ConfigureProductInCustomerWishlistOnFrontendTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/TestCase/ConfigureProductInCustomerWishlistOnFrontendTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/TestCase/ConfigureProductInCustomerWishlistOnFrontendTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/TestCase/ConfigureProductInCustomerWishlistOnFrontendTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/TestCase/CreateDownloadableProductEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/TestCase/CreateDownloadableProductEntityTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/TestCase/CreateDownloadableProductEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/TestCase/CreateDownloadableProductEntityTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/TestCase/CreateDownloadableProductEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/TestCase/CreateDownloadableProductEntityTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/TestCase/CreateDownloadableProductEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/TestCase/CreateDownloadableProductEntityTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/TestCase/CreateDownloadableProductEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/TestCase/CreateDownloadableProductEntityTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/TestCase/CreateDownloadableProductEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/TestCase/CreateDownloadableProductEntityTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/TestCase/DeleteDownloadableProductEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/TestCase/DeleteDownloadableProductEntityTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/TestCase/DeleteDownloadableProductEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/TestCase/DeleteDownloadableProductEntityTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/TestCase/DeleteDownloadableProductEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/TestCase/DeleteDownloadableProductEntityTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/TestCase/MoveProductFromShoppingCartToWishlistTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/TestCase/MoveProductFromShoppingCartToWishlistTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/TestCase/MoveProductFromShoppingCartToWishlistTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/TestCase/MoveProductFromShoppingCartToWishlistTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/TestCase/MoveProductFromShoppingCartToWishlistTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/TestCase/MoveProductFromShoppingCartToWishlistTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/TestCase/TaxCalculationForDownloadableProductTest.php
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/TestCase/TaxCalculationForDownloadableProductTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/TestCase/TaxCalculationForDownloadableProductTest.php
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/TestCase/TaxCalculationForDownloadableProductTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/TestCase/TaxCalculationForDownloadableProductTest.php
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/TestCase/TaxCalculationForDownloadableProductTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/TestCase/TaxCalculationForDownloadableProductTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/TestCase/TaxCalculationForDownloadableProductTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/TestCase/TaxCalculationForDownloadableProductTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/TestCase/TaxCalculationForDownloadableProductTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/TestCase/TaxCalculationForDownloadableProductTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/TestCase/TaxCalculationForDownloadableProductTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/etc/curl/di.xml
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/etc/curl/di.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/etc/curl/di.xml
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/etc/curl/di.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/etc/curl/di.xml
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/etc/curl/di.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/etc/fixture.xml
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/etc/fixture.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/etc/fixture.xml
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/etc/fixture.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/etc/fixture.xml
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/etc/fixture.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/etc/testcase.xml
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/etc/testcase.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/etc/testcase.xml
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/etc/testcase.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Downloadable/Test/etc/testcase.xml
+++ b/dev/tests/functional/tests/app/Mage/Downloadable/Test/etc/testcase.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/GiftMessage/Test/Block/Message/Inline.php
+++ b/dev/tests/functional/tests/app/Mage/GiftMessage/Test/Block/Message/Inline.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/GiftMessage/Test/Block/Message/Inline.php
+++ b/dev/tests/functional/tests/app/Mage/GiftMessage/Test/Block/Message/Inline.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/GiftMessage/Test/Block/Message/Inline.php
+++ b/dev/tests/functional/tests/app/Mage/GiftMessage/Test/Block/Message/Inline.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/GiftMessage/Test/Block/Message/Inline.xml
+++ b/dev/tests/functional/tests/app/Mage/GiftMessage/Test/Block/Message/Inline.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/GiftMessage/Test/Block/Message/Inline.xml
+++ b/dev/tests/functional/tests/app/Mage/GiftMessage/Test/Block/Message/Inline.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/GiftMessage/Test/Block/Message/Inline.xml
+++ b/dev/tests/functional/tests/app/Mage/GiftMessage/Test/Block/Message/Inline.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/GiftMessage/Test/Block/Message/Inline/GiftMessageForm.php
+++ b/dev/tests/functional/tests/app/Mage/GiftMessage/Test/Block/Message/Inline/GiftMessageForm.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/GiftMessage/Test/Block/Message/Inline/GiftMessageForm.php
+++ b/dev/tests/functional/tests/app/Mage/GiftMessage/Test/Block/Message/Inline/GiftMessageForm.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/GiftMessage/Test/Block/Message/Inline/GiftMessageForm.php
+++ b/dev/tests/functional/tests/app/Mage/GiftMessage/Test/Block/Message/Inline/GiftMessageForm.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/GiftMessage/Test/Block/Message/Inline/GiftMessageForm.xml
+++ b/dev/tests/functional/tests/app/Mage/GiftMessage/Test/Block/Message/Inline/GiftMessageForm.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/GiftMessage/Test/Block/Message/Inline/GiftMessageForm.xml
+++ b/dev/tests/functional/tests/app/Mage/GiftMessage/Test/Block/Message/Inline/GiftMessageForm.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/GiftMessage/Test/Block/Message/Inline/GiftMessageForm.xml
+++ b/dev/tests/functional/tests/app/Mage/GiftMessage/Test/Block/Message/Inline/GiftMessageForm.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/GiftMessage/Test/Block/Message/Order/Items/View.php
+++ b/dev/tests/functional/tests/app/Mage/GiftMessage/Test/Block/Message/Order/Items/View.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/GiftMessage/Test/Block/Message/Order/Items/View.php
+++ b/dev/tests/functional/tests/app/Mage/GiftMessage/Test/Block/Message/Order/Items/View.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/GiftMessage/Test/Block/Message/Order/Items/View.php
+++ b/dev/tests/functional/tests/app/Mage/GiftMessage/Test/Block/Message/Order/Items/View.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/GiftMessage/Test/Block/Message/Order/View.php
+++ b/dev/tests/functional/tests/app/Mage/GiftMessage/Test/Block/Message/Order/View.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/GiftMessage/Test/Block/Message/Order/View.php
+++ b/dev/tests/functional/tests/app/Mage/GiftMessage/Test/Block/Message/Order/View.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/GiftMessage/Test/Block/Message/Order/View.php
+++ b/dev/tests/functional/tests/app/Mage/GiftMessage/Test/Block/Message/Order/View.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/GiftMessage/Test/Constraint/AbstractAssertGiftMessageOnFrontend.php
+++ b/dev/tests/functional/tests/app/Mage/GiftMessage/Test/Constraint/AbstractAssertGiftMessageOnFrontend.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/GiftMessage/Test/Constraint/AbstractAssertGiftMessageOnFrontend.php
+++ b/dev/tests/functional/tests/app/Mage/GiftMessage/Test/Constraint/AbstractAssertGiftMessageOnFrontend.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/GiftMessage/Test/Constraint/AbstractAssertGiftMessageOnFrontend.php
+++ b/dev/tests/functional/tests/app/Mage/GiftMessage/Test/Constraint/AbstractAssertGiftMessageOnFrontend.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/GiftMessage/Test/Constraint/AssertGiftMessageInFrontendOrder.php
+++ b/dev/tests/functional/tests/app/Mage/GiftMessage/Test/Constraint/AssertGiftMessageInFrontendOrder.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/GiftMessage/Test/Constraint/AssertGiftMessageInFrontendOrder.php
+++ b/dev/tests/functional/tests/app/Mage/GiftMessage/Test/Constraint/AssertGiftMessageInFrontendOrder.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/GiftMessage/Test/Constraint/AssertGiftMessageInFrontendOrder.php
+++ b/dev/tests/functional/tests/app/Mage/GiftMessage/Test/Constraint/AssertGiftMessageInFrontendOrder.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/GiftMessage/Test/Constraint/AssertGiftMessageInFrontendOrderItems.php
+++ b/dev/tests/functional/tests/app/Mage/GiftMessage/Test/Constraint/AssertGiftMessageInFrontendOrderItems.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/GiftMessage/Test/Constraint/AssertGiftMessageInFrontendOrderItems.php
+++ b/dev/tests/functional/tests/app/Mage/GiftMessage/Test/Constraint/AssertGiftMessageInFrontendOrderItems.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/GiftMessage/Test/Constraint/AssertGiftMessageInFrontendOrderItems.php
+++ b/dev/tests/functional/tests/app/Mage/GiftMessage/Test/Constraint/AssertGiftMessageInFrontendOrderItems.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/GiftMessage/Test/Fixture/GiftMessage.xml
+++ b/dev/tests/functional/tests/app/Mage/GiftMessage/Test/Fixture/GiftMessage.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/GiftMessage/Test/Fixture/GiftMessage.xml
+++ b/dev/tests/functional/tests/app/Mage/GiftMessage/Test/Fixture/GiftMessage.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/GiftMessage/Test/Fixture/GiftMessage.xml
+++ b/dev/tests/functional/tests/app/Mage/GiftMessage/Test/Fixture/GiftMessage.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/GiftMessage/Test/Fixture/GiftMessage/Items.php
+++ b/dev/tests/functional/tests/app/Mage/GiftMessage/Test/Fixture/GiftMessage/Items.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/GiftMessage/Test/Fixture/GiftMessage/Items.php
+++ b/dev/tests/functional/tests/app/Mage/GiftMessage/Test/Fixture/GiftMessage/Items.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/GiftMessage/Test/Fixture/GiftMessage/Items.php
+++ b/dev/tests/functional/tests/app/Mage/GiftMessage/Test/Fixture/GiftMessage/Items.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/GiftMessage/Test/Page/CheckoutOnepage.xml
+++ b/dev/tests/functional/tests/app/Mage/GiftMessage/Test/Page/CheckoutOnepage.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/GiftMessage/Test/Page/CheckoutOnepage.xml
+++ b/dev/tests/functional/tests/app/Mage/GiftMessage/Test/Page/CheckoutOnepage.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/GiftMessage/Test/Page/CheckoutOnepage.xml
+++ b/dev/tests/functional/tests/app/Mage/GiftMessage/Test/Page/CheckoutOnepage.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/GiftMessage/Test/Page/OrderView.xml
+++ b/dev/tests/functional/tests/app/Mage/GiftMessage/Test/Page/OrderView.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/GiftMessage/Test/Page/OrderView.xml
+++ b/dev/tests/functional/tests/app/Mage/GiftMessage/Test/Page/OrderView.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/GiftMessage/Test/Page/OrderView.xml
+++ b/dev/tests/functional/tests/app/Mage/GiftMessage/Test/Page/OrderView.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/GiftMessage/Test/Repository/GiftMessage.xml
+++ b/dev/tests/functional/tests/app/Mage/GiftMessage/Test/Repository/GiftMessage.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/GiftMessage/Test/Repository/GiftMessage.xml
+++ b/dev/tests/functional/tests/app/Mage/GiftMessage/Test/Repository/GiftMessage.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/GiftMessage/Test/Repository/GiftMessage.xml
+++ b/dev/tests/functional/tests/app/Mage/GiftMessage/Test/Repository/GiftMessage.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/GiftMessage/Test/TestCase/CheckoutWithGiftMessagesTest.php
+++ b/dev/tests/functional/tests/app/Mage/GiftMessage/Test/TestCase/CheckoutWithGiftMessagesTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/GiftMessage/Test/TestCase/CheckoutWithGiftMessagesTest.php
+++ b/dev/tests/functional/tests/app/Mage/GiftMessage/Test/TestCase/CheckoutWithGiftMessagesTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/GiftMessage/Test/TestCase/CheckoutWithGiftMessagesTest.php
+++ b/dev/tests/functional/tests/app/Mage/GiftMessage/Test/TestCase/CheckoutWithGiftMessagesTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/GiftMessage/Test/TestCase/CheckoutWithGiftMessagesTest.xml
+++ b/dev/tests/functional/tests/app/Mage/GiftMessage/Test/TestCase/CheckoutWithGiftMessagesTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/GiftMessage/Test/TestCase/CheckoutWithGiftMessagesTest.xml
+++ b/dev/tests/functional/tests/app/Mage/GiftMessage/Test/TestCase/CheckoutWithGiftMessagesTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/GiftMessage/Test/TestCase/CheckoutWithGiftMessagesTest.xml
+++ b/dev/tests/functional/tests/app/Mage/GiftMessage/Test/TestCase/CheckoutWithGiftMessagesTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/GiftMessage/Test/TestStep/AddGiftMessageStep.php
+++ b/dev/tests/functional/tests/app/Mage/GiftMessage/Test/TestStep/AddGiftMessageStep.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/GiftMessage/Test/TestStep/AddGiftMessageStep.php
+++ b/dev/tests/functional/tests/app/Mage/GiftMessage/Test/TestStep/AddGiftMessageStep.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/GiftMessage/Test/TestStep/AddGiftMessageStep.php
+++ b/dev/tests/functional/tests/app/Mage/GiftMessage/Test/TestStep/AddGiftMessageStep.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/GiftMessage/Test/etc/fixture.xml
+++ b/dev/tests/functional/tests/app/Mage/GiftMessage/Test/etc/fixture.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/GiftMessage/Test/etc/fixture.xml
+++ b/dev/tests/functional/tests/app/Mage/GiftMessage/Test/etc/fixture.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/GiftMessage/Test/etc/fixture.xml
+++ b/dev/tests/functional/tests/app/Mage/GiftMessage/Test/etc/fixture.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/GiftMessage/Test/etc/testcase.xml
+++ b/dev/tests/functional/tests/app/Mage/GiftMessage/Test/etc/testcase.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/GiftMessage/Test/etc/testcase.xml
+++ b/dev/tests/functional/tests/app/Mage/GiftMessage/Test/etc/testcase.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/GiftMessage/Test/etc/testcase.xml
+++ b/dev/tests/functional/tests/app/Mage/GiftMessage/Test/etc/testcase.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Install/Test/Block/Configuration.php
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/Block/Configuration.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Install/Test/Block/Configuration.php
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/Block/Configuration.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Install/Test/Block/Configuration.php
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/Block/Configuration.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Install/Test/Block/Configuration.xml
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/Block/Configuration.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Install/Test/Block/Configuration.xml
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/Block/Configuration.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Install/Test/Block/Configuration.xml
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/Block/Configuration.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Install/Test/Block/ContinueBlock.php
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/Block/ContinueBlock.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Install/Test/Block/ContinueBlock.php
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/Block/ContinueBlock.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Install/Test/Block/ContinueBlock.php
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/Block/ContinueBlock.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Install/Test/Block/License.php
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/Block/License.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Install/Test/Block/License.php
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/Block/License.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Install/Test/Block/License.php
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/Block/License.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Install/Test/Block/Localization.php
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/Block/Localization.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Install/Test/Block/Localization.php
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/Block/Localization.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Install/Test/Block/Localization.php
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/Block/Localization.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Install/Test/Block/Localization.xml
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/Block/Localization.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Install/Test/Block/Localization.xml
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/Block/Localization.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Install/Test/Block/Localization.xml
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/Block/Localization.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Install/Test/Block/Main.php
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/Block/Main.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Install/Test/Block/Main.php
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/Block/Main.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Install/Test/Block/Main.php
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/Block/Main.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Install/Test/Block/PersonalInformation.php
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/Block/PersonalInformation.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Install/Test/Block/PersonalInformation.php
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/Block/PersonalInformation.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Install/Test/Block/PersonalInformation.php
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/Block/PersonalInformation.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Install/Test/Block/PersonalInformation.xml
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/Block/PersonalInformation.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Install/Test/Block/PersonalInformation.xml
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/Block/PersonalInformation.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Install/Test/Block/PersonalInformation.xml
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/Block/PersonalInformation.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Install/Test/Block/Welcome.php
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/Block/Welcome.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Install/Test/Block/Welcome.php
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/Block/Welcome.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Install/Test/Block/Welcome.php
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/Block/Welcome.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Install/Test/Constraint/AssertAgreementTextPresent.php
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/Constraint/AssertAgreementTextPresent.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Install/Test/Constraint/AssertAgreementTextPresent.php
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/Constraint/AssertAgreementTextPresent.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Install/Test/Constraint/AssertAgreementTextPresent.php
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/Constraint/AssertAgreementTextPresent.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Install/Test/Constraint/AssertCurrencySelected.php
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/Constraint/AssertCurrencySelected.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Install/Test/Constraint/AssertCurrencySelected.php
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/Constraint/AssertCurrencySelected.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Install/Test/Constraint/AssertCurrencySelected.php
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/Constraint/AssertCurrencySelected.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Install/Test/Constraint/AssertLanguageSelected.php
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/Constraint/AssertLanguageSelected.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Install/Test/Constraint/AssertLanguageSelected.php
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/Constraint/AssertLanguageSelected.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Install/Test/Constraint/AssertLanguageSelected.php
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/Constraint/AssertLanguageSelected.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Install/Test/Constraint/AssertRewritesEnabled.php
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/Constraint/AssertRewritesEnabled.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Install/Test/Constraint/AssertRewritesEnabled.php
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/Constraint/AssertRewritesEnabled.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Install/Test/Constraint/AssertRewritesEnabled.php
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/Constraint/AssertRewritesEnabled.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Install/Test/Constraint/AssertSecureUrlEnabled.php
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/Constraint/AssertSecureUrlEnabled.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Install/Test/Constraint/AssertSecureUrlEnabled.php
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/Constraint/AssertSecureUrlEnabled.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Install/Test/Constraint/AssertSecureUrlEnabled.php
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/Constraint/AssertSecureUrlEnabled.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Install/Test/Constraint/AssertSuccessInstall.php
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/Constraint/AssertSuccessInstall.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Install/Test/Constraint/AssertSuccessInstall.php
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/Constraint/AssertSuccessInstall.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Install/Test/Constraint/AssertSuccessInstall.php
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/Constraint/AssertSuccessInstall.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Install/Test/Fixture/Install.xml
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/Fixture/Install.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Install/Test/Fixture/Install.xml
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/Fixture/Install.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Install/Test/Fixture/Install.xml
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/Fixture/Install.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Install/Test/Fixture/InstallLocale.xml
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/Fixture/InstallLocale.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Install/Test/Fixture/InstallLocale.xml
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/Fixture/InstallLocale.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Install/Test/Fixture/InstallLocale.xml
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/Fixture/InstallLocale.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Install/Test/Page/Install.xml
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/Page/Install.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Install/Test/Page/Install.xml
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/Page/Install.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Install/Test/Page/Install.xml
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/Page/Install.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Install/Test/Page/InstallWizardAdministrator.xml
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/Page/InstallWizardAdministrator.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Install/Test/Page/InstallWizardAdministrator.xml
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/Page/InstallWizardAdministrator.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Install/Test/Page/InstallWizardAdministrator.xml
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/Page/InstallWizardAdministrator.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Install/Test/Page/InstallWizardConfig.xml
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/Page/InstallWizardConfig.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Install/Test/Page/InstallWizardConfig.xml
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/Page/InstallWizardConfig.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Install/Test/Page/InstallWizardConfig.xml
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/Page/InstallWizardConfig.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Install/Test/Page/InstallWizardEnd.xml
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/Page/InstallWizardEnd.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Install/Test/Page/InstallWizardEnd.xml
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/Page/InstallWizardEnd.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Install/Test/Page/InstallWizardEnd.xml
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/Page/InstallWizardEnd.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Install/Test/Page/InstallWizardLocale.xml
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/Page/InstallWizardLocale.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Install/Test/Page/InstallWizardLocale.xml
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/Page/InstallWizardLocale.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Install/Test/Page/InstallWizardLocale.xml
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/Page/InstallWizardLocale.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Install/Test/TestCase/InstallTest.php
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/TestCase/InstallTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Install/Test/TestCase/InstallTest.php
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/TestCase/InstallTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Install/Test/TestCase/InstallTest.php
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/TestCase/InstallTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Install/Test/TestCase/InstallTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/TestCase/InstallTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Install/Test/TestCase/InstallTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/TestCase/InstallTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Install/Test/TestCase/InstallTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/TestCase/InstallTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Install/Test/TestCase/InstallTest2.php
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/TestCase/InstallTest2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Install/Test/TestCase/InstallTest2.php
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/TestCase/InstallTest2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Install/Test/TestCase/InstallTest2.php
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/TestCase/InstallTest2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Install/Test/TestCase/InstallTest2.xml
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/TestCase/InstallTest2.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Install/Test/TestCase/InstallTest2.xml
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/TestCase/InstallTest2.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Install/Test/TestCase/InstallTest2.xml
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/TestCase/InstallTest2.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Install/Test/TestCase/InstallTest3.php
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/TestCase/InstallTest3.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Install/Test/TestCase/InstallTest3.php
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/TestCase/InstallTest3.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Install/Test/TestCase/InstallTest3.php
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/TestCase/InstallTest3.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Install/Test/TestCase/InstallTest3.xml
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/TestCase/InstallTest3.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Install/Test/TestCase/InstallTest3.xml
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/TestCase/InstallTest3.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Install/Test/TestCase/InstallTest3.xml
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/TestCase/InstallTest3.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Install/Test/TestCase/InstallTest4.php
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/TestCase/InstallTest4.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Install/Test/TestCase/InstallTest4.php
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/TestCase/InstallTest4.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Install/Test/TestCase/InstallTest4.php
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/TestCase/InstallTest4.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Install/Test/TestCase/InstallTest4.xml
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/TestCase/InstallTest4.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Install/Test/TestCase/InstallTest4.xml
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/TestCase/InstallTest4.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Install/Test/TestCase/InstallTest4.xml
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/TestCase/InstallTest4.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Install/Test/TestCase/InstallTest5.php
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/TestCase/InstallTest5.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Install/Test/TestCase/InstallTest5.php
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/TestCase/InstallTest5.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Install/Test/TestCase/InstallTest5.php
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/TestCase/InstallTest5.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Install/Test/TestCase/InstallTest5.xml
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/TestCase/InstallTest5.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Install/Test/TestCase/InstallTest5.xml
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/TestCase/InstallTest5.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Install/Test/TestCase/InstallTest5.xml
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/TestCase/InstallTest5.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Install/Test/TestCase/InstallTest6.php
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/TestCase/InstallTest6.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Install/Test/TestCase/InstallTest6.php
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/TestCase/InstallTest6.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Install/Test/TestCase/InstallTest6.php
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/TestCase/InstallTest6.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Install/Test/TestCase/InstallTest6.xml
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/TestCase/InstallTest6.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Install/Test/TestCase/InstallTest6.xml
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/TestCase/InstallTest6.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Install/Test/TestCase/InstallTest6.xml
+++ b/dev/tests/functional/tests/app/Mage/Install/Test/TestCase/InstallTest6.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Newsletter/Test/Constraint/AssertCustomerIsSubscribedToNewsletter.php
+++ b/dev/tests/functional/tests/app/Mage/Newsletter/Test/Constraint/AssertCustomerIsSubscribedToNewsletter.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Newsletter/Test/Constraint/AssertCustomerIsSubscribedToNewsletter.php
+++ b/dev/tests/functional/tests/app/Mage/Newsletter/Test/Constraint/AssertCustomerIsSubscribedToNewsletter.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Newsletter/Test/Constraint/AssertCustomerIsSubscribedToNewsletter.php
+++ b/dev/tests/functional/tests/app/Mage/Newsletter/Test/Constraint/AssertCustomerIsSubscribedToNewsletter.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Newsletter/Test/Page/Adminhtml/SubscriberIndex.xml
+++ b/dev/tests/functional/tests/app/Mage/Newsletter/Test/Page/Adminhtml/SubscriberIndex.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Newsletter/Test/Page/Adminhtml/SubscriberIndex.xml
+++ b/dev/tests/functional/tests/app/Mage/Newsletter/Test/Page/Adminhtml/SubscriberIndex.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Newsletter/Test/Page/Adminhtml/SubscriberIndex.xml
+++ b/dev/tests/functional/tests/app/Mage/Newsletter/Test/Page/Adminhtml/SubscriberIndex.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Page/Test/Block/Html/Footer.php
+++ b/dev/tests/functional/tests/app/Mage/Page/Test/Block/Html/Footer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Page/Test/Block/Html/Footer.php
+++ b/dev/tests/functional/tests/app/Mage/Page/Test/Block/Html/Footer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Page/Test/Block/Html/Footer.php
+++ b/dev/tests/functional/tests/app/Mage/Page/Test/Block/Html/Footer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Page/Test/Block/Html/Header.php
+++ b/dev/tests/functional/tests/app/Mage/Page/Test/Block/Html/Header.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Page/Test/Block/Html/Header.php
+++ b/dev/tests/functional/tests/app/Mage/Page/Test/Block/Html/Header.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Page/Test/Block/Html/Header.php
+++ b/dev/tests/functional/tests/app/Mage/Page/Test/Block/Html/Header.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Page/Test/Block/Html/Title.php
+++ b/dev/tests/functional/tests/app/Mage/Page/Test/Block/Html/Title.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Page/Test/Block/Html/Title.php
+++ b/dev/tests/functional/tests/app/Mage/Page/Test/Block/Html/Title.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Page/Test/Block/Html/Title.php
+++ b/dev/tests/functional/tests/app/Mage/Page/Test/Block/Html/Title.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Page/Test/Block/Html/Topmenu.php
+++ b/dev/tests/functional/tests/app/Mage/Page/Test/Block/Html/Topmenu.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Page/Test/Block/Html/Topmenu.php
+++ b/dev/tests/functional/tests/app/Mage/Page/Test/Block/Html/Topmenu.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Page/Test/Block/Html/Topmenu.php
+++ b/dev/tests/functional/tests/app/Mage/Page/Test/Block/Html/Topmenu.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Payment/Test/Block/Form/Cc.php
+++ b/dev/tests/functional/tests/app/Mage/Payment/Test/Block/Form/Cc.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Payment/Test/Block/Form/Cc.php
+++ b/dev/tests/functional/tests/app/Mage/Payment/Test/Block/Form/Cc.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Payment/Test/Block/Form/Cc.php
+++ b/dev/tests/functional/tests/app/Mage/Payment/Test/Block/Form/Cc.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Payment/Test/Block/Form/Cc.xml
+++ b/dev/tests/functional/tests/app/Mage/Payment/Test/Block/Form/Cc.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Payment/Test/Block/Form/Cc.xml
+++ b/dev/tests/functional/tests/app/Mage/Payment/Test/Block/Form/Cc.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Payment/Test/Block/Form/Cc.xml
+++ b/dev/tests/functional/tests/app/Mage/Payment/Test/Block/Form/Cc.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Payment/Test/Constraint/Assert3DSecureVerificationFailed.php
+++ b/dev/tests/functional/tests/app/Mage/Payment/Test/Constraint/Assert3DSecureVerificationFailed.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Payment/Test/Constraint/Assert3DSecureVerificationFailed.php
+++ b/dev/tests/functional/tests/app/Mage/Payment/Test/Constraint/Assert3DSecureVerificationFailed.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Payment/Test/Constraint/Assert3DSecureVerificationFailed.php
+++ b/dev/tests/functional/tests/app/Mage/Payment/Test/Constraint/Assert3DSecureVerificationFailed.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Payment/Test/Fixture/Cc.xml
+++ b/dev/tests/functional/tests/app/Mage/Payment/Test/Fixture/Cc.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Payment/Test/Fixture/Cc.xml
+++ b/dev/tests/functional/tests/app/Mage/Payment/Test/Fixture/Cc.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Payment/Test/Fixture/Cc.xml
+++ b/dev/tests/functional/tests/app/Mage/Payment/Test/Fixture/Cc.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Payment/Test/Fixture/ValidationPassword.xml
+++ b/dev/tests/functional/tests/app/Mage/Payment/Test/Fixture/ValidationPassword.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Payment/Test/Fixture/ValidationPassword.xml
+++ b/dev/tests/functional/tests/app/Mage/Payment/Test/Fixture/ValidationPassword.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Payment/Test/Fixture/ValidationPassword.xml
+++ b/dev/tests/functional/tests/app/Mage/Payment/Test/Fixture/ValidationPassword.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Payment/Test/Repository/Cc.xml
+++ b/dev/tests/functional/tests/app/Mage/Payment/Test/Repository/Cc.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Payment/Test/Repository/Cc.xml
+++ b/dev/tests/functional/tests/app/Mage/Payment/Test/Repository/Cc.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Payment/Test/Repository/Cc.xml
+++ b/dev/tests/functional/tests/app/Mage/Payment/Test/Repository/Cc.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Payment/Test/Repository/ConfigData.xml
+++ b/dev/tests/functional/tests/app/Mage/Payment/Test/Repository/ConfigData.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Payment/Test/Repository/ConfigData.xml
+++ b/dev/tests/functional/tests/app/Mage/Payment/Test/Repository/ConfigData.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Payment/Test/Repository/ConfigData.xml
+++ b/dev/tests/functional/tests/app/Mage/Payment/Test/Repository/ConfigData.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Payment/Test/Repository/ValidationPassword.xml
+++ b/dev/tests/functional/tests/app/Mage/Payment/Test/Repository/ValidationPassword.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Payment/Test/Repository/ValidationPassword.xml
+++ b/dev/tests/functional/tests/app/Mage/Payment/Test/Repository/ValidationPassword.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Payment/Test/Repository/ValidationPassword.xml
+++ b/dev/tests/functional/tests/app/Mage/Payment/Test/Repository/ValidationPassword.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Payment/Test/TestStep/Fill3DSecureCreditCardValidationStep.php
+++ b/dev/tests/functional/tests/app/Mage/Payment/Test/TestStep/Fill3DSecureCreditCardValidationStep.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Payment/Test/TestStep/Fill3DSecureCreditCardValidationStep.php
+++ b/dev/tests/functional/tests/app/Mage/Payment/Test/TestStep/Fill3DSecureCreditCardValidationStep.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Payment/Test/TestStep/Fill3DSecureCreditCardValidationStep.php
+++ b/dev/tests/functional/tests/app/Mage/Payment/Test/TestStep/Fill3DSecureCreditCardValidationStep.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/AbstractReview.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/AbstractReview.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/AbstractReview.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/AbstractReview.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/AbstractReview.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/AbstractReview.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/Addresses.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/Addresses.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/Addresses.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/Addresses.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/Addresses.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/Addresses.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/Express/Review.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/Express/Review.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/Express/Review.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/Express/Review.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/Express/Review.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/Express/Review.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/Express/Shortcut.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/Express/Shortcut.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/Express/Shortcut.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/Express/Shortcut.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/Express/Shortcut.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/Express/Shortcut.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/Form/Centinel.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/Form/Centinel.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/Form/Centinel.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/Form/Centinel.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/Form/Centinel.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/Form/Centinel.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/Form/Centinel.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/Form/Centinel.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/Form/Centinel.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/Form/Centinel.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/Form/Centinel.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/Form/Centinel.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/Hosted/Pro/Form.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/Hosted/Pro/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/Hosted/Pro/Form.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/Hosted/Pro/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/Hosted/Pro/Form.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/Hosted/Pro/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/Hosted/Pro/Form.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/Hosted/Pro/Form.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/Hosted/Pro/Form.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/Hosted/Pro/Form.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/Hosted/Pro/Form.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/Hosted/Pro/Form.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/Login.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/Login.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/Login.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/Login.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/Login.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/Login.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/Login.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/Login.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/Login.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/Login.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/Login.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/Login.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/NewLogin.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/NewLogin.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/NewLogin.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/NewLogin.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/NewLogin.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/NewLogin.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/NewLogin.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/NewLogin.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/NewLogin.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/NewLogin.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/NewLogin.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/NewLogin.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/NewLoginPassword.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/NewLoginPassword.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/NewLoginPassword.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/NewLoginPassword.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/NewLoginPassword.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/NewLoginPassword.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/OldAddresses.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/OldAddresses.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/OldAddresses.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/OldAddresses.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/OldAddresses.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/OldAddresses.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/OldLogin.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/OldLogin.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/OldLogin.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/OldLogin.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/OldLogin.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/OldLogin.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/OldLogin.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/OldLogin.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/OldLogin.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/OldLogin.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/OldLogin.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/OldLogin.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/OldReview.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/OldReview.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/OldReview.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/OldReview.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/OldReview.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/OldReview.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/Payflow/Advanced/Form.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/Payflow/Advanced/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/Payflow/Advanced/Form.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/Payflow/Advanced/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/Payflow/Advanced/Form.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/Payflow/Advanced/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/Payflow/Advanced/Form.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/Payflow/Advanced/Form.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/Payflow/Advanced/Form.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/Payflow/Advanced/Form.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/Payflow/Advanced/Form.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/Payflow/Advanced/Form.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/Payflow/Link/Form.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/Payflow/Link/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/Payflow/Link/Form.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/Payflow/Link/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/Payflow/Link/Form.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/Payflow/Link/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/Payflow/Link/Form.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/Payflow/Link/Form.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/Payflow/Link/Form.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/Payflow/Link/Form.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/Payflow/Link/Form.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/Payflow/Link/Form.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/Product/View.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/Product/View.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/Product/View.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/Product/View.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/Product/View.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/Product/View.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/Review.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/Review.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/Review.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/Review.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/Review.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Block/Review.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Constraint/AssertTransaction.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Constraint/AssertTransaction.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Constraint/AssertTransaction.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Constraint/AssertTransaction.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Constraint/AssertTransaction.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Constraint/AssertTransaction.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Fixture/PaypalAddress.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Fixture/PaypalAddress.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Fixture/PaypalAddress.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Fixture/PaypalAddress.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Fixture/PaypalAddress.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Fixture/PaypalAddress.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Fixture/PaypalCustomer.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Fixture/PaypalCustomer.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Fixture/PaypalCustomer.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Fixture/PaypalCustomer.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Fixture/PaypalCustomer.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Fixture/PaypalCustomer.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Fixture/PaypalCustomer/Address.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Fixture/PaypalCustomer/Address.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Fixture/PaypalCustomer/Address.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Fixture/PaypalCustomer/Address.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Fixture/PaypalCustomer/Address.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Fixture/PaypalCustomer/Address.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Page/Paypal.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Page/Paypal.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Page/Paypal.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Page/Paypal.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Page/Paypal.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Page/Paypal.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Page/PaypalExpressReview.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Page/PaypalExpressReview.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Page/PaypalExpressReview.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Page/PaypalExpressReview.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Page/PaypalExpressReview.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Page/PaypalExpressReview.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Page/Product/CatalogProductView.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Page/Product/CatalogProductView.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Page/Product/CatalogProductView.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Page/Product/CatalogProductView.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Page/Product/CatalogProductView.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Page/Product/CatalogProductView.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Repository/ConfigData.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Repository/ConfigData.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Repository/ConfigData.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Repository/ConfigData.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Repository/ConfigData.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Repository/ConfigData.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Repository/PaypalAddress.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Repository/PaypalAddress.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Repository/PaypalAddress.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Repository/PaypalAddress.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Repository/PaypalAddress.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Repository/PaypalAddress.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Repository/PaypalCustomer.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Repository/PaypalCustomer.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Repository/PaypalCustomer.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Repository/PaypalCustomer.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/Repository/PaypalCustomer.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/Repository/PaypalCustomer.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/AbstractCreateSalesEntityForOnlinePaymentMethodsTest.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/AbstractCreateSalesEntityForOnlinePaymentMethodsTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/AbstractCreateSalesEntityForOnlinePaymentMethodsTest.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/AbstractCreateSalesEntityForOnlinePaymentMethodsTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/AbstractCreateSalesEntityForOnlinePaymentMethodsTest.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/AbstractCreateSalesEntityForOnlinePaymentMethodsTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/AbstractCreateSalesEntityForPaypalExpressCheckoutTest.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/AbstractCreateSalesEntityForPaypalExpressCheckoutTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/AbstractCreateSalesEntityForPaypalExpressCheckoutTest.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/AbstractCreateSalesEntityForPaypalExpressCheckoutTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/AbstractCreateSalesEntityForPaypalExpressCheckoutTest.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/AbstractCreateSalesEntityForPaypalExpressCheckoutTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateInvoiceForPaypalExpressCheckoutTest.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateInvoiceForPaypalExpressCheckoutTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateInvoiceForPaypalExpressCheckoutTest.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateInvoiceForPaypalExpressCheckoutTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateInvoiceForPaypalExpressCheckoutTest.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateInvoiceForPaypalExpressCheckoutTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateInvoiceForPaypalExpressCheckoutTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateInvoiceForPaypalExpressCheckoutTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateInvoiceForPaypalExpressCheckoutTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateInvoiceForPaypalExpressCheckoutTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateInvoiceForPaypalExpressCheckoutTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateInvoiceForPaypalExpressCheckoutTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOfflineInvoiceForOnlinePaymentsMethodsWithIFrameTest.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOfflineInvoiceForOnlinePaymentsMethodsWithIFrameTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOfflineInvoiceForOnlinePaymentsMethodsWithIFrameTest.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOfflineInvoiceForOnlinePaymentsMethodsWithIFrameTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOfflineInvoiceForOnlinePaymentsMethodsWithIFrameTest.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOfflineInvoiceForOnlinePaymentsMethodsWithIFrameTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOfflineInvoiceForOnlinePaymentsMethodsWithIFrameTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOfflineInvoiceForOnlinePaymentsMethodsWithIFrameTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOfflineInvoiceForOnlinePaymentsMethodsWithIFrameTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOfflineInvoiceForOnlinePaymentsMethodsWithIFrameTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOfflineInvoiceForOnlinePaymentsMethodsWithIFrameTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOfflineInvoiceForOnlinePaymentsMethodsWithIFrameTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOfflineInvoiceForOnlinePaymentsMethodsWithoutIFrameTest.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOfflineInvoiceForOnlinePaymentsMethodsWithoutIFrameTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOfflineInvoiceForOnlinePaymentsMethodsWithoutIFrameTest.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOfflineInvoiceForOnlinePaymentsMethodsWithoutIFrameTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOfflineInvoiceForOnlinePaymentsMethodsWithoutIFrameTest.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOfflineInvoiceForOnlinePaymentsMethodsWithoutIFrameTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOfflineInvoiceForOnlinePaymentsMethodsWithoutIFrameTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOfflineInvoiceForOnlinePaymentsMethodsWithoutIFrameTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOfflineInvoiceForOnlinePaymentsMethodsWithoutIFrameTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOfflineInvoiceForOnlinePaymentsMethodsWithoutIFrameTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOfflineInvoiceForOnlinePaymentsMethodsWithoutIFrameTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOfflineInvoiceForOnlinePaymentsMethodsWithoutIFrameTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOnlineInvoiceForOnlinePaymentsMethodsWithIFrameTest.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOnlineInvoiceForOnlinePaymentsMethodsWithIFrameTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOnlineInvoiceForOnlinePaymentsMethodsWithIFrameTest.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOnlineInvoiceForOnlinePaymentsMethodsWithIFrameTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOnlineInvoiceForOnlinePaymentsMethodsWithIFrameTest.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOnlineInvoiceForOnlinePaymentsMethodsWithIFrameTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOnlineInvoiceForOnlinePaymentsMethodsWithIFrameTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOnlineInvoiceForOnlinePaymentsMethodsWithIFrameTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOnlineInvoiceForOnlinePaymentsMethodsWithIFrameTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOnlineInvoiceForOnlinePaymentsMethodsWithIFrameTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOnlineInvoiceForOnlinePaymentsMethodsWithIFrameTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOnlineInvoiceForOnlinePaymentsMethodsWithIFrameTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOnlineInvoiceForOnlinePaymentsMethodsWithoutIFrameTest.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOnlineInvoiceForOnlinePaymentsMethodsWithoutIFrameTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOnlineInvoiceForOnlinePaymentsMethodsWithoutIFrameTest.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOnlineInvoiceForOnlinePaymentsMethodsWithoutIFrameTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOnlineInvoiceForOnlinePaymentsMethodsWithoutIFrameTest.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOnlineInvoiceForOnlinePaymentsMethodsWithoutIFrameTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOnlineInvoiceForOnlinePaymentsMethodsWithoutIFrameTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOnlineInvoiceForOnlinePaymentsMethodsWithoutIFrameTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOnlineInvoiceForOnlinePaymentsMethodsWithoutIFrameTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOnlineInvoiceForOnlinePaymentsMethodsWithoutIFrameTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOnlineInvoiceForOnlinePaymentsMethodsWithoutIFrameTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOnlineInvoiceForOnlinePaymentsMethodsWithoutIFrameTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOnlineRefundForOnlinePaymentsMethodsWithIFrameTest.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOnlineRefundForOnlinePaymentsMethodsWithIFrameTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOnlineRefundForOnlinePaymentsMethodsWithIFrameTest.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOnlineRefundForOnlinePaymentsMethodsWithIFrameTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOnlineRefundForOnlinePaymentsMethodsWithIFrameTest.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOnlineRefundForOnlinePaymentsMethodsWithIFrameTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOnlineRefundForOnlinePaymentsMethodsWithIFrameTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOnlineRefundForOnlinePaymentsMethodsWithIFrameTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOnlineRefundForOnlinePaymentsMethodsWithIFrameTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOnlineRefundForOnlinePaymentsMethodsWithIFrameTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOnlineRefundForOnlinePaymentsMethodsWithIFrameTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOnlineRefundForOnlinePaymentsMethodsWithIFrameTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOnlineRefundForOnlinePaymentsMethodsWithoutIFrameTest.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOnlineRefundForOnlinePaymentsMethodsWithoutIFrameTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOnlineRefundForOnlinePaymentsMethodsWithoutIFrameTest.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOnlineRefundForOnlinePaymentsMethodsWithoutIFrameTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOnlineRefundForOnlinePaymentsMethodsWithoutIFrameTest.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOnlineRefundForOnlinePaymentsMethodsWithoutIFrameTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOnlineRefundForOnlinePaymentsMethodsWithoutIFrameTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOnlineRefundForOnlinePaymentsMethodsWithoutIFrameTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOnlineRefundForOnlinePaymentsMethodsWithoutIFrameTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOnlineRefundForOnlinePaymentsMethodsWithoutIFrameTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOnlineRefundForOnlinePaymentsMethodsWithoutIFrameTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOnlineRefundForOnlinePaymentsMethodsWithoutIFrameTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOnlineRefundForPaypalExpressCheckoutTest.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOnlineRefundForPaypalExpressCheckoutTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOnlineRefundForPaypalExpressCheckoutTest.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOnlineRefundForPaypalExpressCheckoutTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOnlineRefundForPaypalExpressCheckoutTest.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOnlineRefundForPaypalExpressCheckoutTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOnlineRefundForPaypalExpressCheckoutTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOnlineRefundForPaypalExpressCheckoutTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOnlineRefundForPaypalExpressCheckoutTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOnlineRefundForPaypalExpressCheckoutTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOnlineRefundForPaypalExpressCheckoutTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOnlineRefundForPaypalExpressCheckoutTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOrderWithOnlinePaymentsMethodsWith3DSecureTest.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOrderWithOnlinePaymentsMethodsWith3DSecureTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOrderWithOnlinePaymentsMethodsWith3DSecureTest.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOrderWithOnlinePaymentsMethodsWith3DSecureTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOrderWithOnlinePaymentsMethodsWith3DSecureTest.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOrderWithOnlinePaymentsMethodsWith3DSecureTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOrderWithOnlinePaymentsMethodsWith3DSecureTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOrderWithOnlinePaymentsMethodsWith3DSecureTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOrderWithOnlinePaymentsMethodsWith3DSecureTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOrderWithOnlinePaymentsMethodsWith3DSecureTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOrderWithOnlinePaymentsMethodsWith3DSecureTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOrderWithOnlinePaymentsMethodsWith3DSecureTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOrderWithOnlinePaymentsMethodsWithIFrameTest.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOrderWithOnlinePaymentsMethodsWithIFrameTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOrderWithOnlinePaymentsMethodsWithIFrameTest.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOrderWithOnlinePaymentsMethodsWithIFrameTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOrderWithOnlinePaymentsMethodsWithIFrameTest.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOrderWithOnlinePaymentsMethodsWithIFrameTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOrderWithOnlinePaymentsMethodsWithIFrameTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOrderWithOnlinePaymentsMethodsWithIFrameTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOrderWithOnlinePaymentsMethodsWithIFrameTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOrderWithOnlinePaymentsMethodsWithIFrameTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOrderWithOnlinePaymentsMethodsWithIFrameTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOrderWithOnlinePaymentsMethodsWithIFrameTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOrderWithOnlinePaymentsMethodsWithoutIFrameTest.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOrderWithOnlinePaymentsMethodsWithoutIFrameTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOrderWithOnlinePaymentsMethodsWithoutIFrameTest.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOrderWithOnlinePaymentsMethodsWithoutIFrameTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOrderWithOnlinePaymentsMethodsWithoutIFrameTest.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOrderWithOnlinePaymentsMethodsWithoutIFrameTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOrderWithOnlinePaymentsMethodsWithoutIFrameTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOrderWithOnlinePaymentsMethodsWithoutIFrameTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOrderWithOnlinePaymentsMethodsWithoutIFrameTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOrderWithOnlinePaymentsMethodsWithoutIFrameTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOrderWithOnlinePaymentsMethodsWithoutIFrameTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOrderWithOnlinePaymentsMethodsWithoutIFrameTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOrderWithPayPalStandardTest.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOrderWithPayPalStandardTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOrderWithPayPalStandardTest.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOrderWithPayPalStandardTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOrderWithPayPalStandardTest.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOrderWithPayPalStandardTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOrderWithPayPalStandardTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOrderWithPayPalStandardTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOrderWithPayPalStandardTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOrderWithPayPalStandardTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOrderWithPayPalStandardTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateOrderWithPayPalStandardTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateShipmentForOnlinePaymentMethodsWithIFrameTest.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateShipmentForOnlinePaymentMethodsWithIFrameTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateShipmentForOnlinePaymentMethodsWithIFrameTest.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateShipmentForOnlinePaymentMethodsWithIFrameTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateShipmentForOnlinePaymentMethodsWithIFrameTest.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateShipmentForOnlinePaymentMethodsWithIFrameTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateShipmentForOnlinePaymentMethodsWithIFrameTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateShipmentForOnlinePaymentMethodsWithIFrameTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateShipmentForOnlinePaymentMethodsWithIFrameTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateShipmentForOnlinePaymentMethodsWithIFrameTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateShipmentForOnlinePaymentMethodsWithIFrameTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateShipmentForOnlinePaymentMethodsWithIFrameTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateShipmentForOnlinePaymentMethodsWithoutIFrameTest.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateShipmentForOnlinePaymentMethodsWithoutIFrameTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateShipmentForOnlinePaymentMethodsWithoutIFrameTest.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateShipmentForOnlinePaymentMethodsWithoutIFrameTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateShipmentForOnlinePaymentMethodsWithoutIFrameTest.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateShipmentForOnlinePaymentMethodsWithoutIFrameTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateShipmentForOnlinePaymentMethodsWithoutIFrameTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateShipmentForOnlinePaymentMethodsWithoutIFrameTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateShipmentForOnlinePaymentMethodsWithoutIFrameTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateShipmentForOnlinePaymentMethodsWithoutIFrameTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateShipmentForOnlinePaymentMethodsWithoutIFrameTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateShipmentForOnlinePaymentMethodsWithoutIFrameTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateShipmentForPaypalExpressCheckoutTest.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateShipmentForPaypalExpressCheckoutTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateShipmentForPaypalExpressCheckoutTest.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateShipmentForPaypalExpressCheckoutTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateShipmentForPaypalExpressCheckoutTest.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateShipmentForPaypalExpressCheckoutTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateShipmentForPaypalExpressCheckoutTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateShipmentForPaypalExpressCheckoutTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateShipmentForPaypalExpressCheckoutTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateShipmentForPaypalExpressCheckoutTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateShipmentForPaypalExpressCheckoutTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/CreateShipmentForPaypalExpressCheckoutTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/TestCreationForExpressCheckoutWithinPayPalButtonFromProductPageTest.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/TestCreationForExpressCheckoutWithinPayPalButtonFromProductPageTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/TestCreationForExpressCheckoutWithinPayPalButtonFromProductPageTest.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/TestCreationForExpressCheckoutWithinPayPalButtonFromProductPageTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/TestCreationForExpressCheckoutWithinPayPalButtonFromProductPageTest.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/TestCreationForExpressCheckoutWithinPayPalButtonFromProductPageTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/TestCreationForExpressCheckoutWithinPayPalButtonFromProductPageTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/TestCreationForExpressCheckoutWithinPayPalButtonFromProductPageTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/TestCreationForExpressCheckoutWithinPayPalButtonFromProductPageTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/TestCreationForExpressCheckoutWithinPayPalButtonFromProductPageTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/TestCreationForExpressCheckoutWithinPayPalButtonFromProductPageTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/TestCreationForExpressCheckoutWithinPayPalButtonFromProductPageTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/TestCreationForExpressCheckoutWithinPayPalButtonTest.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/TestCreationForExpressCheckoutWithinPayPalButtonTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/TestCreationForExpressCheckoutWithinPayPalButtonTest.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/TestCreationForExpressCheckoutWithinPayPalButtonTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/TestCreationForExpressCheckoutWithinPayPalButtonTest.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/TestCreationForExpressCheckoutWithinPayPalButtonTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/TestCreationForExpressCheckoutWithinPayPalButtonTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/TestCreationForExpressCheckoutWithinPayPalButtonTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/TestCreationForExpressCheckoutWithinPayPalButtonTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/TestCreationForExpressCheckoutWithinPayPalButtonTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/TestCreationForExpressCheckoutWithinPayPalButtonTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestCase/TestCreationForExpressCheckoutWithinPayPalButtonTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestStep/CheckoutWithPayPalFromProductPageStep.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestStep/CheckoutWithPayPalFromProductPageStep.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestStep/CheckoutWithPayPalFromProductPageStep.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestStep/CheckoutWithPayPalFromProductPageStep.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestStep/CheckoutWithPayPalFromProductPageStep.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestStep/CheckoutWithPayPalFromProductPageStep.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestStep/CheckoutWithPayPalStep.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestStep/CheckoutWithPayPalStep.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestStep/CheckoutWithPayPalStep.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestStep/CheckoutWithPayPalStep.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestStep/CheckoutWithPayPalStep.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestStep/CheckoutWithPayPalStep.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestStep/ContinuePayPalCheckoutStep.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestStep/ContinuePayPalCheckoutStep.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestStep/ContinuePayPalCheckoutStep.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestStep/ContinuePayPalCheckoutStep.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestStep/ContinuePayPalCheckoutStep.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestStep/ContinuePayPalCheckoutStep.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestStep/FillCreditCardInIFrameStep.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestStep/FillCreditCardInIFrameStep.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestStep/FillCreditCardInIFrameStep.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestStep/FillCreditCardInIFrameStep.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestStep/FillCreditCardInIFrameStep.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestStep/FillCreditCardInIFrameStep.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestStep/LoginToPayPalStep.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestStep/LoginToPayPalStep.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestStep/LoginToPayPalStep.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestStep/LoginToPayPalStep.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestStep/LoginToPayPalStep.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestStep/LoginToPayPalStep.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestStep/PlaceOrderStep.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestStep/PlaceOrderStep.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestStep/PlaceOrderStep.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestStep/PlaceOrderStep.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/TestStep/PlaceOrderStep.php
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/TestStep/PlaceOrderStep.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/etc/testcase.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/etc/testcase.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/etc/testcase.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/etc/testcase.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Paypal/Test/etc/testcase.xml
+++ b/dev/tests/functional/tests/app/Mage/Paypal/Test/etc/testcase.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Rating/Test/Constraint/AssertProductRatingInProductPage.php
+++ b/dev/tests/functional/tests/app/Mage/Rating/Test/Constraint/AssertProductRatingInProductPage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Rating/Test/Constraint/AssertProductRatingInProductPage.php
+++ b/dev/tests/functional/tests/app/Mage/Rating/Test/Constraint/AssertProductRatingInProductPage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Rating/Test/Constraint/AssertProductRatingInProductPage.php
+++ b/dev/tests/functional/tests/app/Mage/Rating/Test/Constraint/AssertProductRatingInProductPage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Rating/Test/Constraint/AssertProductRatingOnReviewPage.php
+++ b/dev/tests/functional/tests/app/Mage/Rating/Test/Constraint/AssertProductRatingOnReviewPage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Rating/Test/Constraint/AssertProductRatingOnReviewPage.php
+++ b/dev/tests/functional/tests/app/Mage/Rating/Test/Constraint/AssertProductRatingOnReviewPage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Rating/Test/Constraint/AssertProductRatingOnReviewPage.php
+++ b/dev/tests/functional/tests/app/Mage/Rating/Test/Constraint/AssertProductRatingOnReviewPage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Rating/Test/Fixture/Rating.xml
+++ b/dev/tests/functional/tests/app/Mage/Rating/Test/Fixture/Rating.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Rating/Test/Fixture/Rating.xml
+++ b/dev/tests/functional/tests/app/Mage/Rating/Test/Fixture/Rating.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Rating/Test/Fixture/Rating.xml
+++ b/dev/tests/functional/tests/app/Mage/Rating/Test/Fixture/Rating.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Rating/Test/Fixture/Rating/Stores.php
+++ b/dev/tests/functional/tests/app/Mage/Rating/Test/Fixture/Rating/Stores.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Rating/Test/Fixture/Rating/Stores.php
+++ b/dev/tests/functional/tests/app/Mage/Rating/Test/Fixture/Rating/Stores.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Rating/Test/Fixture/Rating/Stores.php
+++ b/dev/tests/functional/tests/app/Mage/Rating/Test/Fixture/Rating/Stores.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Rating/Test/Handler/Curl.php
+++ b/dev/tests/functional/tests/app/Mage/Rating/Test/Handler/Curl.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Rating/Test/Handler/Curl.php
+++ b/dev/tests/functional/tests/app/Mage/Rating/Test/Handler/Curl.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Rating/Test/Handler/Curl.php
+++ b/dev/tests/functional/tests/app/Mage/Rating/Test/Handler/Curl.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Rating/Test/Handler/RatingInterface.php
+++ b/dev/tests/functional/tests/app/Mage/Rating/Test/Handler/RatingInterface.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Rating/Test/Handler/RatingInterface.php
+++ b/dev/tests/functional/tests/app/Mage/Rating/Test/Handler/RatingInterface.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Rating/Test/Handler/RatingInterface.php
+++ b/dev/tests/functional/tests/app/Mage/Rating/Test/Handler/RatingInterface.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Rating/Test/Page/Adminhtml/RatingEdit.xml
+++ b/dev/tests/functional/tests/app/Mage/Rating/Test/Page/Adminhtml/RatingEdit.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Rating/Test/Page/Adminhtml/RatingEdit.xml
+++ b/dev/tests/functional/tests/app/Mage/Rating/Test/Page/Adminhtml/RatingEdit.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Rating/Test/Page/Adminhtml/RatingEdit.xml
+++ b/dev/tests/functional/tests/app/Mage/Rating/Test/Page/Adminhtml/RatingEdit.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Rating/Test/Page/Adminhtml/RatingIndex.xml
+++ b/dev/tests/functional/tests/app/Mage/Rating/Test/Page/Adminhtml/RatingIndex.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Rating/Test/Page/Adminhtml/RatingIndex.xml
+++ b/dev/tests/functional/tests/app/Mage/Rating/Test/Page/Adminhtml/RatingIndex.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Rating/Test/Page/Adminhtml/RatingIndex.xml
+++ b/dev/tests/functional/tests/app/Mage/Rating/Test/Page/Adminhtml/RatingIndex.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Rating/Test/Repository/Rating.xml
+++ b/dev/tests/functional/tests/app/Mage/Rating/Test/Repository/Rating.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Rating/Test/Repository/Rating.xml
+++ b/dev/tests/functional/tests/app/Mage/Rating/Test/Repository/Rating.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Rating/Test/Repository/Rating.xml
+++ b/dev/tests/functional/tests/app/Mage/Rating/Test/Repository/Rating.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Rating/Test/etc/curl/di.xml
+++ b/dev/tests/functional/tests/app/Mage/Rating/Test/etc/curl/di.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Rating/Test/etc/curl/di.xml
+++ b/dev/tests/functional/tests/app/Mage/Rating/Test/etc/curl/di.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Rating/Test/etc/curl/di.xml
+++ b/dev/tests/functional/tests/app/Mage/Rating/Test/etc/curl/di.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Review/Test/Block/Product/View.php
+++ b/dev/tests/functional/tests/app/Mage/Review/Test/Block/Product/View.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Review/Test/Block/Product/View.php
+++ b/dev/tests/functional/tests/app/Mage/Review/Test/Block/Product/View.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Review/Test/Block/Product/View.php
+++ b/dev/tests/functional/tests/app/Mage/Review/Test/Block/Product/View.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Review/Test/Block/Product/View/Form.php
+++ b/dev/tests/functional/tests/app/Mage/Review/Test/Block/Product/View/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Review/Test/Block/Product/View/Form.php
+++ b/dev/tests/functional/tests/app/Mage/Review/Test/Block/Product/View/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Review/Test/Block/Product/View/Form.php
+++ b/dev/tests/functional/tests/app/Mage/Review/Test/Block/Product/View/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Review/Test/Block/Product/View/Form.xml
+++ b/dev/tests/functional/tests/app/Mage/Review/Test/Block/Product/View/Form.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Review/Test/Block/Product/View/Form.xml
+++ b/dev/tests/functional/tests/app/Mage/Review/Test/Block/Product/View/Form.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Review/Test/Block/Product/View/Form.xml
+++ b/dev/tests/functional/tests/app/Mage/Review/Test/Block/Product/View/Form.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Review/Test/Block/Product/View/Review.php
+++ b/dev/tests/functional/tests/app/Mage/Review/Test/Block/Product/View/Review.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Review/Test/Block/Product/View/Review.php
+++ b/dev/tests/functional/tests/app/Mage/Review/Test/Block/Product/View/Review.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Review/Test/Block/Product/View/Review.php
+++ b/dev/tests/functional/tests/app/Mage/Review/Test/Block/Product/View/Review.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Review/Test/Constraint/AssertProductReviewForm.php
+++ b/dev/tests/functional/tests/app/Mage/Review/Test/Constraint/AssertProductReviewForm.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Review/Test/Constraint/AssertProductReviewForm.php
+++ b/dev/tests/functional/tests/app/Mage/Review/Test/Constraint/AssertProductReviewForm.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Review/Test/Constraint/AssertProductReviewForm.php
+++ b/dev/tests/functional/tests/app/Mage/Review/Test/Constraint/AssertProductReviewForm.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Review/Test/Constraint/AssertProductReviewInGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Review/Test/Constraint/AssertProductReviewInGrid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Review/Test/Constraint/AssertProductReviewInGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Review/Test/Constraint/AssertProductReviewInGrid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Review/Test/Constraint/AssertProductReviewInGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Review/Test/Constraint/AssertProductReviewInGrid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Review/Test/Constraint/AssertProductReviewIsAbsentOnProductPage.php
+++ b/dev/tests/functional/tests/app/Mage/Review/Test/Constraint/AssertProductReviewIsAbsentOnProductPage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Review/Test/Constraint/AssertProductReviewIsAbsentOnProductPage.php
+++ b/dev/tests/functional/tests/app/Mage/Review/Test/Constraint/AssertProductReviewIsAbsentOnProductPage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Review/Test/Constraint/AssertProductReviewIsAbsentOnProductPage.php
+++ b/dev/tests/functional/tests/app/Mage/Review/Test/Constraint/AssertProductReviewIsAbsentOnProductPage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Review/Test/Constraint/AssertProductReviewOnProductPage.php
+++ b/dev/tests/functional/tests/app/Mage/Review/Test/Constraint/AssertProductReviewOnProductPage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Review/Test/Constraint/AssertProductReviewOnProductPage.php
+++ b/dev/tests/functional/tests/app/Mage/Review/Test/Constraint/AssertProductReviewOnProductPage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Review/Test/Constraint/AssertProductReviewOnProductPage.php
+++ b/dev/tests/functional/tests/app/Mage/Review/Test/Constraint/AssertProductReviewOnProductPage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Review/Test/Constraint/AssertReviewCreationSuccessMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Review/Test/Constraint/AssertReviewCreationSuccessMessage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Review/Test/Constraint/AssertReviewCreationSuccessMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Review/Test/Constraint/AssertReviewCreationSuccessMessage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Review/Test/Constraint/AssertReviewCreationSuccessMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Review/Test/Constraint/AssertReviewCreationSuccessMessage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Review/Test/Constraint/AssertReviewLinksIsPresentOnProductPage.php
+++ b/dev/tests/functional/tests/app/Mage/Review/Test/Constraint/AssertReviewLinksIsPresentOnProductPage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Review/Test/Constraint/AssertReviewLinksIsPresentOnProductPage.php
+++ b/dev/tests/functional/tests/app/Mage/Review/Test/Constraint/AssertReviewLinksIsPresentOnProductPage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Review/Test/Constraint/AssertReviewLinksIsPresentOnProductPage.php
+++ b/dev/tests/functional/tests/app/Mage/Review/Test/Constraint/AssertReviewLinksIsPresentOnProductPage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Review/Test/Constraint/AssertReviewSuccessSaveMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Review/Test/Constraint/AssertReviewSuccessSaveMessage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Review/Test/Constraint/AssertReviewSuccessSaveMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Review/Test/Constraint/AssertReviewSuccessSaveMessage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Review/Test/Constraint/AssertReviewSuccessSaveMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Review/Test/Constraint/AssertReviewSuccessSaveMessage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Review/Test/Constraint/AssertSetApprovedProductReview.php
+++ b/dev/tests/functional/tests/app/Mage/Review/Test/Constraint/AssertSetApprovedProductReview.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Review/Test/Constraint/AssertSetApprovedProductReview.php
+++ b/dev/tests/functional/tests/app/Mage/Review/Test/Constraint/AssertSetApprovedProductReview.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Review/Test/Constraint/AssertSetApprovedProductReview.php
+++ b/dev/tests/functional/tests/app/Mage/Review/Test/Constraint/AssertSetApprovedProductReview.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Review/Test/Fixture/Review.xml
+++ b/dev/tests/functional/tests/app/Mage/Review/Test/Fixture/Review.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Review/Test/Fixture/Review.xml
+++ b/dev/tests/functional/tests/app/Mage/Review/Test/Fixture/Review.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Review/Test/Fixture/Review.xml
+++ b/dev/tests/functional/tests/app/Mage/Review/Test/Fixture/Review.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Review/Test/Fixture/Review/EntityId.php
+++ b/dev/tests/functional/tests/app/Mage/Review/Test/Fixture/Review/EntityId.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Review/Test/Fixture/Review/EntityId.php
+++ b/dev/tests/functional/tests/app/Mage/Review/Test/Fixture/Review/EntityId.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Review/Test/Fixture/Review/EntityId.php
+++ b/dev/tests/functional/tests/app/Mage/Review/Test/Fixture/Review/EntityId.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Review/Test/Fixture/Review/Ratings.php
+++ b/dev/tests/functional/tests/app/Mage/Review/Test/Fixture/Review/Ratings.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Review/Test/Fixture/Review/Ratings.php
+++ b/dev/tests/functional/tests/app/Mage/Review/Test/Fixture/Review/Ratings.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Review/Test/Fixture/Review/Ratings.php
+++ b/dev/tests/functional/tests/app/Mage/Review/Test/Fixture/Review/Ratings.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Review/Test/Page/Adminhtml/CatalogProductReview.xml
+++ b/dev/tests/functional/tests/app/Mage/Review/Test/Page/Adminhtml/CatalogProductReview.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Review/Test/Page/Adminhtml/CatalogProductReview.xml
+++ b/dev/tests/functional/tests/app/Mage/Review/Test/Page/Adminhtml/CatalogProductReview.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Review/Test/Page/Adminhtml/CatalogProductReview.xml
+++ b/dev/tests/functional/tests/app/Mage/Review/Test/Page/Adminhtml/CatalogProductReview.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Review/Test/Page/Adminhtml/CatalogProductReviewEdit.xml
+++ b/dev/tests/functional/tests/app/Mage/Review/Test/Page/Adminhtml/CatalogProductReviewEdit.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Review/Test/Page/Adminhtml/CatalogProductReviewEdit.xml
+++ b/dev/tests/functional/tests/app/Mage/Review/Test/Page/Adminhtml/CatalogProductReviewEdit.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Review/Test/Page/Adminhtml/CatalogProductReviewEdit.xml
+++ b/dev/tests/functional/tests/app/Mage/Review/Test/Page/Adminhtml/CatalogProductReviewEdit.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Review/Test/Page/Product/CatalogProductView.xml
+++ b/dev/tests/functional/tests/app/Mage/Review/Test/Page/Product/CatalogProductView.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Review/Test/Page/Product/CatalogProductView.xml
+++ b/dev/tests/functional/tests/app/Mage/Review/Test/Page/Product/CatalogProductView.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Review/Test/Page/Product/CatalogProductView.xml
+++ b/dev/tests/functional/tests/app/Mage/Review/Test/Page/Product/CatalogProductView.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Review/Test/Page/Product/ReviewProductList.xml
+++ b/dev/tests/functional/tests/app/Mage/Review/Test/Page/Product/ReviewProductList.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Review/Test/Page/Product/ReviewProductList.xml
+++ b/dev/tests/functional/tests/app/Mage/Review/Test/Page/Product/ReviewProductList.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Review/Test/Page/Product/ReviewProductList.xml
+++ b/dev/tests/functional/tests/app/Mage/Review/Test/Page/Product/ReviewProductList.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Review/Test/TestCase/CreateProductReviewFrontendEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Review/Test/TestCase/CreateProductReviewFrontendEntityTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Review/Test/TestCase/CreateProductReviewFrontendEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Review/Test/TestCase/CreateProductReviewFrontendEntityTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Review/Test/TestCase/CreateProductReviewFrontendEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Review/Test/TestCase/CreateProductReviewFrontendEntityTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Review/Test/TestCase/CreateProductReviewFrontendEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Review/Test/TestCase/CreateProductReviewFrontendEntityTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Review/Test/TestCase/CreateProductReviewFrontendEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Review/Test/TestCase/CreateProductReviewFrontendEntityTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Review/Test/TestCase/CreateProductReviewFrontendEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Review/Test/TestCase/CreateProductReviewFrontendEntityTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Review/Test/TestStep/AddFrontendReviewStep.php
+++ b/dev/tests/functional/tests/app/Mage/Review/Test/TestStep/AddFrontendReviewStep.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Review/Test/TestStep/AddFrontendReviewStep.php
+++ b/dev/tests/functional/tests/app/Mage/Review/Test/TestStep/AddFrontendReviewStep.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Review/Test/TestStep/AddFrontendReviewStep.php
+++ b/dev/tests/functional/tests/app/Mage/Review/Test/TestStep/AddFrontendReviewStep.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Review/Test/TestStep/DeleteAllRatingsStep.php
+++ b/dev/tests/functional/tests/app/Mage/Review/Test/TestStep/DeleteAllRatingsStep.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Review/Test/TestStep/DeleteAllRatingsStep.php
+++ b/dev/tests/functional/tests/app/Mage/Review/Test/TestStep/DeleteAllRatingsStep.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Review/Test/TestStep/DeleteAllRatingsStep.php
+++ b/dev/tests/functional/tests/app/Mage/Review/Test/TestStep/DeleteAllRatingsStep.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Review/Test/etc/testcase.xml
+++ b/dev/tests/functional/tests/app/Mage/Review/Test/etc/testcase.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Review/Test/etc/testcase.xml
+++ b/dev/tests/functional/tests/app/Mage/Review/Test/etc/testcase.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Review/Test/etc/testcase.xml
+++ b/dev/tests/functional/tests/app/Mage/Review/Test/etc/testcase.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/AbstractProductView.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/AbstractProductView.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/AbstractProductView.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/AbstractProductView.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/AbstractProductView.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/AbstractProductView.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/AbstractSalesEntities.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/AbstractSalesEntities.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/AbstractSalesEntities.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/AbstractSalesEntities.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/AbstractSalesEntities.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/AbstractSalesEntities.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/AbstractSalesEntities/SalesEntity.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/AbstractSalesEntities/SalesEntity.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/AbstractSalesEntities/SalesEntity.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/AbstractSalesEntities/SalesEntity.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/AbstractSalesEntities/SalesEntity.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/AbstractSalesEntities/SalesEntity.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/AbstractSalesEntities/SalesEntity/Items/Product.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/AbstractSalesEntities/SalesEntity/Items/Product.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/AbstractSalesEntities/SalesEntity/Items/Product.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/AbstractSalesEntities/SalesEntity/Items/Product.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/AbstractSalesEntities/SalesEntity/Items/Product.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/AbstractSalesEntities/SalesEntity/Items/Product.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/CreditMemos.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/CreditMemos.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/CreditMemos.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/CreditMemos.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/CreditMemos.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/CreditMemos.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/CreditMemos/CreditMemo.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/CreditMemos/CreditMemo.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/CreditMemos/CreditMemo.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/CreditMemos/CreditMemo.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/CreditMemos/CreditMemo.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/CreditMemos/CreditMemo.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/CreditMemos/CreditMemo/Items.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/CreditMemos/CreditMemo/Items.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/CreditMemos/CreditMemo/Items.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/CreditMemos/CreditMemo/Items.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/CreditMemos/CreditMemo/Items.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/CreditMemos/CreditMemo/Items.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/CreditMemos/CreditMemo/Items/Product.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/CreditMemos/CreditMemo/Items/Product.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/CreditMemos/CreditMemo/Items/Product.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/CreditMemos/CreditMemo/Items/Product.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/CreditMemos/CreditMemo/Items/Product.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/CreditMemos/CreditMemo/Items/Product.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/History.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/History.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/History.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/History.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/History.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/History.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/Invoices.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/Invoices.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/Invoices.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/Invoices.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/Invoices.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/Invoices.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/Invoices/Invoice.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/Invoices/Invoice.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/Invoices/Invoice.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/Invoices/Invoice.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/Invoices/Invoice.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/Invoices/Invoice.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/Invoices/Invoice/Items.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/Invoices/Invoice/Items.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/Invoices/Invoice/Items.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/Invoices/Invoice/Items.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/Invoices/Invoice/Items.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/Invoices/Invoice/Items.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/Invoices/Invoice/Items/Product.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/Invoices/Invoice/Items/Product.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/Invoices/Invoice/Items/Product.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/Invoices/Invoice/Items/Product.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/Invoices/Invoice/Items/Product.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/Invoices/Invoice/Items/Product.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/OrderPrint/View.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/OrderPrint/View.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/OrderPrint/View.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/OrderPrint/View.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/OrderPrint/View.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/OrderPrint/View.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/View.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/View.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/View.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/View.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/View.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/View.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/View/ActionsToolbar.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/View/ActionsToolbar.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/View/ActionsToolbar.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/View/ActionsToolbar.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/View/ActionsToolbar.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/View/ActionsToolbar.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/View/Items.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/View/Items.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/View/Items.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/View/Items.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/View/Items.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/View/Items.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/View/Items/Product.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/View/Items/Product.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/View/Items/Product.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/View/Items/Product.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/View/Items/Product.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/View/Items/Product.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/View/Totals.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/View/Totals.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/View/Totals.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/View/Totals.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/View/Totals.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Order/View/Totals.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Widget/Guest/Form.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Widget/Guest/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Widget/Guest/Form.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Widget/Guest/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Widget/Guest/Form.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Widget/Guest/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Widget/Guest/Form.xml
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Widget/Guest/Form.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Widget/Guest/Form.xml
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Widget/Guest/Form.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Widget/Guest/Form.xml
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Block/Widget/Guest/Form.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AbstractAssertItems.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AbstractAssertItems.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AbstractAssertItems.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AbstractAssertItems.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AbstractAssertItems.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AbstractAssertItems.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AbstractAssertNoButtonOnOrderPage.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AbstractAssertNoButtonOnOrderPage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AbstractAssertNoButtonOnOrderPage.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AbstractAssertNoButtonOnOrderPage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AbstractAssertNoButtonOnOrderPage.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AbstractAssertNoButtonOnOrderPage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AbstractAssertOrdersAddress.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AbstractAssertOrdersAddress.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AbstractAssertOrdersAddress.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AbstractAssertOrdersAddress.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AbstractAssertOrdersAddress.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AbstractAssertOrdersAddress.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AbstractAssertSales.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AbstractAssertSales.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AbstractAssertSales.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AbstractAssertSales.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AbstractAssertSales.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AbstractAssertSales.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AbstractAssertSalesEntityInGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AbstractAssertSalesEntityInGrid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AbstractAssertSalesEntityInGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AbstractAssertSalesEntityInGrid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AbstractAssertSalesEntityInGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AbstractAssertSalesEntityInGrid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AbstractAssertSalesEntityInSalesEntityGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AbstractAssertSalesEntityInSalesEntityGrid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AbstractAssertSalesEntityInSalesEntityGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AbstractAssertSalesEntityInSalesEntityGrid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AbstractAssertSalesEntityInSalesEntityGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AbstractAssertSalesEntityInSalesEntityGrid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AbstractAssertSalesEntityInSalesEntityTab.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AbstractAssertSalesEntityInSalesEntityTab.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AbstractAssertSalesEntityInSalesEntityTab.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AbstractAssertSalesEntityInSalesEntityTab.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AbstractAssertSalesEntityInSalesEntityTab.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AbstractAssertSalesEntityInSalesEntityTab.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AbstractAssertSalesEntityItemsOnFrontend.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AbstractAssertSalesEntityItemsOnFrontend.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AbstractAssertSalesEntityItemsOnFrontend.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AbstractAssertSalesEntityItemsOnFrontend.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AbstractAssertSalesEntityItemsOnFrontend.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AbstractAssertSalesEntityItemsOnFrontend.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertConfigurableProductInItemsOrderedGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertConfigurableProductInItemsOrderedGrid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertConfigurableProductInItemsOrderedGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertConfigurableProductInItemsOrderedGrid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertConfigurableProductInItemsOrderedGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertConfigurableProductInItemsOrderedGrid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertCreditMemoConfigurableItems.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertCreditMemoConfigurableItems.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertCreditMemoConfigurableItems.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertCreditMemoConfigurableItems.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertCreditMemoConfigurableItems.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertCreditMemoConfigurableItems.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertCreditMemoConfigurableItemsOnFrontend.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertCreditMemoConfigurableItemsOnFrontend.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertCreditMemoConfigurableItemsOnFrontend.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertCreditMemoConfigurableItemsOnFrontend.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertCreditMemoConfigurableItemsOnFrontend.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertCreditMemoConfigurableItemsOnFrontend.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertCreditMemoInCreditMemosGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertCreditMemoInCreditMemosGrid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertCreditMemoInCreditMemosGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertCreditMemoInCreditMemosGrid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertCreditMemoInCreditMemosGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertCreditMemoInCreditMemosGrid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertCreditMemoInCreditMemosTab.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertCreditMemoInCreditMemosTab.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertCreditMemoInCreditMemosTab.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertCreditMemoInCreditMemosTab.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertCreditMemoInCreditMemosTab.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertCreditMemoInCreditMemosTab.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertCreditMemoItems.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertCreditMemoItems.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertCreditMemoItems.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertCreditMemoItems.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertCreditMemoItems.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertCreditMemoItems.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertCreditMemoItemsOnFrontend.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertCreditMemoItemsOnFrontend.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertCreditMemoItemsOnFrontend.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertCreditMemoItemsOnFrontend.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertCreditMemoItemsOnFrontend.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertCreditMemoItemsOnFrontend.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertCreditMemoSuccessCreateMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertCreditMemoSuccessCreateMessage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertCreditMemoSuccessCreateMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertCreditMemoSuccessCreateMessage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertCreditMemoSuccessCreateMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertCreditMemoSuccessCreateMessage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertInvoiceConfigurableItems.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertInvoiceConfigurableItems.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertInvoiceConfigurableItems.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertInvoiceConfigurableItems.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertInvoiceConfigurableItems.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertInvoiceConfigurableItems.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertInvoiceConfigurableItemsOnFrontend.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertInvoiceConfigurableItemsOnFrontend.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertInvoiceConfigurableItemsOnFrontend.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertInvoiceConfigurableItemsOnFrontend.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertInvoiceConfigurableItemsOnFrontend.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertInvoiceConfigurableItemsOnFrontend.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertInvoiceInInvoicesGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertInvoiceInInvoicesGrid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertInvoiceInInvoicesGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertInvoiceInInvoicesGrid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertInvoiceInInvoicesGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertInvoiceInInvoicesGrid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertInvoiceInInvoicesTab.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertInvoiceInInvoicesTab.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertInvoiceInInvoicesTab.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertInvoiceInInvoicesTab.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertInvoiceInInvoicesTab.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertInvoiceInInvoicesTab.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertInvoiceItems.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertInvoiceItems.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertInvoiceItems.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertInvoiceItems.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertInvoiceItems.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertInvoiceItems.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertInvoiceItemsOnFrontend.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertInvoiceItemsOnFrontend.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertInvoiceItemsOnFrontend.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertInvoiceItemsOnFrontend.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertInvoiceItemsOnFrontend.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertInvoiceItemsOnFrontend.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertInvoiceSuccessCreateMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertInvoiceSuccessCreateMessage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertInvoiceSuccessCreateMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertInvoiceSuccessCreateMessage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertInvoiceSuccessCreateMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertInvoiceSuccessCreateMessage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertInvoiceWithShipmentSuccessMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertInvoiceWithShipmentSuccessMessage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertInvoiceWithShipmentSuccessMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertInvoiceWithShipmentSuccessMessage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertInvoiceWithShipmentSuccessMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertInvoiceWithShipmentSuccessMessage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertItemsOrderedBlockIsEmpty.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertItemsOrderedBlockIsEmpty.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertItemsOrderedBlockIsEmpty.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertItemsOrderedBlockIsEmpty.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertItemsOrderedBlockIsEmpty.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertItemsOrderedBlockIsEmpty.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertNoCreditMemoButton.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertNoCreditMemoButton.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertNoCreditMemoButton.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertNoCreditMemoButton.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertNoCreditMemoButton.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertNoCreditMemoButton.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertNoInvoiceButton.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertNoInvoiceButton.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertNoInvoiceButton.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertNoInvoiceButton.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertNoInvoiceButton.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertNoInvoiceButton.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertOrderButtonsAvailable.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertOrderButtonsAvailable.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertOrderButtonsAvailable.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertOrderButtonsAvailable.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertOrderButtonsAvailable.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertOrderButtonsAvailable.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertOrderCancelSuccessMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertOrderCancelSuccessMessage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertOrderCancelSuccessMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertOrderCancelSuccessMessage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertOrderCancelSuccessMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertOrderCancelSuccessMessage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertOrderCreateSuccessMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertOrderCreateSuccessMessage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertOrderCreateSuccessMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertOrderCreateSuccessMessage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertOrderCreateSuccessMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertOrderCreateSuccessMessage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertOrderGrandTotal.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertOrderGrandTotal.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertOrderGrandTotal.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertOrderGrandTotal.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertOrderGrandTotal.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertOrderGrandTotal.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertOrderInOrdersGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertOrderInOrdersGrid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertOrderInOrdersGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertOrderInOrdersGrid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertOrderInOrdersGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertOrderInOrdersGrid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertOrderInOrdersGridOnFrontend.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertOrderInOrdersGridOnFrontend.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertOrderInOrdersGridOnFrontend.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertOrderInOrdersGridOnFrontend.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertOrderInOrdersGridOnFrontend.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertOrderInOrdersGridOnFrontend.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertOrderStatusIsCorrect.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertOrderStatusIsCorrect.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertOrderStatusIsCorrect.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertOrderStatusIsCorrect.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertOrderStatusIsCorrect.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertOrderStatusIsCorrect.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertOrdersBillingAddress.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertOrdersBillingAddress.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertOrdersBillingAddress.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertOrdersBillingAddress.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertOrdersBillingAddress.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertOrdersBillingAddress.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertOrdersCount.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertOrdersCount.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertOrdersCount.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertOrdersCount.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertOrdersCount.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertOrdersCount.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertOrdersGrandTotal.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertOrdersGrandTotal.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertOrdersGrandTotal.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertOrdersGrandTotal.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertOrdersGrandTotal.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertOrdersGrandTotal.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertOrdersShippingAddress.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertOrdersShippingAddress.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertOrdersShippingAddress.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertOrdersShippingAddress.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertOrdersShippingAddress.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertOrdersShippingAddress.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertProductInItemsOrderedGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertProductInItemsOrderedGrid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertProductInItemsOrderedGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertProductInItemsOrderedGrid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertProductInItemsOrderedGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertProductInItemsOrderedGrid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertProductsVisibilityInItemsOrderedBlock.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertProductsVisibilityInItemsOrderedBlock.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertProductsVisibilityInItemsOrderedBlock.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertProductsVisibilityInItemsOrderedBlock.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertProductsVisibilityInItemsOrderedBlock.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertProductsVisibilityInItemsOrderedBlock.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertReorderedOrderStatusIsCorrect.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertReorderedOrderStatusIsCorrect.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertReorderedOrderStatusIsCorrect.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertReorderedOrderStatusIsCorrect.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertReorderedOrderStatusIsCorrect.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertReorderedOrderStatusIsCorrect.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertSalesPrintOrderBillingAddress.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertSalesPrintOrderBillingAddress.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertSalesPrintOrderBillingAddress.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertSalesPrintOrderBillingAddress.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertSalesPrintOrderBillingAddress.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertSalesPrintOrderBillingAddress.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertSalesPrintOrderGrandTotal.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertSalesPrintOrderGrandTotal.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertSalesPrintOrderGrandTotal.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertSalesPrintOrderGrandTotal.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertSalesPrintOrderGrandTotal.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertSalesPrintOrderGrandTotal.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertSalesPrintOrderPaymentMethod.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertSalesPrintOrderPaymentMethod.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertSalesPrintOrderPaymentMethod.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertSalesPrintOrderPaymentMethod.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertSalesPrintOrderPaymentMethod.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertSalesPrintOrderPaymentMethod.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertSalesPrintOrderProducts.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertSalesPrintOrderProducts.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertSalesPrintOrderProducts.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertSalesPrintOrderProducts.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertSalesPrintOrderProducts.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/AssertSalesPrintOrderProducts.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/FrontendActionsForSalesAssert.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/FrontendActionsForSalesAssert.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/FrontendActionsForSalesAssert.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/FrontendActionsForSalesAssert.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/FrontendActionsForSalesAssert.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Constraint/FrontendActionsForSalesAssert.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Fixture/Order.xml
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Fixture/Order.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Fixture/Order.xml
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Fixture/Order.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Fixture/Order.xml
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Fixture/Order.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Fixture/Order/BillingAddressId.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Fixture/Order/BillingAddressId.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Fixture/Order/BillingAddressId.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Fixture/Order/BillingAddressId.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Fixture/Order/BillingAddressId.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Fixture/Order/BillingAddressId.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Fixture/Order/CustomerId.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Fixture/Order/CustomerId.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Fixture/Order/CustomerId.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Fixture/Order/CustomerId.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Fixture/Order/CustomerId.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Fixture/Order/CustomerId.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Fixture/Order/EntityId.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Fixture/Order/EntityId.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Fixture/Order/EntityId.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Fixture/Order/EntityId.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Fixture/Order/EntityId.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Fixture/Order/EntityId.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Fixture/Order/StoreId.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Fixture/Order/StoreId.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Fixture/Order/StoreId.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Fixture/Order/StoreId.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Fixture/Order/StoreId.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Fixture/Order/StoreId.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Handler/Order/Curl.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Handler/Order/Curl.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Handler/Order/Curl.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Handler/Order/Curl.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Handler/Order/Curl.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Handler/Order/Curl.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Handler/Order/OrderInterface.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Handler/Order/OrderInterface.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Handler/Order/OrderInterface.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Handler/Order/OrderInterface.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Handler/Order/OrderInterface.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Handler/Order/OrderInterface.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Page/Adminhtml/SalesCreditMemo.xml
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Page/Adminhtml/SalesCreditMemo.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Page/Adminhtml/SalesCreditMemo.xml
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Page/Adminhtml/SalesCreditMemo.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Page/Adminhtml/SalesCreditMemo.xml
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Page/Adminhtml/SalesCreditMemo.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Page/Adminhtml/SalesCreditMemoView.xml
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Page/Adminhtml/SalesCreditMemoView.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Page/Adminhtml/SalesCreditMemoView.xml
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Page/Adminhtml/SalesCreditMemoView.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Page/Adminhtml/SalesCreditMemoView.xml
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Page/Adminhtml/SalesCreditMemoView.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Page/Adminhtml/SalesInvoice.xml
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Page/Adminhtml/SalesInvoice.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Page/Adminhtml/SalesInvoice.xml
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Page/Adminhtml/SalesInvoice.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Page/Adminhtml/SalesInvoice.xml
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Page/Adminhtml/SalesInvoice.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Page/Adminhtml/SalesInvoiceView.xml
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Page/Adminhtml/SalesInvoiceView.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Page/Adminhtml/SalesInvoiceView.xml
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Page/Adminhtml/SalesInvoiceView.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Page/Adminhtml/SalesInvoiceView.xml
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Page/Adminhtml/SalesInvoiceView.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Page/Adminhtml/SalesOrderCreateIndex.xml
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Page/Adminhtml/SalesOrderCreateIndex.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Page/Adminhtml/SalesOrderCreateIndex.xml
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Page/Adminhtml/SalesOrderCreateIndex.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Page/Adminhtml/SalesOrderCreateIndex.xml
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Page/Adminhtml/SalesOrderCreateIndex.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Page/Adminhtml/SalesOrderCreditMemoNew.xml
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Page/Adminhtml/SalesOrderCreditMemoNew.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Page/Adminhtml/SalesOrderCreditMemoNew.xml
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Page/Adminhtml/SalesOrderCreditMemoNew.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Page/Adminhtml/SalesOrderCreditMemoNew.xml
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Page/Adminhtml/SalesOrderCreditMemoNew.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Page/Adminhtml/SalesOrderIndex.xml
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Page/Adminhtml/SalesOrderIndex.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Page/Adminhtml/SalesOrderIndex.xml
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Page/Adminhtml/SalesOrderIndex.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Page/Adminhtml/SalesOrderIndex.xml
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Page/Adminhtml/SalesOrderIndex.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Page/Adminhtml/SalesOrderInvoiceNew.xml
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Page/Adminhtml/SalesOrderInvoiceNew.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Page/Adminhtml/SalesOrderInvoiceNew.xml
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Page/Adminhtml/SalesOrderInvoiceNew.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Page/Adminhtml/SalesOrderInvoiceNew.xml
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Page/Adminhtml/SalesOrderInvoiceNew.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Page/Adminhtml/SalesOrderView.xml
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Page/Adminhtml/SalesOrderView.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Page/Adminhtml/SalesOrderView.xml
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Page/Adminhtml/SalesOrderView.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Page/Adminhtml/SalesOrderView.xml
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Page/Adminhtml/SalesOrderView.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Page/CreditMemoView.xml
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Page/CreditMemoView.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Page/CreditMemoView.xml
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Page/CreditMemoView.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Page/CreditMemoView.xml
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Page/CreditMemoView.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Page/InvoiceView.xml
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Page/InvoiceView.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Page/InvoiceView.xml
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Page/InvoiceView.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Page/InvoiceView.xml
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Page/InvoiceView.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Page/OrderHistory.xml
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Page/OrderHistory.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Page/OrderHistory.xml
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Page/OrderHistory.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Page/OrderHistory.xml
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Page/OrderHistory.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Page/OrderView.xml
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Page/OrderView.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Page/OrderView.xml
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Page/OrderView.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Page/OrderView.xml
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Page/OrderView.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Page/SalesGuestForm.xml
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Page/SalesGuestForm.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Page/SalesGuestForm.xml
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Page/SalesGuestForm.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Page/SalesGuestForm.xml
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Page/SalesGuestForm.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Page/SalesGuestPrint.xml
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Page/SalesGuestPrint.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Page/SalesGuestPrint.xml
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Page/SalesGuestPrint.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Page/SalesGuestPrint.xml
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Page/SalesGuestPrint.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Page/SalesGuestView.xml
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Page/SalesGuestView.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Page/SalesGuestView.xml
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Page/SalesGuestView.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Page/SalesGuestView.xml
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Page/SalesGuestView.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Repository/ConfigData.xml
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Repository/ConfigData.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Repository/ConfigData.xml
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Repository/ConfigData.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Repository/ConfigData.xml
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Repository/ConfigData.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Repository/Order.xml
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Repository/Order.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Repository/Order.xml
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Repository/Order.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/Repository/Order.xml
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/Repository/Order.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/TestCase/CancelCreatedOrderTest.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/TestCase/CancelCreatedOrderTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/TestCase/CancelCreatedOrderTest.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/TestCase/CancelCreatedOrderTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/TestCase/CancelCreatedOrderTest.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/TestCase/CancelCreatedOrderTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/TestCase/CancelCreatedOrderTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/TestCase/CancelCreatedOrderTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/TestCase/CancelCreatedOrderTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/TestCase/CancelCreatedOrderTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/TestCase/CancelCreatedOrderTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/TestCase/CancelCreatedOrderTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/TestCase/CreateOrderFromBackendCustomerPageTest.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/TestCase/CreateOrderFromBackendCustomerPageTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/TestCase/CreateOrderFromBackendCustomerPageTest.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/TestCase/CreateOrderFromBackendCustomerPageTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/TestCase/CreateOrderFromBackendCustomerPageTest.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/TestCase/CreateOrderFromBackendCustomerPageTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/TestCase/CreateOrderFromBackendCustomerPageTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/TestCase/CreateOrderFromBackendCustomerPageTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/TestCase/CreateOrderFromBackendCustomerPageTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/TestCase/CreateOrderFromBackendCustomerPageTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/TestCase/CreateOrderFromBackendCustomerPageTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/TestCase/CreateOrderFromBackendCustomerPageTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/TestCase/CreateOrderFromBackendWithinOfflinePaymentMethodsTest.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/TestCase/CreateOrderFromBackendWithinOfflinePaymentMethodsTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/TestCase/CreateOrderFromBackendWithinOfflinePaymentMethodsTest.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/TestCase/CreateOrderFromBackendWithinOfflinePaymentMethodsTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/TestCase/CreateOrderFromBackendWithinOfflinePaymentMethodsTest.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/TestCase/CreateOrderFromBackendWithinOfflinePaymentMethodsTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/TestCase/CreateOrderFromBackendWithinOfflinePaymentMethodsTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/TestCase/CreateOrderFromBackendWithinOfflinePaymentMethodsTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/TestCase/CreateOrderFromBackendWithinOfflinePaymentMethodsTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/TestCase/CreateOrderFromBackendWithinOfflinePaymentMethodsTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/TestCase/CreateOrderFromBackendWithinOfflinePaymentMethodsTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/TestCase/CreateOrderFromBackendWithinOfflinePaymentMethodsTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/TestCase/MoveShoppingCartProductsOnOrderPageTest.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/TestCase/MoveShoppingCartProductsOnOrderPageTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/TestCase/MoveShoppingCartProductsOnOrderPageTest.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/TestCase/MoveShoppingCartProductsOnOrderPageTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/TestCase/MoveShoppingCartProductsOnOrderPageTest.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/TestCase/MoveShoppingCartProductsOnOrderPageTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/TestCase/MoveShoppingCartProductsOnOrderPageTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/TestCase/MoveShoppingCartProductsOnOrderPageTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/TestCase/MoveShoppingCartProductsOnOrderPageTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/TestCase/MoveShoppingCartProductsOnOrderPageTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/TestCase/MoveShoppingCartProductsOnOrderPageTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/TestCase/MoveShoppingCartProductsOnOrderPageTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/TestCase/ReorderOrderEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/TestCase/ReorderOrderEntityTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/TestCase/ReorderOrderEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/TestCase/ReorderOrderEntityTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/TestCase/ReorderOrderEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/TestCase/ReorderOrderEntityTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/TestCase/ReorderOrderEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/TestCase/ReorderOrderEntityTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/TestCase/ReorderOrderEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/TestCase/ReorderOrderEntityTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/TestCase/ReorderOrderEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/TestCase/ReorderOrderEntityTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/AbstractCreateRefundStep.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/AbstractCreateRefundStep.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/AbstractCreateRefundStep.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/AbstractCreateRefundStep.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/AbstractCreateRefundStep.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/AbstractCreateRefundStep.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/AbstractCreateSalesEntityStep.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/AbstractCreateSalesEntityStep.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/AbstractCreateSalesEntityStep.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/AbstractCreateSalesEntityStep.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/AbstractCreateSalesEntityStep.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/AbstractCreateSalesEntityStep.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/AddProductsStep.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/AddProductsStep.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/AddProductsStep.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/AddProductsStep.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/AddProductsStep.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/AddProductsStep.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/CreateInvoiceStep.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/CreateInvoiceStep.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/CreateInvoiceStep.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/CreateInvoiceStep.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/CreateInvoiceStep.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/CreateInvoiceStep.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/CreateNewOrderStep.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/CreateNewOrderStep.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/CreateNewOrderStep.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/CreateNewOrderStep.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/CreateNewOrderStep.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/CreateNewOrderStep.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/CreateNewOrderViaCurlStep.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/CreateNewOrderViaCurlStep.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/CreateNewOrderViaCurlStep.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/CreateNewOrderViaCurlStep.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/CreateNewOrderViaCurlStep.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/CreateNewOrderViaCurlStep.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/CreateOfflineRefundStep.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/CreateOfflineRefundStep.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/CreateOfflineRefundStep.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/CreateOfflineRefundStep.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/CreateOfflineRefundStep.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/CreateOfflineRefundStep.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/CreateOnlineRefundStep.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/CreateOnlineRefundStep.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/CreateOnlineRefundStep.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/CreateOnlineRefundStep.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/CreateOnlineRefundStep.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/CreateOnlineRefundStep.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/FillBillingAddressStep.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/FillBillingAddressStep.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/FillBillingAddressStep.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/FillBillingAddressStep.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/FillBillingAddressStep.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/FillBillingAddressStep.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/MoveProductsFromShoppingCartSidebarStep.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/MoveProductsFromShoppingCartSidebarStep.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/MoveProductsFromShoppingCartSidebarStep.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/MoveProductsFromShoppingCartSidebarStep.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/MoveProductsFromShoppingCartSidebarStep.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/MoveProductsFromShoppingCartSidebarStep.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/OpenOrderStep.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/OpenOrderStep.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/OpenOrderStep.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/OpenOrderStep.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/OpenOrderStep.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/OpenOrderStep.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/OpenSalesOrderOnFrontendForGuestStep.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/OpenSalesOrderOnFrontendForGuestStep.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/OpenSalesOrderOnFrontendForGuestStep.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/OpenSalesOrderOnFrontendForGuestStep.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/OpenSalesOrderOnFrontendForGuestStep.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/OpenSalesOrderOnFrontendForGuestStep.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/OpenSalesOrdersStep.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/OpenSalesOrdersStep.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/OpenSalesOrdersStep.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/OpenSalesOrdersStep.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/OpenSalesOrdersStep.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/OpenSalesOrdersStep.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/PrintOrderOnFrontendStep.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/PrintOrderOnFrontendStep.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/PrintOrderOnFrontendStep.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/PrintOrderOnFrontendStep.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/PrintOrderOnFrontendStep.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/PrintOrderOnFrontendStep.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/ReorderOrderStep.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/ReorderOrderStep.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/ReorderOrderStep.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/ReorderOrderStep.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/ReorderOrderStep.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/ReorderOrderStep.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/SelectCustomerOrderStep.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/SelectCustomerOrderStep.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/SelectCustomerOrderStep.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/SelectCustomerOrderStep.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/SelectCustomerOrderStep.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/SelectCustomerOrderStep.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/SelectPaymentMethodForOrderStep.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/SelectPaymentMethodForOrderStep.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/SelectPaymentMethodForOrderStep.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/SelectPaymentMethodForOrderStep.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/SelectPaymentMethodForOrderStep.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/SelectPaymentMethodForOrderStep.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/SelectShippingMethodForOrderStep.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/SelectShippingMethodForOrderStep.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/SelectShippingMethodForOrderStep.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/SelectShippingMethodForOrderStep.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/SelectShippingMethodForOrderStep.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/SelectShippingMethodForOrderStep.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/SelectStoreOnCreateOrderStep.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/SelectStoreOnCreateOrderStep.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/SelectStoreOnCreateOrderStep.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/SelectStoreOnCreateOrderStep.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/SelectStoreOnCreateOrderStep.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/SelectStoreOnCreateOrderStep.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/SubmitOrderStep.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/SubmitOrderStep.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/SubmitOrderStep.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/SubmitOrderStep.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/SubmitOrderStep.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/SubmitOrderStep.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/UpdateProductsDataStep.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/UpdateProductsDataStep.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/UpdateProductsDataStep.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/UpdateProductsDataStep.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/UpdateProductsDataStep.php
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/TestStep/UpdateProductsDataStep.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/etc/curl/di.xml
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/etc/curl/di.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/etc/curl/di.xml
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/etc/curl/di.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/etc/curl/di.xml
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/etc/curl/di.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/etc/fixture.xml
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/etc/fixture.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/etc/fixture.xml
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/etc/fixture.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/etc/fixture.xml
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/etc/fixture.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/etc/testcase.xml
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/etc/testcase.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/etc/testcase.xml
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/etc/testcase.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sales/Test/etc/testcase.xml
+++ b/dev/tests/functional/tests/app/Mage/Sales/Test/etc/testcase.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/SalesRule/Test/Constraint/AbstractCartPriceRuleApplying.php
+++ b/dev/tests/functional/tests/app/Mage/SalesRule/Test/Constraint/AbstractCartPriceRuleApplying.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/SalesRule/Test/Constraint/AbstractCartPriceRuleApplying.php
+++ b/dev/tests/functional/tests/app/Mage/SalesRule/Test/Constraint/AbstractCartPriceRuleApplying.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/SalesRule/Test/Constraint/AbstractCartPriceRuleApplying.php
+++ b/dev/tests/functional/tests/app/Mage/SalesRule/Test/Constraint/AbstractCartPriceRuleApplying.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/SalesRule/Test/Constraint/AssertCartPriceRuleConditionIsApplied.php
+++ b/dev/tests/functional/tests/app/Mage/SalesRule/Test/Constraint/AssertCartPriceRuleConditionIsApplied.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/SalesRule/Test/Constraint/AssertCartPriceRuleConditionIsApplied.php
+++ b/dev/tests/functional/tests/app/Mage/SalesRule/Test/Constraint/AssertCartPriceRuleConditionIsApplied.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/SalesRule/Test/Constraint/AssertCartPriceRuleConditionIsApplied.php
+++ b/dev/tests/functional/tests/app/Mage/SalesRule/Test/Constraint/AssertCartPriceRuleConditionIsApplied.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/SalesRule/Test/Constraint/AssertCartPriceRuleConditionIsNotApplied.php
+++ b/dev/tests/functional/tests/app/Mage/SalesRule/Test/Constraint/AssertCartPriceRuleConditionIsNotApplied.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/SalesRule/Test/Constraint/AssertCartPriceRuleConditionIsNotApplied.php
+++ b/dev/tests/functional/tests/app/Mage/SalesRule/Test/Constraint/AssertCartPriceRuleConditionIsNotApplied.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/SalesRule/Test/Constraint/AssertCartPriceRuleConditionIsNotApplied.php
+++ b/dev/tests/functional/tests/app/Mage/SalesRule/Test/Constraint/AssertCartPriceRuleConditionIsNotApplied.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/SalesRule/Test/Constraint/AssertCartPriceRuleForm.php
+++ b/dev/tests/functional/tests/app/Mage/SalesRule/Test/Constraint/AssertCartPriceRuleForm.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/SalesRule/Test/Constraint/AssertCartPriceRuleForm.php
+++ b/dev/tests/functional/tests/app/Mage/SalesRule/Test/Constraint/AssertCartPriceRuleForm.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/SalesRule/Test/Constraint/AssertCartPriceRuleForm.php
+++ b/dev/tests/functional/tests/app/Mage/SalesRule/Test/Constraint/AssertCartPriceRuleForm.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/SalesRule/Test/Constraint/AssertCartPriceRuleFreeShippingIsApplied.php
+++ b/dev/tests/functional/tests/app/Mage/SalesRule/Test/Constraint/AssertCartPriceRuleFreeShippingIsApplied.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/SalesRule/Test/Constraint/AssertCartPriceRuleFreeShippingIsApplied.php
+++ b/dev/tests/functional/tests/app/Mage/SalesRule/Test/Constraint/AssertCartPriceRuleFreeShippingIsApplied.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/SalesRule/Test/Constraint/AssertCartPriceRuleFreeShippingIsApplied.php
+++ b/dev/tests/functional/tests/app/Mage/SalesRule/Test/Constraint/AssertCartPriceRuleFreeShippingIsApplied.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/SalesRule/Test/Constraint/AssertCartPriceRuleIsAppliedToShipping.php
+++ b/dev/tests/functional/tests/app/Mage/SalesRule/Test/Constraint/AssertCartPriceRuleIsAppliedToShipping.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/SalesRule/Test/Constraint/AssertCartPriceRuleIsAppliedToShipping.php
+++ b/dev/tests/functional/tests/app/Mage/SalesRule/Test/Constraint/AssertCartPriceRuleIsAppliedToShipping.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/SalesRule/Test/Constraint/AssertCartPriceRuleIsAppliedToShipping.php
+++ b/dev/tests/functional/tests/app/Mage/SalesRule/Test/Constraint/AssertCartPriceRuleIsAppliedToShipping.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/SalesRule/Test/Constraint/AssertCartPriceRuleIsNotPresentedInGrid.php
+++ b/dev/tests/functional/tests/app/Mage/SalesRule/Test/Constraint/AssertCartPriceRuleIsNotPresentedInGrid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/SalesRule/Test/Constraint/AssertCartPriceRuleIsNotPresentedInGrid.php
+++ b/dev/tests/functional/tests/app/Mage/SalesRule/Test/Constraint/AssertCartPriceRuleIsNotPresentedInGrid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/SalesRule/Test/Constraint/AssertCartPriceRuleIsNotPresentedInGrid.php
+++ b/dev/tests/functional/tests/app/Mage/SalesRule/Test/Constraint/AssertCartPriceRuleIsNotPresentedInGrid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/SalesRule/Test/Constraint/AssertCartPriceRuleSuccessDeleteMessage.php
+++ b/dev/tests/functional/tests/app/Mage/SalesRule/Test/Constraint/AssertCartPriceRuleSuccessDeleteMessage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/SalesRule/Test/Constraint/AssertCartPriceRuleSuccessDeleteMessage.php
+++ b/dev/tests/functional/tests/app/Mage/SalesRule/Test/Constraint/AssertCartPriceRuleSuccessDeleteMessage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/SalesRule/Test/Constraint/AssertCartPriceRuleSuccessDeleteMessage.php
+++ b/dev/tests/functional/tests/app/Mage/SalesRule/Test/Constraint/AssertCartPriceRuleSuccessDeleteMessage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/SalesRule/Test/Constraint/AssertCartPriceRuleSuccessSaveMessage.php
+++ b/dev/tests/functional/tests/app/Mage/SalesRule/Test/Constraint/AssertCartPriceRuleSuccessSaveMessage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/SalesRule/Test/Constraint/AssertCartPriceRuleSuccessSaveMessage.php
+++ b/dev/tests/functional/tests/app/Mage/SalesRule/Test/Constraint/AssertCartPriceRuleSuccessSaveMessage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/SalesRule/Test/Constraint/AssertCartPriceRuleSuccessSaveMessage.php
+++ b/dev/tests/functional/tests/app/Mage/SalesRule/Test/Constraint/AssertCartPriceRuleSuccessSaveMessage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/SalesRule/Test/Fixture/SalesRule.xml
+++ b/dev/tests/functional/tests/app/Mage/SalesRule/Test/Fixture/SalesRule.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/SalesRule/Test/Fixture/SalesRule.xml
+++ b/dev/tests/functional/tests/app/Mage/SalesRule/Test/Fixture/SalesRule.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/SalesRule/Test/Fixture/SalesRule.xml
+++ b/dev/tests/functional/tests/app/Mage/SalesRule/Test/Fixture/SalesRule.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/SalesRule/Test/Fixture/SalesRule/WebsiteIds.php
+++ b/dev/tests/functional/tests/app/Mage/SalesRule/Test/Fixture/SalesRule/WebsiteIds.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/SalesRule/Test/Fixture/SalesRule/WebsiteIds.php
+++ b/dev/tests/functional/tests/app/Mage/SalesRule/Test/Fixture/SalesRule/WebsiteIds.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/SalesRule/Test/Fixture/SalesRule/WebsiteIds.php
+++ b/dev/tests/functional/tests/app/Mage/SalesRule/Test/Fixture/SalesRule/WebsiteIds.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/SalesRule/Test/Handler/SalesRule/Curl.php
+++ b/dev/tests/functional/tests/app/Mage/SalesRule/Test/Handler/SalesRule/Curl.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/SalesRule/Test/Handler/SalesRule/Curl.php
+++ b/dev/tests/functional/tests/app/Mage/SalesRule/Test/Handler/SalesRule/Curl.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/SalesRule/Test/Handler/SalesRule/Curl.php
+++ b/dev/tests/functional/tests/app/Mage/SalesRule/Test/Handler/SalesRule/Curl.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/SalesRule/Test/Handler/SalesRule/SalesRuleInterface.php
+++ b/dev/tests/functional/tests/app/Mage/SalesRule/Test/Handler/SalesRule/SalesRuleInterface.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/SalesRule/Test/Handler/SalesRule/SalesRuleInterface.php
+++ b/dev/tests/functional/tests/app/Mage/SalesRule/Test/Handler/SalesRule/SalesRuleInterface.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/SalesRule/Test/Handler/SalesRule/SalesRuleInterface.php
+++ b/dev/tests/functional/tests/app/Mage/SalesRule/Test/Handler/SalesRule/SalesRuleInterface.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/SalesRule/Test/Page/Adminhtml/PromoQuoteEdit.xml
+++ b/dev/tests/functional/tests/app/Mage/SalesRule/Test/Page/Adminhtml/PromoQuoteEdit.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/SalesRule/Test/Page/Adminhtml/PromoQuoteEdit.xml
+++ b/dev/tests/functional/tests/app/Mage/SalesRule/Test/Page/Adminhtml/PromoQuoteEdit.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/SalesRule/Test/Page/Adminhtml/PromoQuoteEdit.xml
+++ b/dev/tests/functional/tests/app/Mage/SalesRule/Test/Page/Adminhtml/PromoQuoteEdit.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/SalesRule/Test/Page/Adminhtml/PromoQuoteIndex.xml
+++ b/dev/tests/functional/tests/app/Mage/SalesRule/Test/Page/Adminhtml/PromoQuoteIndex.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/SalesRule/Test/Page/Adminhtml/PromoQuoteIndex.xml
+++ b/dev/tests/functional/tests/app/Mage/SalesRule/Test/Page/Adminhtml/PromoQuoteIndex.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/SalesRule/Test/Page/Adminhtml/PromoQuoteIndex.xml
+++ b/dev/tests/functional/tests/app/Mage/SalesRule/Test/Page/Adminhtml/PromoQuoteIndex.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/SalesRule/Test/Page/Adminhtml/PromoQuoteNew.xml
+++ b/dev/tests/functional/tests/app/Mage/SalesRule/Test/Page/Adminhtml/PromoQuoteNew.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/SalesRule/Test/Page/Adminhtml/PromoQuoteNew.xml
+++ b/dev/tests/functional/tests/app/Mage/SalesRule/Test/Page/Adminhtml/PromoQuoteNew.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/SalesRule/Test/Page/Adminhtml/PromoQuoteNew.xml
+++ b/dev/tests/functional/tests/app/Mage/SalesRule/Test/Page/Adminhtml/PromoQuoteNew.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/SalesRule/Test/Repository/SalesRule.xml
+++ b/dev/tests/functional/tests/app/Mage/SalesRule/Test/Repository/SalesRule.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/SalesRule/Test/Repository/SalesRule.xml
+++ b/dev/tests/functional/tests/app/Mage/SalesRule/Test/Repository/SalesRule.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/SalesRule/Test/Repository/SalesRule.xml
+++ b/dev/tests/functional/tests/app/Mage/SalesRule/Test/Repository/SalesRule.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/SalesRule/Test/TestCase/CreateSalesRuleEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/SalesRule/Test/TestCase/CreateSalesRuleEntityTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/SalesRule/Test/TestCase/CreateSalesRuleEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/SalesRule/Test/TestCase/CreateSalesRuleEntityTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/SalesRule/Test/TestCase/CreateSalesRuleEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/SalesRule/Test/TestCase/CreateSalesRuleEntityTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/SalesRule/Test/TestCase/CreateSalesRuleEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/SalesRule/Test/TestCase/CreateSalesRuleEntityTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/SalesRule/Test/TestCase/CreateSalesRuleEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/SalesRule/Test/TestCase/CreateSalesRuleEntityTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/SalesRule/Test/TestCase/CreateSalesRuleEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/SalesRule/Test/TestCase/CreateSalesRuleEntityTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/SalesRule/Test/TestCase/DeleteSalesRuleEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/SalesRule/Test/TestCase/DeleteSalesRuleEntityTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/SalesRule/Test/TestCase/DeleteSalesRuleEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/SalesRule/Test/TestCase/DeleteSalesRuleEntityTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/SalesRule/Test/TestCase/DeleteSalesRuleEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/SalesRule/Test/TestCase/DeleteSalesRuleEntityTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/SalesRule/Test/TestCase/DeleteSalesRuleEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/SalesRule/Test/TestCase/DeleteSalesRuleEntityTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/SalesRule/Test/TestCase/DeleteSalesRuleEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/SalesRule/Test/TestCase/DeleteSalesRuleEntityTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/SalesRule/Test/TestCase/DeleteSalesRuleEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/SalesRule/Test/TestCase/DeleteSalesRuleEntityTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/SalesRule/Test/TestCase/ReorderOrderEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/SalesRule/Test/TestCase/ReorderOrderEntityTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/SalesRule/Test/TestCase/ReorderOrderEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/SalesRule/Test/TestCase/ReorderOrderEntityTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/SalesRule/Test/TestCase/ReorderOrderEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/SalesRule/Test/TestCase/ReorderOrderEntityTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/SalesRule/Test/TestStep/ApplySalesRuleOnBackendStep.php
+++ b/dev/tests/functional/tests/app/Mage/SalesRule/Test/TestStep/ApplySalesRuleOnBackendStep.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/SalesRule/Test/TestStep/ApplySalesRuleOnBackendStep.php
+++ b/dev/tests/functional/tests/app/Mage/SalesRule/Test/TestStep/ApplySalesRuleOnBackendStep.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/SalesRule/Test/TestStep/ApplySalesRuleOnBackendStep.php
+++ b/dev/tests/functional/tests/app/Mage/SalesRule/Test/TestStep/ApplySalesRuleOnBackendStep.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/SalesRule/Test/TestStep/ApplySalesRuleOnFrontendStep.php
+++ b/dev/tests/functional/tests/app/Mage/SalesRule/Test/TestStep/ApplySalesRuleOnFrontendStep.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/SalesRule/Test/TestStep/ApplySalesRuleOnFrontendStep.php
+++ b/dev/tests/functional/tests/app/Mage/SalesRule/Test/TestStep/ApplySalesRuleOnFrontendStep.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/SalesRule/Test/TestStep/ApplySalesRuleOnFrontendStep.php
+++ b/dev/tests/functional/tests/app/Mage/SalesRule/Test/TestStep/ApplySalesRuleOnFrontendStep.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/SalesRule/Test/TestStep/CreateSalesRuleStep.php
+++ b/dev/tests/functional/tests/app/Mage/SalesRule/Test/TestStep/CreateSalesRuleStep.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/SalesRule/Test/TestStep/CreateSalesRuleStep.php
+++ b/dev/tests/functional/tests/app/Mage/SalesRule/Test/TestStep/CreateSalesRuleStep.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/SalesRule/Test/TestStep/CreateSalesRuleStep.php
+++ b/dev/tests/functional/tests/app/Mage/SalesRule/Test/TestStep/CreateSalesRuleStep.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/SalesRule/Test/TestStep/DeleteAllSalesRuleStep.php
+++ b/dev/tests/functional/tests/app/Mage/SalesRule/Test/TestStep/DeleteAllSalesRuleStep.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/SalesRule/Test/TestStep/DeleteAllSalesRuleStep.php
+++ b/dev/tests/functional/tests/app/Mage/SalesRule/Test/TestStep/DeleteAllSalesRuleStep.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/SalesRule/Test/TestStep/DeleteAllSalesRuleStep.php
+++ b/dev/tests/functional/tests/app/Mage/SalesRule/Test/TestStep/DeleteAllSalesRuleStep.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/SalesRule/Test/etc/curl/di.xml
+++ b/dev/tests/functional/tests/app/Mage/SalesRule/Test/etc/curl/di.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/SalesRule/Test/etc/curl/di.xml
+++ b/dev/tests/functional/tests/app/Mage/SalesRule/Test/etc/curl/di.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/SalesRule/Test/etc/curl/di.xml
+++ b/dev/tests/functional/tests/app/Mage/SalesRule/Test/etc/curl/di.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/SalesRule/Test/etc/fixture.xml
+++ b/dev/tests/functional/tests/app/Mage/SalesRule/Test/etc/fixture.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/SalesRule/Test/etc/fixture.xml
+++ b/dev/tests/functional/tests/app/Mage/SalesRule/Test/etc/fixture.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/SalesRule/Test/etc/fixture.xml
+++ b/dev/tests/functional/tests/app/Mage/SalesRule/Test/etc/fixture.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/SalesRule/Test/etc/testcase.xml
+++ b/dev/tests/functional/tests/app/Mage/SalesRule/Test/etc/testcase.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/SalesRule/Test/etc/testcase.xml
+++ b/dev/tests/functional/tests/app/Mage/SalesRule/Test/etc/testcase.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/SalesRule/Test/etc/testcase.xml
+++ b/dev/tests/functional/tests/app/Mage/SalesRule/Test/etc/testcase.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Shipping/Test/Block/Sales/Order/Shipments.php
+++ b/dev/tests/functional/tests/app/Mage/Shipping/Test/Block/Sales/Order/Shipments.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Shipping/Test/Block/Sales/Order/Shipments.php
+++ b/dev/tests/functional/tests/app/Mage/Shipping/Test/Block/Sales/Order/Shipments.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Shipping/Test/Block/Sales/Order/Shipments.php
+++ b/dev/tests/functional/tests/app/Mage/Shipping/Test/Block/Sales/Order/Shipments.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Shipping/Test/Block/Sales/Order/Shipments/Shipment.php
+++ b/dev/tests/functional/tests/app/Mage/Shipping/Test/Block/Sales/Order/Shipments/Shipment.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Shipping/Test/Block/Sales/Order/Shipments/Shipment.php
+++ b/dev/tests/functional/tests/app/Mage/Shipping/Test/Block/Sales/Order/Shipments/Shipment.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Shipping/Test/Block/Sales/Order/Shipments/Shipment.php
+++ b/dev/tests/functional/tests/app/Mage/Shipping/Test/Block/Sales/Order/Shipments/Shipment.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Shipping/Test/Block/Sales/Order/Shipments/Shipment/Items.php
+++ b/dev/tests/functional/tests/app/Mage/Shipping/Test/Block/Sales/Order/Shipments/Shipment/Items.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Shipping/Test/Block/Sales/Order/Shipments/Shipment/Items.php
+++ b/dev/tests/functional/tests/app/Mage/Shipping/Test/Block/Sales/Order/Shipments/Shipment/Items.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Shipping/Test/Block/Sales/Order/Shipments/Shipment/Items.php
+++ b/dev/tests/functional/tests/app/Mage/Shipping/Test/Block/Sales/Order/Shipments/Shipment/Items.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Shipping/Test/Block/Sales/Order/Shipments/Shipment/Items/Product.php
+++ b/dev/tests/functional/tests/app/Mage/Shipping/Test/Block/Sales/Order/Shipments/Shipment/Items/Product.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Shipping/Test/Block/Sales/Order/Shipments/Shipment/Items/Product.php
+++ b/dev/tests/functional/tests/app/Mage/Shipping/Test/Block/Sales/Order/Shipments/Shipment/Items/Product.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Shipping/Test/Block/Sales/Order/Shipments/Shipment/Items/Product.php
+++ b/dev/tests/functional/tests/app/Mage/Shipping/Test/Block/Sales/Order/Shipments/Shipment/Items/Product.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Shipping/Test/Constraint/AssertNoShipButton.php
+++ b/dev/tests/functional/tests/app/Mage/Shipping/Test/Constraint/AssertNoShipButton.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Shipping/Test/Constraint/AssertNoShipButton.php
+++ b/dev/tests/functional/tests/app/Mage/Shipping/Test/Constraint/AssertNoShipButton.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Shipping/Test/Constraint/AssertNoShipButton.php
+++ b/dev/tests/functional/tests/app/Mage/Shipping/Test/Constraint/AssertNoShipButton.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Shipping/Test/Constraint/AssertShipmentConfigurableItems.php
+++ b/dev/tests/functional/tests/app/Mage/Shipping/Test/Constraint/AssertShipmentConfigurableItems.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Shipping/Test/Constraint/AssertShipmentConfigurableItems.php
+++ b/dev/tests/functional/tests/app/Mage/Shipping/Test/Constraint/AssertShipmentConfigurableItems.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Shipping/Test/Constraint/AssertShipmentConfigurableItems.php
+++ b/dev/tests/functional/tests/app/Mage/Shipping/Test/Constraint/AssertShipmentConfigurableItems.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Shipping/Test/Constraint/AssertShipmentConfigurableItemsOnFrontend.php
+++ b/dev/tests/functional/tests/app/Mage/Shipping/Test/Constraint/AssertShipmentConfigurableItemsOnFrontend.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Shipping/Test/Constraint/AssertShipmentConfigurableItemsOnFrontend.php
+++ b/dev/tests/functional/tests/app/Mage/Shipping/Test/Constraint/AssertShipmentConfigurableItemsOnFrontend.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Shipping/Test/Constraint/AssertShipmentConfigurableItemsOnFrontend.php
+++ b/dev/tests/functional/tests/app/Mage/Shipping/Test/Constraint/AssertShipmentConfigurableItemsOnFrontend.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Shipping/Test/Constraint/AssertShipmentInShipmentsGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Shipping/Test/Constraint/AssertShipmentInShipmentsGrid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Shipping/Test/Constraint/AssertShipmentInShipmentsGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Shipping/Test/Constraint/AssertShipmentInShipmentsGrid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Shipping/Test/Constraint/AssertShipmentInShipmentsGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Shipping/Test/Constraint/AssertShipmentInShipmentsGrid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Shipping/Test/Constraint/AssertShipmentInShipmentsTab.php
+++ b/dev/tests/functional/tests/app/Mage/Shipping/Test/Constraint/AssertShipmentInShipmentsTab.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Shipping/Test/Constraint/AssertShipmentInShipmentsTab.php
+++ b/dev/tests/functional/tests/app/Mage/Shipping/Test/Constraint/AssertShipmentInShipmentsTab.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Shipping/Test/Constraint/AssertShipmentInShipmentsTab.php
+++ b/dev/tests/functional/tests/app/Mage/Shipping/Test/Constraint/AssertShipmentInShipmentsTab.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Shipping/Test/Constraint/AssertShipmentItems.php
+++ b/dev/tests/functional/tests/app/Mage/Shipping/Test/Constraint/AssertShipmentItems.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Shipping/Test/Constraint/AssertShipmentItems.php
+++ b/dev/tests/functional/tests/app/Mage/Shipping/Test/Constraint/AssertShipmentItems.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Shipping/Test/Constraint/AssertShipmentItems.php
+++ b/dev/tests/functional/tests/app/Mage/Shipping/Test/Constraint/AssertShipmentItems.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Shipping/Test/Constraint/AssertShipmentItemsOnFrontend.php
+++ b/dev/tests/functional/tests/app/Mage/Shipping/Test/Constraint/AssertShipmentItemsOnFrontend.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Shipping/Test/Constraint/AssertShipmentItemsOnFrontend.php
+++ b/dev/tests/functional/tests/app/Mage/Shipping/Test/Constraint/AssertShipmentItemsOnFrontend.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Shipping/Test/Constraint/AssertShipmentItemsOnFrontend.php
+++ b/dev/tests/functional/tests/app/Mage/Shipping/Test/Constraint/AssertShipmentItemsOnFrontend.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Shipping/Test/Constraint/AssertShipmentSuccessCreateMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Shipping/Test/Constraint/AssertShipmentSuccessCreateMessage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Shipping/Test/Constraint/AssertShipmentSuccessCreateMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Shipping/Test/Constraint/AssertShipmentSuccessCreateMessage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Shipping/Test/Constraint/AssertShipmentSuccessCreateMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Shipping/Test/Constraint/AssertShipmentSuccessCreateMessage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Shipping/Test/Constraint/AssertShippingMethodOnPrintOrder.php
+++ b/dev/tests/functional/tests/app/Mage/Shipping/Test/Constraint/AssertShippingMethodOnPrintOrder.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Shipping/Test/Constraint/AssertShippingMethodOnPrintOrder.php
+++ b/dev/tests/functional/tests/app/Mage/Shipping/Test/Constraint/AssertShippingMethodOnPrintOrder.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Shipping/Test/Constraint/AssertShippingMethodOnPrintOrder.php
+++ b/dev/tests/functional/tests/app/Mage/Shipping/Test/Constraint/AssertShippingMethodOnPrintOrder.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Shipping/Test/Page/Adminhtml/SalesOrderShipmentNew.xml
+++ b/dev/tests/functional/tests/app/Mage/Shipping/Test/Page/Adminhtml/SalesOrderShipmentNew.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Shipping/Test/Page/Adminhtml/SalesOrderShipmentNew.xml
+++ b/dev/tests/functional/tests/app/Mage/Shipping/Test/Page/Adminhtml/SalesOrderShipmentNew.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Shipping/Test/Page/Adminhtml/SalesOrderShipmentNew.xml
+++ b/dev/tests/functional/tests/app/Mage/Shipping/Test/Page/Adminhtml/SalesOrderShipmentNew.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Shipping/Test/Page/Adminhtml/SalesShipment.xml
+++ b/dev/tests/functional/tests/app/Mage/Shipping/Test/Page/Adminhtml/SalesShipment.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Shipping/Test/Page/Adminhtml/SalesShipment.xml
+++ b/dev/tests/functional/tests/app/Mage/Shipping/Test/Page/Adminhtml/SalesShipment.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Shipping/Test/Page/Adminhtml/SalesShipment.xml
+++ b/dev/tests/functional/tests/app/Mage/Shipping/Test/Page/Adminhtml/SalesShipment.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Shipping/Test/Page/Adminhtml/SalesShipmentView.xml
+++ b/dev/tests/functional/tests/app/Mage/Shipping/Test/Page/Adminhtml/SalesShipmentView.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Shipping/Test/Page/Adminhtml/SalesShipmentView.xml
+++ b/dev/tests/functional/tests/app/Mage/Shipping/Test/Page/Adminhtml/SalesShipmentView.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Shipping/Test/Page/Adminhtml/SalesShipmentView.xml
+++ b/dev/tests/functional/tests/app/Mage/Shipping/Test/Page/Adminhtml/SalesShipmentView.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Shipping/Test/Page/ShipmentView.xml
+++ b/dev/tests/functional/tests/app/Mage/Shipping/Test/Page/ShipmentView.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Shipping/Test/Page/ShipmentView.xml
+++ b/dev/tests/functional/tests/app/Mage/Shipping/Test/Page/ShipmentView.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Shipping/Test/Page/ShipmentView.xml
+++ b/dev/tests/functional/tests/app/Mage/Shipping/Test/Page/ShipmentView.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Shipping/Test/Repository/ConfigData.xml
+++ b/dev/tests/functional/tests/app/Mage/Shipping/Test/Repository/ConfigData.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Shipping/Test/Repository/ConfigData.xml
+++ b/dev/tests/functional/tests/app/Mage/Shipping/Test/Repository/ConfigData.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Shipping/Test/Repository/ConfigData.xml
+++ b/dev/tests/functional/tests/app/Mage/Shipping/Test/Repository/ConfigData.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Shipping/Test/TestStep/CreateShipmentStep.php
+++ b/dev/tests/functional/tests/app/Mage/Shipping/Test/TestStep/CreateShipmentStep.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Shipping/Test/TestStep/CreateShipmentStep.php
+++ b/dev/tests/functional/tests/app/Mage/Shipping/Test/TestStep/CreateShipmentStep.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Shipping/Test/TestStep/CreateShipmentStep.php
+++ b/dev/tests/functional/tests/app/Mage/Shipping/Test/TestStep/CreateShipmentStep.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sitemap/Test/Constraint/AssertSitemapContent.php
+++ b/dev/tests/functional/tests/app/Mage/Sitemap/Test/Constraint/AssertSitemapContent.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sitemap/Test/Constraint/AssertSitemapContent.php
+++ b/dev/tests/functional/tests/app/Mage/Sitemap/Test/Constraint/AssertSitemapContent.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sitemap/Test/Constraint/AssertSitemapContent.php
+++ b/dev/tests/functional/tests/app/Mage/Sitemap/Test/Constraint/AssertSitemapContent.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sitemap/Test/Constraint/AssertSitemapFailFolderSaveMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Sitemap/Test/Constraint/AssertSitemapFailFolderSaveMessage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sitemap/Test/Constraint/AssertSitemapFailFolderSaveMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Sitemap/Test/Constraint/AssertSitemapFailFolderSaveMessage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sitemap/Test/Constraint/AssertSitemapFailFolderSaveMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Sitemap/Test/Constraint/AssertSitemapFailFolderSaveMessage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sitemap/Test/Constraint/AssertSitemapFailPathSaveMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Sitemap/Test/Constraint/AssertSitemapFailPathSaveMessage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sitemap/Test/Constraint/AssertSitemapFailPathSaveMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Sitemap/Test/Constraint/AssertSitemapFailPathSaveMessage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sitemap/Test/Constraint/AssertSitemapFailPathSaveMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Sitemap/Test/Constraint/AssertSitemapFailPathSaveMessage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sitemap/Test/Constraint/AssertSitemapInGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Sitemap/Test/Constraint/AssertSitemapInGrid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sitemap/Test/Constraint/AssertSitemapInGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Sitemap/Test/Constraint/AssertSitemapInGrid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sitemap/Test/Constraint/AssertSitemapInGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Sitemap/Test/Constraint/AssertSitemapInGrid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sitemap/Test/Constraint/AssertSitemapSuccessSaveAndGenerateMessages.php
+++ b/dev/tests/functional/tests/app/Mage/Sitemap/Test/Constraint/AssertSitemapSuccessSaveAndGenerateMessages.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sitemap/Test/Constraint/AssertSitemapSuccessSaveAndGenerateMessages.php
+++ b/dev/tests/functional/tests/app/Mage/Sitemap/Test/Constraint/AssertSitemapSuccessSaveAndGenerateMessages.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sitemap/Test/Constraint/AssertSitemapSuccessSaveAndGenerateMessages.php
+++ b/dev/tests/functional/tests/app/Mage/Sitemap/Test/Constraint/AssertSitemapSuccessSaveAndGenerateMessages.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sitemap/Test/Constraint/AssertSitemapSuccessSaveMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Sitemap/Test/Constraint/AssertSitemapSuccessSaveMessage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sitemap/Test/Constraint/AssertSitemapSuccessSaveMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Sitemap/Test/Constraint/AssertSitemapSuccessSaveMessage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sitemap/Test/Constraint/AssertSitemapSuccessSaveMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Sitemap/Test/Constraint/AssertSitemapSuccessSaveMessage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sitemap/Test/Fixture/Sitemap.xml
+++ b/dev/tests/functional/tests/app/Mage/Sitemap/Test/Fixture/Sitemap.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sitemap/Test/Fixture/Sitemap.xml
+++ b/dev/tests/functional/tests/app/Mage/Sitemap/Test/Fixture/Sitemap.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sitemap/Test/Fixture/Sitemap.xml
+++ b/dev/tests/functional/tests/app/Mage/Sitemap/Test/Fixture/Sitemap.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sitemap/Test/Page/Adminhtml/SitemapIndex.xml
+++ b/dev/tests/functional/tests/app/Mage/Sitemap/Test/Page/Adminhtml/SitemapIndex.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sitemap/Test/Page/Adminhtml/SitemapIndex.xml
+++ b/dev/tests/functional/tests/app/Mage/Sitemap/Test/Page/Adminhtml/SitemapIndex.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sitemap/Test/Page/Adminhtml/SitemapIndex.xml
+++ b/dev/tests/functional/tests/app/Mage/Sitemap/Test/Page/Adminhtml/SitemapIndex.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sitemap/Test/Page/Adminhtml/SitemapNew.xml
+++ b/dev/tests/functional/tests/app/Mage/Sitemap/Test/Page/Adminhtml/SitemapNew.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sitemap/Test/Page/Adminhtml/SitemapNew.xml
+++ b/dev/tests/functional/tests/app/Mage/Sitemap/Test/Page/Adminhtml/SitemapNew.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sitemap/Test/Page/Adminhtml/SitemapNew.xml
+++ b/dev/tests/functional/tests/app/Mage/Sitemap/Test/Page/Adminhtml/SitemapNew.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sitemap/Test/Repository/Sitemap.xml
+++ b/dev/tests/functional/tests/app/Mage/Sitemap/Test/Repository/Sitemap.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sitemap/Test/Repository/Sitemap.xml
+++ b/dev/tests/functional/tests/app/Mage/Sitemap/Test/Repository/Sitemap.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sitemap/Test/Repository/Sitemap.xml
+++ b/dev/tests/functional/tests/app/Mage/Sitemap/Test/Repository/Sitemap.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sitemap/Test/TestCase/CreateSitemapEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Sitemap/Test/TestCase/CreateSitemapEntityTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sitemap/Test/TestCase/CreateSitemapEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Sitemap/Test/TestCase/CreateSitemapEntityTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sitemap/Test/TestCase/CreateSitemapEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Sitemap/Test/TestCase/CreateSitemapEntityTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sitemap/Test/TestCase/CreateSitemapEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Sitemap/Test/TestCase/CreateSitemapEntityTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sitemap/Test/TestCase/CreateSitemapEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Sitemap/Test/TestCase/CreateSitemapEntityTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sitemap/Test/TestCase/CreateSitemapEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Sitemap/Test/TestCase/CreateSitemapEntityTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sitemap/Test/TestCase/GenerateSitemapEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Sitemap/Test/TestCase/GenerateSitemapEntityTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sitemap/Test/TestCase/GenerateSitemapEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Sitemap/Test/TestCase/GenerateSitemapEntityTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sitemap/Test/TestCase/GenerateSitemapEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Sitemap/Test/TestCase/GenerateSitemapEntityTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sitemap/Test/TestCase/GenerateSitemapEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Sitemap/Test/TestCase/GenerateSitemapEntityTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sitemap/Test/TestCase/GenerateSitemapEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Sitemap/Test/TestCase/GenerateSitemapEntityTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sitemap/Test/TestCase/GenerateSitemapEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Sitemap/Test/TestCase/GenerateSitemapEntityTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sitemap/Test/etc/fixture.xml
+++ b/dev/tests/functional/tests/app/Mage/Sitemap/Test/etc/fixture.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Sitemap/Test/etc/fixture.xml
+++ b/dev/tests/functional/tests/app/Mage/Sitemap/Test/etc/fixture.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Sitemap/Test/etc/fixture.xml
+++ b/dev/tests/functional/tests/app/Mage/Sitemap/Test/etc/fixture.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AbstractAssertOrderTaxOnBackend.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AbstractAssertOrderTaxOnBackend.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AbstractAssertOrderTaxOnBackend.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AbstractAssertOrderTaxOnBackend.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AbstractAssertOrderTaxOnBackend.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AbstractAssertOrderTaxOnBackend.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AbstractAssertTax.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AbstractAssertTax.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AbstractAssertTax.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AbstractAssertTax.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AbstractAssertTax.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AbstractAssertTax.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AbstractAssertTaxCalculationAfterCheckout.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AbstractAssertTaxCalculationAfterCheckout.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AbstractAssertTaxCalculationAfterCheckout.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AbstractAssertTaxCalculationAfterCheckout.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AbstractAssertTaxCalculationAfterCheckout.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AbstractAssertTaxCalculationAfterCheckout.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AbstractAssertTaxRuleIsAppliedToAllPrices.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AbstractAssertTaxRuleIsAppliedToAllPrices.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AbstractAssertTaxRuleIsAppliedToAllPrices.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AbstractAssertTaxRuleIsAppliedToAllPrices.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AbstractAssertTaxRuleIsAppliedToAllPrices.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AbstractAssertTaxRuleIsAppliedToAllPrices.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AbstractAssertTaxWithCrossBorderApplying.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AbstractAssertTaxWithCrossBorderApplying.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AbstractAssertTaxWithCrossBorderApplying.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AbstractAssertTaxWithCrossBorderApplying.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AbstractAssertTaxWithCrossBorderApplying.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AbstractAssertTaxWithCrossBorderApplying.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertOrderTaxOnBackendExcludingIncludingTax.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertOrderTaxOnBackendExcludingIncludingTax.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertOrderTaxOnBackendExcludingIncludingTax.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertOrderTaxOnBackendExcludingIncludingTax.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertOrderTaxOnBackendExcludingIncludingTax.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertOrderTaxOnBackendExcludingIncludingTax.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertOrderTaxOnBackendExcludingTax.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertOrderTaxOnBackendExcludingTax.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertOrderTaxOnBackendExcludingTax.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertOrderTaxOnBackendExcludingTax.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertOrderTaxOnBackendExcludingTax.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertOrderTaxOnBackendExcludingTax.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertOrderTaxOnBackendIncludingTax.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertOrderTaxOnBackendIncludingTax.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertOrderTaxOnBackendIncludingTax.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertOrderTaxOnBackendIncludingTax.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertOrderTaxOnBackendIncludingTax.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertOrderTaxOnBackendIncludingTax.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxCalculationAfterCheckoutExcludingIncludingTax.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxCalculationAfterCheckoutExcludingIncludingTax.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxCalculationAfterCheckoutExcludingIncludingTax.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxCalculationAfterCheckoutExcludingIncludingTax.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxCalculationAfterCheckoutExcludingIncludingTax.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxCalculationAfterCheckoutExcludingIncludingTax.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxCalculationAfterCheckoutExcludingTax.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxCalculationAfterCheckoutExcludingTax.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxCalculationAfterCheckoutExcludingTax.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxCalculationAfterCheckoutExcludingTax.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxCalculationAfterCheckoutExcludingTax.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxCalculationAfterCheckoutExcludingTax.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxCalculationAfterCheckoutIncludingTax.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxCalculationAfterCheckoutIncludingTax.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxCalculationAfterCheckoutIncludingTax.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxCalculationAfterCheckoutIncludingTax.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxCalculationAfterCheckoutIncludingTax.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxCalculationAfterCheckoutIncludingTax.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxRateForm.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxRateForm.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxRateForm.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxRateForm.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxRateForm.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxRateForm.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxRateInGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxRateInGrid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxRateInGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxRateInGrid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxRateInGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxRateInGrid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxRateInTaxRule.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxRateInTaxRule.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxRateInTaxRule.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxRateInTaxRule.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxRateInTaxRule.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxRateInTaxRule.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxRateIsInCorrectRange.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxRateIsInCorrectRange.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxRateIsInCorrectRange.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxRateIsInCorrectRange.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxRateIsInCorrectRange.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxRateIsInCorrectRange.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxRateNotInGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxRateNotInGrid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxRateNotInGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxRateNotInGrid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxRateNotInGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxRateNotInGrid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxRateNotInTaxRule.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxRateNotInTaxRule.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxRateNotInTaxRule.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxRateNotInTaxRule.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxRateNotInTaxRule.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxRateNotInTaxRule.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxRateSuccessDeleteMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxRateSuccessDeleteMessage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxRateSuccessDeleteMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxRateSuccessDeleteMessage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxRateSuccessDeleteMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxRateSuccessDeleteMessage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxRateSuccessSaveMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxRateSuccessSaveMessage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxRateSuccessSaveMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxRateSuccessSaveMessage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxRateSuccessSaveMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxRateSuccessSaveMessage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxRuleForm.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxRuleForm.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxRuleForm.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxRuleForm.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxRuleForm.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxRuleForm.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxRuleInGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxRuleInGrid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxRuleInGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxRuleInGrid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxRuleInGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxRuleInGrid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxRuleIsAppliedToAllPricesExcludingIncludingTax.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxRuleIsAppliedToAllPricesExcludingIncludingTax.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxRuleIsAppliedToAllPricesExcludingIncludingTax.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxRuleIsAppliedToAllPricesExcludingIncludingTax.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxRuleIsAppliedToAllPricesExcludingIncludingTax.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxRuleIsAppliedToAllPricesExcludingIncludingTax.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxRuleIsAppliedToAllPricesExcludingTax.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxRuleIsAppliedToAllPricesExcludingTax.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxRuleIsAppliedToAllPricesExcludingTax.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxRuleIsAppliedToAllPricesExcludingTax.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxRuleIsAppliedToAllPricesExcludingTax.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxRuleIsAppliedToAllPricesExcludingTax.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxRuleIsAppliedToAllPricesIncludingTax.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxRuleIsAppliedToAllPricesIncludingTax.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxRuleIsAppliedToAllPricesIncludingTax.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxRuleIsAppliedToAllPricesIncludingTax.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxRuleIsAppliedToAllPricesIncludingTax.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxRuleIsAppliedToAllPricesIncludingTax.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxRuleSuccessSaveMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxRuleSuccessSaveMessage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxRuleSuccessSaveMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxRuleSuccessSaveMessage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxRuleSuccessSaveMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxRuleSuccessSaveMessage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxWithCrossBorderApplied.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxWithCrossBorderApplied.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxWithCrossBorderApplied.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxWithCrossBorderApplied.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxWithCrossBorderApplied.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxWithCrossBorderApplied.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxWithCrossBorderNotApplied.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxWithCrossBorderNotApplied.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxWithCrossBorderNotApplied.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxWithCrossBorderNotApplied.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxWithCrossBorderNotApplied.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Constraint/AssertTaxWithCrossBorderNotApplied.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Fixture/TaxClass.xml
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Fixture/TaxClass.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Fixture/TaxClass.xml
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Fixture/TaxClass.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Fixture/TaxClass.xml
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Fixture/TaxClass.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Fixture/TaxRate.xml
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Fixture/TaxRate.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Fixture/TaxRate.xml
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Fixture/TaxRate.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Fixture/TaxRate.xml
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Fixture/TaxRate.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Fixture/TaxRule.xml
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Fixture/TaxRule.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Fixture/TaxRule.xml
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Fixture/TaxRule.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Fixture/TaxRule.xml
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Fixture/TaxRule.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Fixture/TaxRule/TaxClass.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Fixture/TaxRule/TaxClass.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Fixture/TaxRule/TaxClass.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Fixture/TaxRule/TaxClass.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Fixture/TaxRule/TaxClass.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Fixture/TaxRule/TaxClass.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Fixture/TaxRule/TaxRate.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Fixture/TaxRule/TaxRate.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Fixture/TaxRule/TaxRate.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Fixture/TaxRule/TaxRate.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Fixture/TaxRule/TaxRate.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Fixture/TaxRule/TaxRate.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Handler/TaxClass/Curl.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Handler/TaxClass/Curl.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Handler/TaxClass/Curl.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Handler/TaxClass/Curl.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Handler/TaxClass/Curl.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Handler/TaxClass/Curl.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Handler/TaxClass/TaxClassInterface.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Handler/TaxClass/TaxClassInterface.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Handler/TaxClass/TaxClassInterface.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Handler/TaxClass/TaxClassInterface.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Handler/TaxClass/TaxClassInterface.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Handler/TaxClass/TaxClassInterface.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Handler/TaxRate/Curl.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Handler/TaxRate/Curl.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Handler/TaxRate/Curl.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Handler/TaxRate/Curl.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Handler/TaxRate/Curl.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Handler/TaxRate/Curl.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Handler/TaxRate/TaxRateInterface.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Handler/TaxRate/TaxRateInterface.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Handler/TaxRate/TaxRateInterface.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Handler/TaxRate/TaxRateInterface.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Handler/TaxRate/TaxRateInterface.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Handler/TaxRate/TaxRateInterface.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Handler/TaxRule/Curl.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Handler/TaxRule/Curl.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Handler/TaxRule/Curl.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Handler/TaxRule/Curl.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Handler/TaxRule/Curl.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Handler/TaxRule/Curl.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Handler/TaxRule/TaxRuleInterface.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Handler/TaxRule/TaxRuleInterface.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Handler/TaxRule/TaxRuleInterface.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Handler/TaxRule/TaxRuleInterface.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Handler/TaxRule/TaxRuleInterface.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Handler/TaxRule/TaxRuleInterface.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Page/Adminhtml/TaxRateEdit.xml
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Page/Adminhtml/TaxRateEdit.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Page/Adminhtml/TaxRateEdit.xml
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Page/Adminhtml/TaxRateEdit.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Page/Adminhtml/TaxRateEdit.xml
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Page/Adminhtml/TaxRateEdit.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Page/Adminhtml/TaxRateIndex.xml
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Page/Adminhtml/TaxRateIndex.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Page/Adminhtml/TaxRateIndex.xml
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Page/Adminhtml/TaxRateIndex.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Page/Adminhtml/TaxRateIndex.xml
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Page/Adminhtml/TaxRateIndex.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Page/Adminhtml/TaxRateNew.xml
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Page/Adminhtml/TaxRateNew.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Page/Adminhtml/TaxRateNew.xml
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Page/Adminhtml/TaxRateNew.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Page/Adminhtml/TaxRateNew.xml
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Page/Adminhtml/TaxRateNew.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Page/Adminhtml/TaxRuleIndex.xml
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Page/Adminhtml/TaxRuleIndex.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Page/Adminhtml/TaxRuleIndex.xml
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Page/Adminhtml/TaxRuleIndex.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Page/Adminhtml/TaxRuleIndex.xml
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Page/Adminhtml/TaxRuleIndex.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Page/Adminhtml/TaxRuleNew.xml
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Page/Adminhtml/TaxRuleNew.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Page/Adminhtml/TaxRuleNew.xml
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Page/Adminhtml/TaxRuleNew.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Page/Adminhtml/TaxRuleNew.xml
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Page/Adminhtml/TaxRuleNew.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Repository/ConfigData.xml
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Repository/ConfigData.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Repository/ConfigData.xml
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Repository/ConfigData.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Repository/ConfigData.xml
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Repository/ConfigData.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Repository/TaxClass.xml
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Repository/TaxClass.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Repository/TaxClass.xml
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Repository/TaxClass.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Repository/TaxClass.xml
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Repository/TaxClass.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Repository/TaxRate.xml
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Repository/TaxRate.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Repository/TaxRate.xml
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Repository/TaxRate.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Repository/TaxRate.xml
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Repository/TaxRate.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Repository/TaxRule.xml
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Repository/TaxRule.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Repository/TaxRule.xml
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Repository/TaxRule.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/Repository/TaxRule.xml
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/Repository/TaxRule.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/TestCase/AutomaticTaxApplyingBasedOnVatIdTest.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/TestCase/AutomaticTaxApplyingBasedOnVatIdTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/TestCase/AutomaticTaxApplyingBasedOnVatIdTest.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/TestCase/AutomaticTaxApplyingBasedOnVatIdTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/TestCase/AutomaticTaxApplyingBasedOnVatIdTest.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/TestCase/AutomaticTaxApplyingBasedOnVatIdTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/TestCase/AutomaticTaxApplyingBasedOnVatIdTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/TestCase/AutomaticTaxApplyingBasedOnVatIdTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/TestCase/AutomaticTaxApplyingBasedOnVatIdTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/TestCase/AutomaticTaxApplyingBasedOnVatIdTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/TestCase/AutomaticTaxApplyingBasedOnVatIdTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/TestCase/AutomaticTaxApplyingBasedOnVatIdTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/TestCase/CreateTaxRateEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/TestCase/CreateTaxRateEntityTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/TestCase/CreateTaxRateEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/TestCase/CreateTaxRateEntityTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/TestCase/CreateTaxRateEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/TestCase/CreateTaxRateEntityTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/TestCase/CreateTaxRateEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/TestCase/CreateTaxRateEntityTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/TestCase/CreateTaxRateEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/TestCase/CreateTaxRateEntityTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/TestCase/CreateTaxRateEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/TestCase/CreateTaxRateEntityTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/TestCase/CreateTaxRuleEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/TestCase/CreateTaxRuleEntityTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/TestCase/CreateTaxRuleEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/TestCase/CreateTaxRuleEntityTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/TestCase/CreateTaxRuleEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/TestCase/CreateTaxRuleEntityTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/TestCase/CreateTaxRuleEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/TestCase/CreateTaxRuleEntityTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/TestCase/CreateTaxRuleEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/TestCase/CreateTaxRuleEntityTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/TestCase/CreateTaxRuleEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/TestCase/CreateTaxRuleEntityTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/TestCase/DeleteTaxRateEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/TestCase/DeleteTaxRateEntityTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/TestCase/DeleteTaxRateEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/TestCase/DeleteTaxRateEntityTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/TestCase/DeleteTaxRateEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/TestCase/DeleteTaxRateEntityTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/TestCase/DeleteTaxRateEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/TestCase/DeleteTaxRateEntityTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/TestCase/DeleteTaxRateEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/TestCase/DeleteTaxRateEntityTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/TestCase/DeleteTaxRateEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/TestCase/DeleteTaxRateEntityTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/TestCase/TaxCalculationTest.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/TestCase/TaxCalculationTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/TestCase/TaxCalculationTest.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/TestCase/TaxCalculationTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/TestCase/TaxCalculationTest.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/TestCase/TaxCalculationTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/TestCase/TaxCalculationTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/TestCase/TaxCalculationTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/TestCase/TaxCalculationTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/TestCase/TaxCalculationTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/TestCase/TaxCalculationTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/TestCase/TaxCalculationTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/TestCase/TaxWithCrossBorderTest.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/TestCase/TaxWithCrossBorderTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/TestCase/TaxWithCrossBorderTest.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/TestCase/TaxWithCrossBorderTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/TestCase/TaxWithCrossBorderTest.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/TestCase/TaxWithCrossBorderTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/TestCase/TaxWithCrossBorderTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/TestCase/TaxWithCrossBorderTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/TestCase/TaxWithCrossBorderTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/TestCase/TaxWithCrossBorderTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/TestCase/TaxWithCrossBorderTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/TestCase/TaxWithCrossBorderTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/TestStep/CreateTaxRuleStep.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/TestStep/CreateTaxRuleStep.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/TestStep/CreateTaxRuleStep.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/TestStep/CreateTaxRuleStep.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/TestStep/CreateTaxRuleStep.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/TestStep/CreateTaxRuleStep.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/TestStep/DeleteAllTaxRulesStep.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/TestStep/DeleteAllTaxRulesStep.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/TestStep/DeleteAllTaxRulesStep.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/TestStep/DeleteAllTaxRulesStep.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/TestStep/DeleteAllTaxRulesStep.php
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/TestStep/DeleteAllTaxRulesStep.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/etc/curl/di.xml
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/etc/curl/di.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/etc/curl/di.xml
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/etc/curl/di.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/etc/curl/di.xml
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/etc/curl/di.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/etc/fixture.xml
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/etc/fixture.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/etc/fixture.xml
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/etc/fixture.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/etc/fixture.xml
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/etc/fixture.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/etc/testcase.xml
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/etc/testcase.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/etc/testcase.xml
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/etc/testcase.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Tax/Test/etc/testcase.xml
+++ b/dev/tests/functional/tests/app/Mage/Tax/Test/etc/testcase.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Theme/Test/Block/Links.php
+++ b/dev/tests/functional/tests/app/Mage/Theme/Test/Block/Links.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Theme/Test/Block/Links.php
+++ b/dev/tests/functional/tests/app/Mage/Theme/Test/Block/Links.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Theme/Test/Block/Links.php
+++ b/dev/tests/functional/tests/app/Mage/Theme/Test/Block/Links.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Theme/Test/Block/Title.php
+++ b/dev/tests/functional/tests/app/Mage/Theme/Test/Block/Title.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Theme/Test/Block/Title.php
+++ b/dev/tests/functional/tests/app/Mage/Theme/Test/Block/Title.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Theme/Test/Block/Title.php
+++ b/dev/tests/functional/tests/app/Mage/Theme/Test/Block/Title.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Theme/Test/Block/TopLinks.php
+++ b/dev/tests/functional/tests/app/Mage/Theme/Test/Block/TopLinks.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Theme/Test/Block/TopLinks.php
+++ b/dev/tests/functional/tests/app/Mage/Theme/Test/Block/TopLinks.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Theme/Test/Block/TopLinks.php
+++ b/dev/tests/functional/tests/app/Mage/Theme/Test/Block/TopLinks.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Weee/Test/Block/Cart.php
+++ b/dev/tests/functional/tests/app/Mage/Weee/Test/Block/Cart.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Weee/Test/Block/Cart.php
+++ b/dev/tests/functional/tests/app/Mage/Weee/Test/Block/Cart.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Weee/Test/Block/Cart.php
+++ b/dev/tests/functional/tests/app/Mage/Weee/Test/Block/Cart.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Weee/Test/Block/Cart/CartItem.php
+++ b/dev/tests/functional/tests/app/Mage/Weee/Test/Block/Cart/CartItem.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Weee/Test/Block/Cart/CartItem.php
+++ b/dev/tests/functional/tests/app/Mage/Weee/Test/Block/Cart/CartItem.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Weee/Test/Block/Cart/CartItem.php
+++ b/dev/tests/functional/tests/app/Mage/Weee/Test/Block/Cart/CartItem.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Weee/Test/Block/Product/ListProduct.php
+++ b/dev/tests/functional/tests/app/Mage/Weee/Test/Block/Product/ListProduct.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Weee/Test/Block/Product/ListProduct.php
+++ b/dev/tests/functional/tests/app/Mage/Weee/Test/Block/Product/ListProduct.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Weee/Test/Block/Product/ListProduct.php
+++ b/dev/tests/functional/tests/app/Mage/Weee/Test/Block/Product/ListProduct.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Weee/Test/Block/Product/Price.php
+++ b/dev/tests/functional/tests/app/Mage/Weee/Test/Block/Product/Price.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Weee/Test/Block/Product/Price.php
+++ b/dev/tests/functional/tests/app/Mage/Weee/Test/Block/Product/Price.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Weee/Test/Block/Product/Price.php
+++ b/dev/tests/functional/tests/app/Mage/Weee/Test/Block/Product/Price.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Weee/Test/Block/Product/ProductList/ProductItem.php
+++ b/dev/tests/functional/tests/app/Mage/Weee/Test/Block/Product/ProductList/ProductItem.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Weee/Test/Block/Product/ProductList/ProductItem.php
+++ b/dev/tests/functional/tests/app/Mage/Weee/Test/Block/Product/ProductList/ProductItem.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Weee/Test/Block/Product/ProductList/ProductItem.php
+++ b/dev/tests/functional/tests/app/Mage/Weee/Test/Block/Product/ProductList/ProductItem.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Weee/Test/Block/Product/View.php
+++ b/dev/tests/functional/tests/app/Mage/Weee/Test/Block/Product/View.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Weee/Test/Block/Product/View.php
+++ b/dev/tests/functional/tests/app/Mage/Weee/Test/Block/Product/View.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Weee/Test/Block/Product/View.php
+++ b/dev/tests/functional/tests/app/Mage/Weee/Test/Block/Product/View.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Weee/Test/Constraint/AssertFptApplied.php
+++ b/dev/tests/functional/tests/app/Mage/Weee/Test/Constraint/AssertFptApplied.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Weee/Test/Constraint/AssertFptApplied.php
+++ b/dev/tests/functional/tests/app/Mage/Weee/Test/Constraint/AssertFptApplied.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Weee/Test/Constraint/AssertFptApplied.php
+++ b/dev/tests/functional/tests/app/Mage/Weee/Test/Constraint/AssertFptApplied.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Weee/Test/Page/Category/CatalogCategoryView.xml
+++ b/dev/tests/functional/tests/app/Mage/Weee/Test/Page/Category/CatalogCategoryView.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Weee/Test/Page/Category/CatalogCategoryView.xml
+++ b/dev/tests/functional/tests/app/Mage/Weee/Test/Page/Category/CatalogCategoryView.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Weee/Test/Page/Category/CatalogCategoryView.xml
+++ b/dev/tests/functional/tests/app/Mage/Weee/Test/Page/Category/CatalogCategoryView.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Weee/Test/Page/CheckoutCart.xml
+++ b/dev/tests/functional/tests/app/Mage/Weee/Test/Page/CheckoutCart.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Weee/Test/Page/CheckoutCart.xml
+++ b/dev/tests/functional/tests/app/Mage/Weee/Test/Page/CheckoutCart.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Weee/Test/Page/CheckoutCart.xml
+++ b/dev/tests/functional/tests/app/Mage/Weee/Test/Page/CheckoutCart.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Weee/Test/Page/Product/CatalogProductView.xml
+++ b/dev/tests/functional/tests/app/Mage/Weee/Test/Page/Product/CatalogProductView.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Weee/Test/Page/Product/CatalogProductView.xml
+++ b/dev/tests/functional/tests/app/Mage/Weee/Test/Page/Product/CatalogProductView.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Weee/Test/Page/Product/CatalogProductView.xml
+++ b/dev/tests/functional/tests/app/Mage/Weee/Test/Page/Product/CatalogProductView.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Weee/Test/Repository/ConfigData.xml
+++ b/dev/tests/functional/tests/app/Mage/Weee/Test/Repository/ConfigData.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Weee/Test/Repository/ConfigData.xml
+++ b/dev/tests/functional/tests/app/Mage/Weee/Test/Repository/ConfigData.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Weee/Test/Repository/ConfigData.xml
+++ b/dev/tests/functional/tests/app/Mage/Weee/Test/Repository/ConfigData.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Weee/Test/TestCase/CreateTaxWithFptTest.php
+++ b/dev/tests/functional/tests/app/Mage/Weee/Test/TestCase/CreateTaxWithFptTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Weee/Test/TestCase/CreateTaxWithFptTest.php
+++ b/dev/tests/functional/tests/app/Mage/Weee/Test/TestCase/CreateTaxWithFptTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Weee/Test/TestCase/CreateTaxWithFptTest.php
+++ b/dev/tests/functional/tests/app/Mage/Weee/Test/TestCase/CreateTaxWithFptTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Weee/Test/TestCase/CreateTaxWithFptTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Weee/Test/TestCase/CreateTaxWithFptTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Weee/Test/TestCase/CreateTaxWithFptTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Weee/Test/TestCase/CreateTaxWithFptTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Weee/Test/TestCase/CreateTaxWithFptTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Weee/Test/TestCase/CreateTaxWithFptTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Weee/Test/etc/testcase.xml
+++ b/dev/tests/functional/tests/app/Mage/Weee/Test/etc/testcase.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Weee/Test/etc/testcase.xml
+++ b/dev/tests/functional/tests/app/Mage/Weee/Test/etc/testcase.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Weee/Test/etc/testcase.xml
+++ b/dev/tests/functional/tests/app/Mage/Weee/Test/etc/testcase.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/FormPageActions.php
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/FormPageActions.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/FormPageActions.php
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/FormPageActions.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/FormPageActions.php
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/FormPageActions.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/Widget/ChosenOption.php
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/Widget/ChosenOption.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/Widget/ChosenOption.php
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/Widget/ChosenOption.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/Widget/ChosenOption.php
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/Widget/ChosenOption.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/Widget/Instance/Edit/Tab/LayoutUpdates.php
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/Widget/Instance/Edit/Tab/LayoutUpdates.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/Widget/Instance/Edit/Tab/LayoutUpdates.php
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/Widget/Instance/Edit/Tab/LayoutUpdates.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/Widget/Instance/Edit/Tab/LayoutUpdates.php
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/Widget/Instance/Edit/Tab/LayoutUpdates.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/Widget/Instance/Edit/Tab/LayoutUpdatesType/GenericPages.php
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/Widget/Instance/Edit/Tab/LayoutUpdatesType/GenericPages.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/Widget/Instance/Edit/Tab/LayoutUpdatesType/GenericPages.php
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/Widget/Instance/Edit/Tab/LayoutUpdatesType/GenericPages.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/Widget/Instance/Edit/Tab/LayoutUpdatesType/GenericPages.php
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/Widget/Instance/Edit/Tab/LayoutUpdatesType/GenericPages.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/Widget/Instance/Edit/Tab/LayoutUpdatesType/GenericPages.xml
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/Widget/Instance/Edit/Tab/LayoutUpdatesType/GenericPages.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/Widget/Instance/Edit/Tab/LayoutUpdatesType/GenericPages.xml
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/Widget/Instance/Edit/Tab/LayoutUpdatesType/GenericPages.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/Widget/Instance/Edit/Tab/LayoutUpdatesType/GenericPages.xml
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/Widget/Instance/Edit/Tab/LayoutUpdatesType/GenericPages.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/Widget/Instance/Edit/Tab/LayoutUpdatesType/LayoutForm.php
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/Widget/Instance/Edit/Tab/LayoutUpdatesType/LayoutForm.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/Widget/Instance/Edit/Tab/LayoutUpdatesType/LayoutForm.php
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/Widget/Instance/Edit/Tab/LayoutUpdatesType/LayoutForm.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/Widget/Instance/Edit/Tab/LayoutUpdatesType/LayoutForm.php
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/Widget/Instance/Edit/Tab/LayoutUpdatesType/LayoutForm.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/Widget/Instance/Edit/Tab/LayoutUpdatesType/Product/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/Widget/Instance/Edit/Tab/LayoutUpdatesType/Product/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/Widget/Instance/Edit/Tab/LayoutUpdatesType/Product/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/Widget/Instance/Edit/Tab/LayoutUpdatesType/Product/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/Widget/Instance/Edit/Tab/LayoutUpdatesType/Product/Grid.php
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/Widget/Instance/Edit/Tab/LayoutUpdatesType/Product/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/Widget/Instance/Edit/Tab/LayoutUpdatesType/Products.php
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/Widget/Instance/Edit/Tab/LayoutUpdatesType/Products.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/Widget/Instance/Edit/Tab/LayoutUpdatesType/Products.php
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/Widget/Instance/Edit/Tab/LayoutUpdatesType/Products.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/Widget/Instance/Edit/Tab/LayoutUpdatesType/Products.php
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/Widget/Instance/Edit/Tab/LayoutUpdatesType/Products.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/Widget/Instance/Edit/Tab/LayoutUpdatesType/Products.xml
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/Widget/Instance/Edit/Tab/LayoutUpdatesType/Products.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/Widget/Instance/Edit/Tab/LayoutUpdatesType/Products.xml
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/Widget/Instance/Edit/Tab/LayoutUpdatesType/Products.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/Widget/Instance/Edit/Tab/LayoutUpdatesType/Products.xml
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/Widget/Instance/Edit/Tab/LayoutUpdatesType/Products.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/Widget/Instance/Edit/Tab/Settings.php
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/Widget/Instance/Edit/Tab/Settings.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/Widget/Instance/Edit/Tab/Settings.php
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/Widget/Instance/Edit/Tab/Settings.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/Widget/Instance/Edit/Tab/Settings.php
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/Widget/Instance/Edit/Tab/Settings.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/Widget/Instance/Edit/Tab/WidgetOptions.php
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/Widget/Instance/Edit/Tab/WidgetOptions.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/Widget/Instance/Edit/Tab/WidgetOptions.php
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/Widget/Instance/Edit/Tab/WidgetOptions.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/Widget/Instance/Edit/Tab/WidgetOptions.php
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/Widget/Instance/Edit/Tab/WidgetOptions.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/Widget/Instance/Edit/Tab/WidgetOptionsType/WidgetOptionsForm.php
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/Widget/Instance/Edit/Tab/WidgetOptionsType/WidgetOptionsForm.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/Widget/Instance/Edit/Tab/WidgetOptionsType/WidgetOptionsForm.php
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/Widget/Instance/Edit/Tab/WidgetOptionsType/WidgetOptionsForm.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/Widget/Instance/Edit/Tab/WidgetOptionsType/WidgetOptionsForm.php
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/Widget/Instance/Edit/Tab/WidgetOptionsType/WidgetOptionsForm.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/Widget/Instance/Edit/WidgetForm.php
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/Widget/Instance/Edit/WidgetForm.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/Widget/Instance/Edit/WidgetForm.php
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/Widget/Instance/Edit/WidgetForm.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/Widget/Instance/Edit/WidgetForm.php
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/Widget/Instance/Edit/WidgetForm.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/Widget/Instance/Edit/WidgetForm.xml
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/Widget/Instance/Edit/WidgetForm.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/Widget/Instance/Edit/WidgetForm.xml
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/Widget/Instance/Edit/WidgetForm.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/Widget/Instance/Edit/WidgetForm.xml
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/Widget/Instance/Edit/WidgetForm.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/Widget/WidgetGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/Widget/WidgetGrid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/Widget/WidgetGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/Widget/WidgetGrid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/Widget/WidgetGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/Widget/WidgetGrid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/WidgetForm.php
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/WidgetForm.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/WidgetForm.php
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/WidgetForm.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/WidgetForm.php
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/WidgetForm.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/WidgetForm.xml
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/WidgetForm.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/WidgetForm.xml
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/WidgetForm.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/WidgetForm.xml
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Block/Adminhtml/WidgetForm.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Block/WidgetView.php
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Block/WidgetView.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Block/WidgetView.php
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Block/WidgetView.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Block/WidgetView.php
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Block/WidgetView.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Constraint/AssertWidgetInGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Constraint/AssertWidgetInGrid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Constraint/AssertWidgetInGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Constraint/AssertWidgetInGrid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Constraint/AssertWidgetInGrid.php
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Constraint/AssertWidgetInGrid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Constraint/AssertWidgetSuccessSaveMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Constraint/AssertWidgetSuccessSaveMessage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Constraint/AssertWidgetSuccessSaveMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Constraint/AssertWidgetSuccessSaveMessage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Constraint/AssertWidgetSuccessSaveMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Constraint/AssertWidgetSuccessSaveMessage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Fixture/Widget.xml
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Fixture/Widget.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Fixture/Widget.xml
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Fixture/Widget.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Fixture/Widget.xml
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Fixture/Widget.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Fixture/Widget/LayoutUpdates.php
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Fixture/Widget/LayoutUpdates.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Fixture/Widget/LayoutUpdates.php
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Fixture/Widget/LayoutUpdates.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Fixture/Widget/LayoutUpdates.php
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Fixture/Widget/LayoutUpdates.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Fixture/Widget/StoreIds.php
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Fixture/Widget/StoreIds.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Fixture/Widget/StoreIds.php
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Fixture/Widget/StoreIds.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Fixture/Widget/StoreIds.php
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Fixture/Widget/StoreIds.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Fixture/Widget/WidgetOptions.php
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Fixture/Widget/WidgetOptions.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Fixture/Widget/WidgetOptions.php
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Fixture/Widget/WidgetOptions.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Fixture/Widget/WidgetOptions.php
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Fixture/Widget/WidgetOptions.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Handler/Widget/Curl.php
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Handler/Widget/Curl.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Handler/Widget/Curl.php
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Handler/Widget/Curl.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Handler/Widget/Curl.php
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Handler/Widget/Curl.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Handler/Widget/WidgetInterface.php
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Handler/Widget/WidgetInterface.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Handler/Widget/WidgetInterface.php
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Handler/Widget/WidgetInterface.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Handler/Widget/WidgetInterface.php
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Handler/Widget/WidgetInterface.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Page/Adminhtml/WidgetInstanceEdit.xml
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Page/Adminhtml/WidgetInstanceEdit.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Page/Adminhtml/WidgetInstanceEdit.xml
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Page/Adminhtml/WidgetInstanceEdit.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Page/Adminhtml/WidgetInstanceEdit.xml
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Page/Adminhtml/WidgetInstanceEdit.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Page/Adminhtml/WidgetInstanceIndex.xml
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Page/Adminhtml/WidgetInstanceIndex.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Page/Adminhtml/WidgetInstanceIndex.xml
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Page/Adminhtml/WidgetInstanceIndex.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Page/Adminhtml/WidgetInstanceIndex.xml
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Page/Adminhtml/WidgetInstanceIndex.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Page/Adminhtml/WidgetInstanceNew.xml
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Page/Adminhtml/WidgetInstanceNew.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Page/Adminhtml/WidgetInstanceNew.xml
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Page/Adminhtml/WidgetInstanceNew.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Page/Adminhtml/WidgetInstanceNew.xml
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Page/Adminhtml/WidgetInstanceNew.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Page/CmsIndex.xml
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Page/CmsIndex.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Page/CmsIndex.xml
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Page/CmsIndex.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Page/CmsIndex.xml
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Page/CmsIndex.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Repository/Widget.xml
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Repository/Widget.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Repository/Widget.xml
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Repository/Widget.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Repository/Widget.xml
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Repository/Widget.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Repository/Widget/LayoutUpdates.xml
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Repository/Widget/LayoutUpdates.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Repository/Widget/LayoutUpdates.xml
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Repository/Widget/LayoutUpdates.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/Repository/Widget/LayoutUpdates.xml
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/Repository/Widget/LayoutUpdates.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/TestCase/AbstractCreateWidgetEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/TestCase/AbstractCreateWidgetEntityTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/TestCase/AbstractCreateWidgetEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/TestCase/AbstractCreateWidgetEntityTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/TestCase/AbstractCreateWidgetEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/TestCase/AbstractCreateWidgetEntityTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/TestStep/DeleteAllWidgetsStep.php
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/TestStep/DeleteAllWidgetsStep.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/TestStep/DeleteAllWidgetsStep.php
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/TestStep/DeleteAllWidgetsStep.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/TestStep/DeleteAllWidgetsStep.php
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/TestStep/DeleteAllWidgetsStep.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/etc/curl/di.xml
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/etc/curl/di.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/etc/curl/di.xml
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/etc/curl/di.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/etc/curl/di.xml
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/etc/curl/di.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/etc/fixture.xml
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/etc/fixture.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/etc/fixture.xml
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/etc/fixture.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Widget/Test/etc/fixture.xml
+++ b/dev/tests/functional/tests/app/Mage/Widget/Test/etc/fixture.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Wishlist/Test/Block/Customer/Wishlist.php
+++ b/dev/tests/functional/tests/app/Mage/Wishlist/Test/Block/Customer/Wishlist.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Wishlist/Test/Block/Customer/Wishlist.php
+++ b/dev/tests/functional/tests/app/Mage/Wishlist/Test/Block/Customer/Wishlist.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Wishlist/Test/Block/Customer/Wishlist.php
+++ b/dev/tests/functional/tests/app/Mage/Wishlist/Test/Block/Customer/Wishlist.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Wishlist/Test/Block/Customer/Wishlist/Items.php
+++ b/dev/tests/functional/tests/app/Mage/Wishlist/Test/Block/Customer/Wishlist/Items.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Wishlist/Test/Block/Customer/Wishlist/Items.php
+++ b/dev/tests/functional/tests/app/Mage/Wishlist/Test/Block/Customer/Wishlist/Items.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Wishlist/Test/Block/Customer/Wishlist/Items.php
+++ b/dev/tests/functional/tests/app/Mage/Wishlist/Test/Block/Customer/Wishlist/Items.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Wishlist/Test/Block/Customer/Wishlist/Items/Product.php
+++ b/dev/tests/functional/tests/app/Mage/Wishlist/Test/Block/Customer/Wishlist/Items/Product.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Wishlist/Test/Block/Customer/Wishlist/Items/Product.php
+++ b/dev/tests/functional/tests/app/Mage/Wishlist/Test/Block/Customer/Wishlist/Items/Product.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Wishlist/Test/Block/Customer/Wishlist/Items/Product.php
+++ b/dev/tests/functional/tests/app/Mage/Wishlist/Test/Block/Customer/Wishlist/Items/Product.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Wishlist/Test/Block/Customer/Wishlist/Items/Product.xml
+++ b/dev/tests/functional/tests/app/Mage/Wishlist/Test/Block/Customer/Wishlist/Items/Product.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Wishlist/Test/Block/Customer/Wishlist/Items/Product.xml
+++ b/dev/tests/functional/tests/app/Mage/Wishlist/Test/Block/Customer/Wishlist/Items/Product.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Wishlist/Test/Block/Customer/Wishlist/Items/Product.xml
+++ b/dev/tests/functional/tests/app/Mage/Wishlist/Test/Block/Customer/Wishlist/Items/Product.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Wishlist/Test/Constraint/AssertAddProductToWishlistSuccessMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Wishlist/Test/Constraint/AssertAddProductToWishlistSuccessMessage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Wishlist/Test/Constraint/AssertAddProductToWishlistSuccessMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Wishlist/Test/Constraint/AssertAddProductToWishlistSuccessMessage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Wishlist/Test/Constraint/AssertAddProductToWishlistSuccessMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Wishlist/Test/Constraint/AssertAddProductToWishlistSuccessMessage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Wishlist/Test/Constraint/AssertAddProductsToWishlistSuccessMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Wishlist/Test/Constraint/AssertAddProductsToWishlistSuccessMessage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Wishlist/Test/Constraint/AssertAddProductsToWishlistSuccessMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Wishlist/Test/Constraint/AssertAddProductsToWishlistSuccessMessage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Wishlist/Test/Constraint/AssertAddProductsToWishlistSuccessMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Wishlist/Test/Constraint/AssertAddProductsToWishlistSuccessMessage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Wishlist/Test/Constraint/AssertMoveProductToWishlistSuccessMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Wishlist/Test/Constraint/AssertMoveProductToWishlistSuccessMessage.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Wishlist/Test/Constraint/AssertMoveProductToWishlistSuccessMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Wishlist/Test/Constraint/AssertMoveProductToWishlistSuccessMessage.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Wishlist/Test/Constraint/AssertMoveProductToWishlistSuccessMessage.php
+++ b/dev/tests/functional/tests/app/Mage/Wishlist/Test/Constraint/AssertMoveProductToWishlistSuccessMessage.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Wishlist/Test/Constraint/AssertProductDetailsInWishlist.php
+++ b/dev/tests/functional/tests/app/Mage/Wishlist/Test/Constraint/AssertProductDetailsInWishlist.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Wishlist/Test/Constraint/AssertProductDetailsInWishlist.php
+++ b/dev/tests/functional/tests/app/Mage/Wishlist/Test/Constraint/AssertProductDetailsInWishlist.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Wishlist/Test/Constraint/AssertProductDetailsInWishlist.php
+++ b/dev/tests/functional/tests/app/Mage/Wishlist/Test/Constraint/AssertProductDetailsInWishlist.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Wishlist/Test/Constraint/AssertProductIsPresentInCustomerBackendWishlist.php
+++ b/dev/tests/functional/tests/app/Mage/Wishlist/Test/Constraint/AssertProductIsPresentInCustomerBackendWishlist.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Wishlist/Test/Constraint/AssertProductIsPresentInCustomerBackendWishlist.php
+++ b/dev/tests/functional/tests/app/Mage/Wishlist/Test/Constraint/AssertProductIsPresentInCustomerBackendWishlist.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Wishlist/Test/Constraint/AssertProductIsPresentInCustomerBackendWishlist.php
+++ b/dev/tests/functional/tests/app/Mage/Wishlist/Test/Constraint/AssertProductIsPresentInCustomerBackendWishlist.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Wishlist/Test/Constraint/AssertProductIsPresentInWishlist.php
+++ b/dev/tests/functional/tests/app/Mage/Wishlist/Test/Constraint/AssertProductIsPresentInWishlist.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Wishlist/Test/Constraint/AssertProductIsPresentInWishlist.php
+++ b/dev/tests/functional/tests/app/Mage/Wishlist/Test/Constraint/AssertProductIsPresentInWishlist.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Wishlist/Test/Constraint/AssertProductIsPresentInWishlist.php
+++ b/dev/tests/functional/tests/app/Mage/Wishlist/Test/Constraint/AssertProductIsPresentInWishlist.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Wishlist/Test/Constraint/AssertProductsArePresentInCustomerBackendWishlist.php
+++ b/dev/tests/functional/tests/app/Mage/Wishlist/Test/Constraint/AssertProductsArePresentInCustomerBackendWishlist.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Wishlist/Test/Constraint/AssertProductsArePresentInCustomerBackendWishlist.php
+++ b/dev/tests/functional/tests/app/Mage/Wishlist/Test/Constraint/AssertProductsArePresentInCustomerBackendWishlist.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Wishlist/Test/Constraint/AssertProductsArePresentInCustomerBackendWishlist.php
+++ b/dev/tests/functional/tests/app/Mage/Wishlist/Test/Constraint/AssertProductsArePresentInCustomerBackendWishlist.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Wishlist/Test/Constraint/AssertProductsIsAbsentInWishlist.php
+++ b/dev/tests/functional/tests/app/Mage/Wishlist/Test/Constraint/AssertProductsIsAbsentInWishlist.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Wishlist/Test/Constraint/AssertProductsIsAbsentInWishlist.php
+++ b/dev/tests/functional/tests/app/Mage/Wishlist/Test/Constraint/AssertProductsIsAbsentInWishlist.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Wishlist/Test/Constraint/AssertProductsIsAbsentInWishlist.php
+++ b/dev/tests/functional/tests/app/Mage/Wishlist/Test/Constraint/AssertProductsIsAbsentInWishlist.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Wishlist/Test/Constraint/AssertWishlistIsEmpty.php
+++ b/dev/tests/functional/tests/app/Mage/Wishlist/Test/Constraint/AssertWishlistIsEmpty.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Wishlist/Test/Constraint/AssertWishlistIsEmpty.php
+++ b/dev/tests/functional/tests/app/Mage/Wishlist/Test/Constraint/AssertWishlistIsEmpty.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Wishlist/Test/Constraint/AssertWishlistIsEmpty.php
+++ b/dev/tests/functional/tests/app/Mage/Wishlist/Test/Constraint/AssertWishlistIsEmpty.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Wishlist/Test/Page/WishlistIndex.xml
+++ b/dev/tests/functional/tests/app/Mage/Wishlist/Test/Page/WishlistIndex.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Wishlist/Test/Page/WishlistIndex.xml
+++ b/dev/tests/functional/tests/app/Mage/Wishlist/Test/Page/WishlistIndex.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Wishlist/Test/Page/WishlistIndex.xml
+++ b/dev/tests/functional/tests/app/Mage/Wishlist/Test/Page/WishlistIndex.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Wishlist/Test/TestCase/AbstractWishlistTest.php
+++ b/dev/tests/functional/tests/app/Mage/Wishlist/Test/TestCase/AbstractWishlistTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Wishlist/Test/TestCase/AbstractWishlistTest.php
+++ b/dev/tests/functional/tests/app/Mage/Wishlist/Test/TestCase/AbstractWishlistTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Wishlist/Test/TestCase/AbstractWishlistTest.php
+++ b/dev/tests/functional/tests/app/Mage/Wishlist/Test/TestCase/AbstractWishlistTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Wishlist/Test/TestCase/AddProductToWishlistEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Wishlist/Test/TestCase/AddProductToWishlistEntityTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Wishlist/Test/TestCase/AddProductToWishlistEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Wishlist/Test/TestCase/AddProductToWishlistEntityTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Wishlist/Test/TestCase/AddProductToWishlistEntityTest.php
+++ b/dev/tests/functional/tests/app/Mage/Wishlist/Test/TestCase/AddProductToWishlistEntityTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Wishlist/Test/TestCase/AddProductToWishlistEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Wishlist/Test/TestCase/AddProductToWishlistEntityTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Wishlist/Test/TestCase/AddProductToWishlistEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Wishlist/Test/TestCase/AddProductToWishlistEntityTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Wishlist/Test/TestCase/AddProductToWishlistEntityTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Wishlist/Test/TestCase/AddProductToWishlistEntityTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Wishlist/Test/TestCase/AddProductsToCartFromCustomerWishlistOnFrontendTest.php
+++ b/dev/tests/functional/tests/app/Mage/Wishlist/Test/TestCase/AddProductsToCartFromCustomerWishlistOnFrontendTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Wishlist/Test/TestCase/AddProductsToCartFromCustomerWishlistOnFrontendTest.php
+++ b/dev/tests/functional/tests/app/Mage/Wishlist/Test/TestCase/AddProductsToCartFromCustomerWishlistOnFrontendTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Wishlist/Test/TestCase/AddProductsToCartFromCustomerWishlistOnFrontendTest.php
+++ b/dev/tests/functional/tests/app/Mage/Wishlist/Test/TestCase/AddProductsToCartFromCustomerWishlistOnFrontendTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Wishlist/Test/TestCase/AddProductsToCartFromCustomerWishlistOnFrontendTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Wishlist/Test/TestCase/AddProductsToCartFromCustomerWishlistOnFrontendTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Wishlist/Test/TestCase/AddProductsToCartFromCustomerWishlistOnFrontendTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Wishlist/Test/TestCase/AddProductsToCartFromCustomerWishlistOnFrontendTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Wishlist/Test/TestCase/AddProductsToCartFromCustomerWishlistOnFrontendTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Wishlist/Test/TestCase/AddProductsToCartFromCustomerWishlistOnFrontendTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Wishlist/Test/TestCase/ConfigureProductInCustomerWishlistOnFrontendTest.php
+++ b/dev/tests/functional/tests/app/Mage/Wishlist/Test/TestCase/ConfigureProductInCustomerWishlistOnFrontendTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Wishlist/Test/TestCase/ConfigureProductInCustomerWishlistOnFrontendTest.php
+++ b/dev/tests/functional/tests/app/Mage/Wishlist/Test/TestCase/ConfigureProductInCustomerWishlistOnFrontendTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Wishlist/Test/TestCase/ConfigureProductInCustomerWishlistOnFrontendTest.php
+++ b/dev/tests/functional/tests/app/Mage/Wishlist/Test/TestCase/ConfigureProductInCustomerWishlistOnFrontendTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Wishlist/Test/TestCase/ConfigureProductInCustomerWishlistOnFrontendTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Wishlist/Test/TestCase/ConfigureProductInCustomerWishlistOnFrontendTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Wishlist/Test/TestCase/ConfigureProductInCustomerWishlistOnFrontendTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Wishlist/Test/TestCase/ConfigureProductInCustomerWishlistOnFrontendTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Wishlist/Test/TestCase/ConfigureProductInCustomerWishlistOnFrontendTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Wishlist/Test/TestCase/ConfigureProductInCustomerWishlistOnFrontendTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Wishlist/Test/TestCase/MoveProductFromShoppingCartToWishlistTest.php
+++ b/dev/tests/functional/tests/app/Mage/Wishlist/Test/TestCase/MoveProductFromShoppingCartToWishlistTest.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Wishlist/Test/TestCase/MoveProductFromShoppingCartToWishlistTest.php
+++ b/dev/tests/functional/tests/app/Mage/Wishlist/Test/TestCase/MoveProductFromShoppingCartToWishlistTest.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Wishlist/Test/TestCase/MoveProductFromShoppingCartToWishlistTest.php
+++ b/dev/tests/functional/tests/app/Mage/Wishlist/Test/TestCase/MoveProductFromShoppingCartToWishlistTest.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Wishlist/Test/TestCase/MoveProductFromShoppingCartToWishlistTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Wishlist/Test/TestCase/MoveProductFromShoppingCartToWishlistTest.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Wishlist/Test/TestCase/MoveProductFromShoppingCartToWishlistTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Wishlist/Test/TestCase/MoveProductFromShoppingCartToWishlistTest.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Wishlist/Test/TestCase/MoveProductFromShoppingCartToWishlistTest.xml
+++ b/dev/tests/functional/tests/app/Mage/Wishlist/Test/TestCase/MoveProductFromShoppingCartToWishlistTest.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Wishlist/Test/TestStep/AddProductsToWishlistStep.php
+++ b/dev/tests/functional/tests/app/Mage/Wishlist/Test/TestStep/AddProductsToWishlistStep.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/tests/app/Mage/Wishlist/Test/TestStep/AddProductsToWishlistStep.php
+++ b/dev/tests/functional/tests/app/Mage/Wishlist/Test/TestStep/AddProductsToWishlistStep.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/tests/app/Mage/Wishlist/Test/TestStep/AddProductsToWishlistStep.php
+++ b/dev/tests/functional/tests/app/Mage/Wishlist/Test/TestStep/AddProductsToWishlistStep.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests.php
+++ b/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests.php
+++ b/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests.php
+++ b/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/3rdParty.xml
+++ b/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/3rdParty.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/3rdParty.xml
+++ b/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/3rdParty.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/3rdParty.xml
+++ b/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/3rdParty.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/authorizenet.xml
+++ b/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/authorizenet.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/authorizenet.xml
+++ b/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/authorizenet.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/authorizenet.xml
+++ b/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/authorizenet.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/authorizenetdp.xml
+++ b/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/authorizenetdp.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/authorizenetdp.xml
+++ b/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/authorizenetdp.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/authorizenetdp.xml
+++ b/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/authorizenetdp.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/basic.xml
+++ b/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/basic.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/basic.xml
+++ b/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/basic.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/basic.xml
+++ b/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/basic.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/ce_main.xml
+++ b/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/ce_main.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/ce_main.xml
+++ b/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/ce_main.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/ce_main.xml
+++ b/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/ce_main.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/installationce.xml
+++ b/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/installationce.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/installationce.xml
+++ b/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/installationce.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/installationce.xml
+++ b/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/installationce.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/installationce2.xml
+++ b/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/installationce2.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/installationce2.xml
+++ b/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/installationce2.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/installationce2.xml
+++ b/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/installationce2.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/installationce3.xml
+++ b/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/installationce3.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/installationce3.xml
+++ b/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/installationce3.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/installationce3.xml
+++ b/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/installationce3.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/installationce4.xml
+++ b/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/installationce4.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/installationce4.xml
+++ b/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/installationce4.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/installationce4.xml
+++ b/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/installationce4.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/installationce5.xml
+++ b/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/installationce5.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/installationce5.xml
+++ b/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/installationce5.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/installationce5.xml
+++ b/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/installationce5.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/installationce6.xml
+++ b/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/installationce6.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/installationce6.xml
+++ b/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/installationce6.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/installationce6.xml
+++ b/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/installationce6.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/paypal.xml
+++ b/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/paypal.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/paypal.xml
+++ b/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/paypal.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/paypal.xml
+++ b/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/paypal.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/paypal1.xml
+++ b/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/paypal1.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/paypal1.xml
+++ b/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/paypal1.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/paypal1.xml
+++ b/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/paypal1.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/paypaladvanced.xml
+++ b/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/paypaladvanced.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/paypaladvanced.xml
+++ b/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/paypaladvanced.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/paypaladvanced.xml
+++ b/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/paypaladvanced.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/paypaldirect.xml
+++ b/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/paypaldirect.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/paypaldirect.xml
+++ b/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/paypaldirect.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/paypaldirect.xml
+++ b/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/paypaldirect.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/paypalecbutton.xml
+++ b/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/paypalecbutton.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/paypalecbutton.xml
+++ b/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/paypalecbutton.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/paypalecbutton.xml
+++ b/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/paypalecbutton.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/paypalecbuttonproduct.xml
+++ b/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/paypalecbuttonproduct.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/paypalecbuttonproduct.xml
+++ b/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/paypalecbuttonproduct.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/paypalecbuttonproduct.xml
+++ b/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/paypalecbuttonproduct.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/paypalecinvoice.xml
+++ b/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/paypalecinvoice.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/paypalecinvoice.xml
+++ b/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/paypalecinvoice.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/paypalecinvoice.xml
+++ b/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/paypalecinvoice.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/paypalecrefund.xml
+++ b/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/paypalecrefund.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/paypalecrefund.xml
+++ b/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/paypalecrefund.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/paypalecrefund.xml
+++ b/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/paypalecrefund.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/paypalecshipment.xml
+++ b/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/paypalecshipment.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/paypalecshipment.xml
+++ b/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/paypalecshipment.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/paypalecshipment.xml
+++ b/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/paypalecshipment.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/paypalhostedsolution.xml
+++ b/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/paypalhostedsolution.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/paypalhostedsolution.xml
+++ b/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/paypalhostedsolution.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/paypalhostedsolution.xml
+++ b/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/paypalhostedsolution.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/paypalpayflowlink.xml
+++ b/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/paypalpayflowlink.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/paypalpayflowlink.xml
+++ b/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/paypalpayflowlink.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/paypalpayflowlink.xml
+++ b/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/paypalpayflowlink.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/paypalpayflowpro.xml
+++ b/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/paypalpayflowpro.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/paypalpayflowpro.xml
+++ b/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/paypalpayflowpro.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/paypalpayflowpro.xml
+++ b/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/paypalpayflowpro.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/paypalpaymentspro.xml
+++ b/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/paypalpaymentspro.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/paypalpaymentspro.xml
+++ b/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/paypalpaymentspro.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/paypalpaymentspro.xml
+++ b/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/paypalpaymentspro.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/paypalstandard.xml
+++ b/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/paypalstandard.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/paypalstandard.xml
+++ b/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/paypalstandard.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/paypalstandard.xml
+++ b/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/paypalstandard.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/suite1.xml
+++ b/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/suite1.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/suite1.xml
+++ b/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/suite1.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/suite1.xml
+++ b/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/suite1.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/suite2.xml
+++ b/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/suite2.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/suite2.xml
+++ b/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/suite2.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/suite2.xml
+++ b/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/suite2.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/suite3.xml
+++ b/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/suite3.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/suite3.xml
+++ b/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/suite3.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/suite3.xml
+++ b/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests/suite3.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/utils/bootstrap.php
+++ b/dev/tests/functional/utils/bootstrap.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/utils/bootstrap.php
+++ b/dev/tests/functional/utils/bootstrap.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/utils/bootstrap.php
+++ b/dev/tests/functional/utils/bootstrap.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/utils/generate.php
+++ b/dev/tests/functional/utils/generate.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/utils/generate.php
+++ b/dev/tests/functional/utils/generate.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/utils/generate.php
+++ b/dev/tests/functional/utils/generate.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/utils/generate/fixture.php
+++ b/dev/tests/functional/utils/generate/fixture.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/utils/generate/fixture.php
+++ b/dev/tests/functional/utils/generate/fixture.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/utils/generate/fixture.php
+++ b/dev/tests/functional/utils/generate/fixture.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/utils/generate/handler.php
+++ b/dev/tests/functional/utils/generate/handler.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/utils/generate/handler.php
+++ b/dev/tests/functional/utils/generate/handler.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/utils/generate/handler.php
+++ b/dev/tests/functional/utils/generate/handler.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/utils/generate/page.php
+++ b/dev/tests/functional/utils/generate/page.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/utils/generate/page.php
+++ b/dev/tests/functional/utils/generate/page.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/utils/generate/page.php
+++ b/dev/tests/functional/utils/generate/page.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/utils/generate/repository.php
+++ b/dev/tests/functional/utils/generate/repository.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/dev/tests/functional/utils/generate/repository.php
+++ b/dev/tests/functional/utils/generate/repository.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/dev/tests/functional/utils/generate/repository.php
+++ b/dev/tests/functional/utils/generate/repository.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Tests
  * @package     Tests_Functional

--- a/errors/404.php
+++ b/errors/404.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Mage
  * @package     Errors

--- a/errors/404.php
+++ b/errors/404.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Mage
  * @package     Errors

--- a/errors/404.php
+++ b/errors/404.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/errors/503.php
+++ b/errors/503.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Mage
  * @package     Errors

--- a/errors/503.php
+++ b/errors/503.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Mage
  * @package     Errors

--- a/errors/503.php
+++ b/errors/503.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/errors/default/404.phtml
+++ b/errors/default/404.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Mage
  * @package     Errors

--- a/errors/default/404.phtml
+++ b/errors/default/404.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/errors/default/404.phtml
+++ b/errors/default/404.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    Mage
  * @package     Errors

--- a/errors/default/503.phtml
+++ b/errors/default/503.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Mage
  * @package     Errors

--- a/errors/default/503.phtml
+++ b/errors/default/503.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/errors/default/503.phtml
+++ b/errors/default/503.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    Mage
  * @package     Errors

--- a/errors/default/css/styles.css
+++ b/errors/default/css/styles.css
@@ -5,9 +5,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Mage
  * @package     Errors

--- a/errors/default/css/styles.css
+++ b/errors/default/css/styles.css
@@ -3,8 +3,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    Mage
  * @package     Errors

--- a/errors/default/css/styles.css
+++ b/errors/default/css/styles.css
@@ -1,8 +1,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/errors/default/page.phtml
+++ b/errors/default/page.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Mage
  * @package     Errors

--- a/errors/default/page.phtml
+++ b/errors/default/page.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/errors/default/page.phtml
+++ b/errors/default/page.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    Mage
  * @package     Errors

--- a/errors/default/report.phtml
+++ b/errors/default/report.phtml
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Mage
  * @package     Errors

--- a/errors/default/report.phtml
+++ b/errors/default/report.phtml
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/errors/default/report.phtml
+++ b/errors/default/report.phtml
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    Mage
  * @package     Errors

--- a/errors/design.xml
+++ b/errors/design.xml
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    Mage
  * @package     Errors

--- a/errors/design.xml
+++ b/errors/design.xml
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Mage
  * @package     Errors

--- a/errors/design.xml
+++ b/errors/design.xml
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/errors/local.xml.sample
+++ b/errors/local.xml.sample
@@ -5,8 +5,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    Mage
  * @package     Errors

--- a/errors/local.xml.sample
+++ b/errors/local.xml.sample
@@ -7,9 +7,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Mage
  * @package     Errors

--- a/errors/local.xml.sample
+++ b/errors/local.xml.sample
@@ -3,8 +3,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/errors/processor.php
+++ b/errors/processor.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Mage
  * @package     Errors

--- a/errors/processor.php
+++ b/errors/processor.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Mage
  * @package     Errors

--- a/errors/processor.php
+++ b/errors/processor.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/errors/report.php
+++ b/errors/report.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Mage
  * @package     Errors

--- a/errors/report.php
+++ b/errors/report.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Mage
  * @package     Errors

--- a/errors/report.php
+++ b/errors/report.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/get.php
+++ b/get.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Mage
  * @package     Mage

--- a/get.php
+++ b/get.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/get.php
+++ b/get.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Mage
  * @package     Mage

--- a/includes/config.php
+++ b/includes/config.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Mage
  * @package     Mage

--- a/includes/config.php
+++ b/includes/config.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/includes/config.php
+++ b/includes/config.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Mage
  * @package     Mage

--- a/index.php
+++ b/index.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Mage
  * @package     Mage

--- a/index.php
+++ b/index.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/index.php
+++ b/index.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Mage
  * @package     Mage

--- a/install.php
+++ b/install.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Mage
  * @package     Mage

--- a/install.php
+++ b/install.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/install.php
+++ b/install.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Mage
  * @package     Mage

--- a/js/extjs/fix-defer-before.js
+++ b/js/extjs/fix-defer-before.js
@@ -5,9 +5,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Mage
  * @package     js

--- a/js/extjs/fix-defer-before.js
+++ b/js/extjs/fix-defer-before.js
@@ -3,8 +3,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    Mage
  * @package     js

--- a/js/extjs/fix-defer-before.js
+++ b/js/extjs/fix-defer-before.js
@@ -1,8 +1,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/js/extjs/fix-defer.js
+++ b/js/extjs/fix-defer.js
@@ -5,9 +5,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Mage
  * @package     js

--- a/js/extjs/fix-defer.js
+++ b/js/extjs/fix-defer.js
@@ -3,8 +3,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    Mage
  * @package     js

--- a/js/extjs/fix-defer.js
+++ b/js/extjs/fix-defer.js
@@ -1,8 +1,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/js/index.php
+++ b/js/index.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Mage
  * @package     Mage

--- a/js/index.php
+++ b/js/index.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/js/index.php
+++ b/js/index.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Mage
  * @package     Mage

--- a/js/lib/dropdown.js
+++ b/js/lib/dropdown.js
@@ -5,9 +5,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Mage
  * @package     js

--- a/js/lib/dropdown.js
+++ b/js/lib/dropdown.js
@@ -3,8 +3,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    Mage
  * @package     js

--- a/js/lib/dropdown.js
+++ b/js/lib/dropdown.js
@@ -1,8 +1,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/js/lib/flex.js
+++ b/js/lib/flex.js
@@ -5,9 +5,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Mage
  * @package     js

--- a/js/lib/flex.js
+++ b/js/lib/flex.js
@@ -3,8 +3,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    Mage
  * @package     js

--- a/js/lib/flex.js
+++ b/js/lib/flex.js
@@ -1,8 +1,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/js/lib/jquery/noconflict.js
+++ b/js/lib/jquery/noconflict.js
@@ -5,9 +5,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Mage
  * @package     js

--- a/js/lib/jquery/noconflict.js
+++ b/js/lib/jquery/noconflict.js
@@ -3,8 +3,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    Mage
  * @package     js

--- a/js/lib/jquery/noconflict.js
+++ b/js/lib/jquery/noconflict.js
@@ -1,8 +1,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/js/mage/adminhtml/accordion.js
+++ b/js/mage/adminhtml/accordion.js
@@ -3,8 +3,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    Mage
  * @package     Mage_Adminhtml

--- a/js/mage/adminhtml/accordion.js
+++ b/js/mage/adminhtml/accordion.js
@@ -1,8 +1,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/js/mage/adminhtml/accordion.js
+++ b/js/mage/adminhtml/accordion.js
@@ -5,9 +5,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Mage
  * @package     Mage_Adminhtml

--- a/js/mage/adminhtml/backup.js
+++ b/js/mage/adminhtml/backup.js
@@ -3,8 +3,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    Mage
  * @package     Mage_Adminhtml

--- a/js/mage/adminhtml/backup.js
+++ b/js/mage/adminhtml/backup.js
@@ -1,8 +1,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/js/mage/adminhtml/backup.js
+++ b/js/mage/adminhtml/backup.js
@@ -5,9 +5,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Mage
  * @package     Mage_Adminhtml

--- a/js/mage/adminhtml/browser.js
+++ b/js/mage/adminhtml/browser.js
@@ -3,8 +3,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    Mage
  * @package     Mage_Adminhtml

--- a/js/mage/adminhtml/browser.js
+++ b/js/mage/adminhtml/browser.js
@@ -1,8 +1,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/js/mage/adminhtml/browser.js
+++ b/js/mage/adminhtml/browser.js
@@ -5,9 +5,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Mage
  * @package     Mage_Adminhtml

--- a/js/mage/adminhtml/events.js
+++ b/js/mage/adminhtml/events.js
@@ -3,8 +3,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    Mage
  * @package     Mage_Adminhtml

--- a/js/mage/adminhtml/events.js
+++ b/js/mage/adminhtml/events.js
@@ -1,8 +1,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/js/mage/adminhtml/events.js
+++ b/js/mage/adminhtml/events.js
@@ -5,9 +5,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Mage
  * @package     Mage_Adminhtml

--- a/js/mage/adminhtml/flexuploader.js
+++ b/js/mage/adminhtml/flexuploader.js
@@ -3,8 +3,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    Mage
  * @package     Mage_Adminhtml

--- a/js/mage/adminhtml/flexuploader.js
+++ b/js/mage/adminhtml/flexuploader.js
@@ -1,8 +1,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/js/mage/adminhtml/flexuploader.js
+++ b/js/mage/adminhtml/flexuploader.js
@@ -5,9 +5,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Mage
  * @package     Mage_Adminhtml

--- a/js/mage/adminhtml/form.js
+++ b/js/mage/adminhtml/form.js
@@ -3,8 +3,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    Mage
  * @package     Mage_Adminhtml

--- a/js/mage/adminhtml/form.js
+++ b/js/mage/adminhtml/form.js
@@ -1,8 +1,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/js/mage/adminhtml/form.js
+++ b/js/mage/adminhtml/form.js
@@ -5,9 +5,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Mage
  * @package     Mage_Adminhtml

--- a/js/mage/adminhtml/giftmessage.js
+++ b/js/mage/adminhtml/giftmessage.js
@@ -3,8 +3,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    Mage
  * @package     Mage_Adminhtml

--- a/js/mage/adminhtml/giftmessage.js
+++ b/js/mage/adminhtml/giftmessage.js
@@ -1,8 +1,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/js/mage/adminhtml/giftmessage.js
+++ b/js/mage/adminhtml/giftmessage.js
@@ -5,9 +5,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Mage
  * @package     Mage_Adminhtml

--- a/js/mage/adminhtml/giftoptions/tooltip.js
+++ b/js/mage/adminhtml/giftoptions/tooltip.js
@@ -3,8 +3,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    Mage
  * @package     Mage_Adminhtml

--- a/js/mage/adminhtml/giftoptions/tooltip.js
+++ b/js/mage/adminhtml/giftoptions/tooltip.js
@@ -1,8 +1,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/js/mage/adminhtml/giftoptions/tooltip.js
+++ b/js/mage/adminhtml/giftoptions/tooltip.js
@@ -5,9 +5,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Mage
  * @package     Mage_Adminhtml

--- a/js/mage/adminhtml/grid.js
+++ b/js/mage/adminhtml/grid.js
@@ -3,8 +3,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    Mage
  * @package     Mage_Adminhtml

--- a/js/mage/adminhtml/grid.js
+++ b/js/mage/adminhtml/grid.js
@@ -1,8 +1,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/js/mage/adminhtml/grid.js
+++ b/js/mage/adminhtml/grid.js
@@ -5,9 +5,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Mage
  * @package     Mage_Adminhtml

--- a/js/mage/adminhtml/hash.js
+++ b/js/mage/adminhtml/hash.js
@@ -3,8 +3,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    Mage
  * @package     Mage_Adminhtml

--- a/js/mage/adminhtml/hash.js
+++ b/js/mage/adminhtml/hash.js
@@ -1,8 +1,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/js/mage/adminhtml/hash.js
+++ b/js/mage/adminhtml/hash.js
@@ -5,9 +5,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Mage
  * @package     Mage_Adminhtml

--- a/js/mage/adminhtml/image.js
+++ b/js/mage/adminhtml/image.js
@@ -3,8 +3,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    Mage
  * @package     Mage_Adminhtml

--- a/js/mage/adminhtml/image.js
+++ b/js/mage/adminhtml/image.js
@@ -1,8 +1,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/js/mage/adminhtml/image.js
+++ b/js/mage/adminhtml/image.js
@@ -5,9 +5,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Mage
  * @package     Mage_Adminhtml

--- a/js/mage/adminhtml/loader.js
+++ b/js/mage/adminhtml/loader.js
@@ -3,8 +3,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    Mage
  * @package     Mage_Adminhtml

--- a/js/mage/adminhtml/loader.js
+++ b/js/mage/adminhtml/loader.js
@@ -1,8 +1,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/js/mage/adminhtml/loader.js
+++ b/js/mage/adminhtml/loader.js
@@ -5,9 +5,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Mage
  * @package     Mage_Adminhtml

--- a/js/mage/adminhtml/magento-all.js
+++ b/js/mage/adminhtml/magento-all.js
@@ -3,8 +3,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    Mage
  * @package     Mage_Adminhtml

--- a/js/mage/adminhtml/magento-all.js
+++ b/js/mage/adminhtml/magento-all.js
@@ -1,8 +1,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/js/mage/adminhtml/magento-all.js
+++ b/js/mage/adminhtml/magento-all.js
@@ -5,9 +5,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Mage
  * @package     Mage_Adminhtml

--- a/js/mage/adminhtml/product.js
+++ b/js/mage/adminhtml/product.js
@@ -3,8 +3,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    Mage
  * @package     Mage_Adminhtml

--- a/js/mage/adminhtml/product.js
+++ b/js/mage/adminhtml/product.js
@@ -1,8 +1,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/js/mage/adminhtml/product.js
+++ b/js/mage/adminhtml/product.js
@@ -5,9 +5,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Mage
  * @package     Mage_Adminhtml

--- a/js/mage/adminhtml/product/composite/configure.js
+++ b/js/mage/adminhtml/product/composite/configure.js
@@ -3,8 +3,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    Mage
  * @package     Mage_Adminhtml

--- a/js/mage/adminhtml/product/composite/configure.js
+++ b/js/mage/adminhtml/product/composite/configure.js
@@ -1,8 +1,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/js/mage/adminhtml/product/composite/configure.js
+++ b/js/mage/adminhtml/product/composite/configure.js
@@ -5,9 +5,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Mage
  * @package     Mage_Adminhtml

--- a/js/mage/adminhtml/rules.js
+++ b/js/mage/adminhtml/rules.js
@@ -3,8 +3,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    Mage
  * @package     Mage_Adminhtml

--- a/js/mage/adminhtml/rules.js
+++ b/js/mage/adminhtml/rules.js
@@ -1,8 +1,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/js/mage/adminhtml/rules.js
+++ b/js/mage/adminhtml/rules.js
@@ -5,9 +5,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Mage
  * @package     Mage_Adminhtml

--- a/js/mage/adminhtml/sales.js
+++ b/js/mage/adminhtml/sales.js
@@ -3,8 +3,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    Mage
  * @package     Mage_Adminhtml

--- a/js/mage/adminhtml/sales.js
+++ b/js/mage/adminhtml/sales.js
@@ -1,8 +1,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/js/mage/adminhtml/sales.js
+++ b/js/mage/adminhtml/sales.js
@@ -5,9 +5,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Mage
  * @package     Mage_Adminhtml

--- a/js/mage/adminhtml/sales/centinel.js
+++ b/js/mage/adminhtml/sales/centinel.js
@@ -3,8 +3,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    Mage
  * @package     Mage_Adminhtml

--- a/js/mage/adminhtml/sales/centinel.js
+++ b/js/mage/adminhtml/sales/centinel.js
@@ -1,8 +1,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/js/mage/adminhtml/sales/centinel.js
+++ b/js/mage/adminhtml/sales/centinel.js
@@ -5,9 +5,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Mage
  * @package     Mage_Adminhtml

--- a/js/mage/adminhtml/sales/packaging.js
+++ b/js/mage/adminhtml/sales/packaging.js
@@ -3,8 +3,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    Mage
  * @package     Mage_Adminhtml

--- a/js/mage/adminhtml/sales/packaging.js
+++ b/js/mage/adminhtml/sales/packaging.js
@@ -1,8 +1,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/js/mage/adminhtml/sales/packaging.js
+++ b/js/mage/adminhtml/sales/packaging.js
@@ -5,9 +5,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Mage
  * @package     Mage_Adminhtml

--- a/js/mage/adminhtml/scrollbar.js
+++ b/js/mage/adminhtml/scrollbar.js
@@ -3,8 +3,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    Mage
  * @package     Mage_Adminhtml

--- a/js/mage/adminhtml/scrollbar.js
+++ b/js/mage/adminhtml/scrollbar.js
@@ -1,8 +1,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/js/mage/adminhtml/scrollbar.js
+++ b/js/mage/adminhtml/scrollbar.js
@@ -5,9 +5,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Mage
  * @package     Mage_Adminhtml

--- a/js/mage/adminhtml/tabs.js
+++ b/js/mage/adminhtml/tabs.js
@@ -3,8 +3,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    Mage
  * @package     Mage_Adminhtml

--- a/js/mage/adminhtml/tabs.js
+++ b/js/mage/adminhtml/tabs.js
@@ -1,8 +1,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/js/mage/adminhtml/tabs.js
+++ b/js/mage/adminhtml/tabs.js
@@ -5,9 +5,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Mage
  * @package     Mage_Adminhtml

--- a/js/mage/adminhtml/tools.js
+++ b/js/mage/adminhtml/tools.js
@@ -3,8 +3,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    Mage
  * @package     Mage_Adminhtml

--- a/js/mage/adminhtml/tools.js
+++ b/js/mage/adminhtml/tools.js
@@ -1,8 +1,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/js/mage/adminhtml/tools.js
+++ b/js/mage/adminhtml/tools.js
@@ -5,9 +5,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Mage
  * @package     Mage_Adminhtml

--- a/js/mage/adminhtml/uploader.js
+++ b/js/mage/adminhtml/uploader.js
@@ -3,8 +3,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    Mage
  * @package     Mage_Adminhtml

--- a/js/mage/adminhtml/uploader.js
+++ b/js/mage/adminhtml/uploader.js
@@ -1,8 +1,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/js/mage/adminhtml/uploader.js
+++ b/js/mage/adminhtml/uploader.js
@@ -5,9 +5,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Mage
  * @package     Mage_Adminhtml

--- a/js/mage/adminhtml/uploader/instance.js
+++ b/js/mage/adminhtml/uploader/instance.js
@@ -3,8 +3,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    Mage
  * @package     Mage_Adminhtml

--- a/js/mage/adminhtml/uploader/instance.js
+++ b/js/mage/adminhtml/uploader/instance.js
@@ -1,8 +1,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/js/mage/adminhtml/uploader/instance.js
+++ b/js/mage/adminhtml/uploader/instance.js
@@ -5,9 +5,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Mage
  * @package     Mage_Adminhtml

--- a/js/mage/adminhtml/variables.js
+++ b/js/mage/adminhtml/variables.js
@@ -3,8 +3,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    Mage
  * @package     Mage_Adminhtml

--- a/js/mage/adminhtml/variables.js
+++ b/js/mage/adminhtml/variables.js
@@ -1,8 +1,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/js/mage/adminhtml/variables.js
+++ b/js/mage/adminhtml/variables.js
@@ -5,9 +5,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Mage
  * @package     Mage_Adminhtml

--- a/js/mage/adminhtml/wysiwyg/tiny_mce/plugins/magentovariable/editor_plugin.js
+++ b/js/mage/adminhtml/wysiwyg/tiny_mce/plugins/magentovariable/editor_plugin.js
@@ -3,8 +3,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    Mage
  * @package     Mage_Adminhtml

--- a/js/mage/adminhtml/wysiwyg/tiny_mce/plugins/magentovariable/editor_plugin.js
+++ b/js/mage/adminhtml/wysiwyg/tiny_mce/plugins/magentovariable/editor_plugin.js
@@ -1,8 +1,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/js/mage/adminhtml/wysiwyg/tiny_mce/plugins/magentovariable/editor_plugin.js
+++ b/js/mage/adminhtml/wysiwyg/tiny_mce/plugins/magentovariable/editor_plugin.js
@@ -5,9 +5,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Mage
  * @package     Mage_Adminhtml

--- a/js/mage/adminhtml/wysiwyg/tiny_mce/plugins/magentowidget/editor_plugin.js
+++ b/js/mage/adminhtml/wysiwyg/tiny_mce/plugins/magentowidget/editor_plugin.js
@@ -3,8 +3,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    Mage
  * @package     Mage_Adminhtml

--- a/js/mage/adminhtml/wysiwyg/tiny_mce/plugins/magentowidget/editor_plugin.js
+++ b/js/mage/adminhtml/wysiwyg/tiny_mce/plugins/magentowidget/editor_plugin.js
@@ -1,8 +1,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/js/mage/adminhtml/wysiwyg/tiny_mce/plugins/magentowidget/editor_plugin.js
+++ b/js/mage/adminhtml/wysiwyg/tiny_mce/plugins/magentowidget/editor_plugin.js
@@ -5,9 +5,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Mage
  * @package     Mage_Adminhtml

--- a/js/mage/adminhtml/wysiwyg/tiny_mce/setup.js
+++ b/js/mage/adminhtml/wysiwyg/tiny_mce/setup.js
@@ -3,8 +3,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    Mage
  * @package     Mage_Adminhtml

--- a/js/mage/adminhtml/wysiwyg/tiny_mce/setup.js
+++ b/js/mage/adminhtml/wysiwyg/tiny_mce/setup.js
@@ -1,8 +1,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/js/mage/adminhtml/wysiwyg/tiny_mce/setup.js
+++ b/js/mage/adminhtml/wysiwyg/tiny_mce/setup.js
@@ -5,9 +5,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Mage
  * @package     Mage_Adminhtml

--- a/js/mage/adminhtml/wysiwyg/tiny_mce/themes/advanced/skins/default/content.css
+++ b/js/mage/adminhtml/wysiwyg/tiny_mce/themes/advanced/skins/default/content.css
@@ -3,8 +3,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    Mage
  * @package     Mage_Adminhtml

--- a/js/mage/adminhtml/wysiwyg/tiny_mce/themes/advanced/skins/default/content.css
+++ b/js/mage/adminhtml/wysiwyg/tiny_mce/themes/advanced/skins/default/content.css
@@ -1,8 +1,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/js/mage/adminhtml/wysiwyg/tiny_mce/themes/advanced/skins/default/content.css
+++ b/js/mage/adminhtml/wysiwyg/tiny_mce/themes/advanced/skins/default/content.css
@@ -5,9 +5,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Mage
  * @package     Mage_Adminhtml

--- a/js/mage/adminhtml/wysiwyg/tiny_mce/themes/advanced/skins/default/dialog.css
+++ b/js/mage/adminhtml/wysiwyg/tiny_mce/themes/advanced/skins/default/dialog.css
@@ -3,8 +3,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    Mage
  * @package     Mage_Adminhtml

--- a/js/mage/adminhtml/wysiwyg/tiny_mce/themes/advanced/skins/default/dialog.css
+++ b/js/mage/adminhtml/wysiwyg/tiny_mce/themes/advanced/skins/default/dialog.css
@@ -1,8 +1,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/js/mage/adminhtml/wysiwyg/tiny_mce/themes/advanced/skins/default/dialog.css
+++ b/js/mage/adminhtml/wysiwyg/tiny_mce/themes/advanced/skins/default/dialog.css
@@ -5,9 +5,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Mage
  * @package     Mage_Adminhtml

--- a/js/mage/adminhtml/wysiwyg/widget.js
+++ b/js/mage/adminhtml/wysiwyg/widget.js
@@ -3,8 +3,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    Mage
  * @package     Mage_Adminhtml

--- a/js/mage/adminhtml/wysiwyg/widget.js
+++ b/js/mage/adminhtml/wysiwyg/widget.js
@@ -1,8 +1,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/js/mage/adminhtml/wysiwyg/widget.js
+++ b/js/mage/adminhtml/wysiwyg/widget.js
@@ -5,9 +5,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Mage
  * @package     Mage_Adminhtml

--- a/js/mage/captcha.js
+++ b/js/mage/captcha.js
@@ -5,9 +5,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Mage
  * @package     js

--- a/js/mage/captcha.js
+++ b/js/mage/captcha.js
@@ -3,8 +3,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    Mage
  * @package     js

--- a/js/mage/captcha.js
+++ b/js/mage/captcha.js
@@ -1,8 +1,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/js/mage/centinel.js
+++ b/js/mage/centinel.js
@@ -5,9 +5,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Mage
  * @package     js

--- a/js/mage/centinel.js
+++ b/js/mage/centinel.js
@@ -3,8 +3,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    Mage
  * @package     js

--- a/js/mage/centinel.js
+++ b/js/mage/centinel.js
@@ -1,8 +1,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/js/mage/cookies.js
+++ b/js/mage/cookies.js
@@ -5,9 +5,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Mage
  * @package     js

--- a/js/mage/cookies.js
+++ b/js/mage/cookies.js
@@ -3,8 +3,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    Mage
  * @package     js

--- a/js/mage/cookies.js
+++ b/js/mage/cookies.js
@@ -1,8 +1,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/js/mage/directpost.js
+++ b/js/mage/directpost.js
@@ -5,9 +5,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Mage
  * @package     js

--- a/js/mage/directpost.js
+++ b/js/mage/directpost.js
@@ -3,8 +3,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    Mage
  * @package     js

--- a/js/mage/directpost.js
+++ b/js/mage/directpost.js
@@ -1,8 +1,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/js/mage/translate.js
+++ b/js/mage/translate.js
@@ -5,9 +5,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Mage
  * @package     js

--- a/js/mage/translate.js
+++ b/js/mage/translate.js
@@ -3,8 +3,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    Mage
  * @package     js

--- a/js/mage/translate.js
+++ b/js/mage/translate.js
@@ -1,8 +1,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/js/mage/translate_inline.css
+++ b/js/mage/translate_inline.css
@@ -5,9 +5,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Mage
  * @package     js

--- a/js/mage/translate_inline.css
+++ b/js/mage/translate_inline.css
@@ -3,8 +3,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    Mage
  * @package     js

--- a/js/mage/translate_inline.css
+++ b/js/mage/translate_inline.css
@@ -1,8 +1,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/js/mage/translate_inline.js
+++ b/js/mage/translate_inline.js
@@ -5,9 +5,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Mage
  * @package     js

--- a/js/mage/translate_inline.js
+++ b/js/mage/translate_inline.js
@@ -3,8 +3,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    Mage
  * @package     js

--- a/js/mage/translate_inline.js
+++ b/js/mage/translate_inline.js
@@ -1,8 +1,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/js/varien/accordion.js
+++ b/js/varien/accordion.js
@@ -1,8 +1,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/js/varien/accordion.js
+++ b/js/varien/accordion.js
@@ -3,8 +3,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    Varien
  * @package     js

--- a/js/varien/accordion.js
+++ b/js/varien/accordion.js
@@ -5,9 +5,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Varien
  * @package     js

--- a/js/varien/configurable.js
+++ b/js/varien/configurable.js
@@ -1,8 +1,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/js/varien/configurable.js
+++ b/js/varien/configurable.js
@@ -3,8 +3,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    Varien
  * @package     js

--- a/js/varien/configurable.js
+++ b/js/varien/configurable.js
@@ -5,9 +5,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Varien
  * @package     js

--- a/js/varien/form.js
+++ b/js/varien/form.js
@@ -1,8 +1,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/js/varien/form.js
+++ b/js/varien/form.js
@@ -3,8 +3,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    Varien
  * @package     js

--- a/js/varien/form.js
+++ b/js/varien/form.js
@@ -5,9 +5,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Varien
  * @package     js

--- a/js/varien/iehover-fix.js
+++ b/js/varien/iehover-fix.js
@@ -1,8 +1,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/js/varien/iehover-fix.js
+++ b/js/varien/iehover-fix.js
@@ -3,8 +3,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    Varien
  * @package     js

--- a/js/varien/iehover-fix.js
+++ b/js/varien/iehover-fix.js
@@ -5,9 +5,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Varien
  * @package     js

--- a/js/varien/js.js
+++ b/js/varien/js.js
@@ -1,8 +1,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/js/varien/js.js
+++ b/js/varien/js.js
@@ -3,8 +3,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    Varien
  * @package     js

--- a/js/varien/js.js
+++ b/js/varien/js.js
@@ -5,9 +5,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Varien
  * @package     js

--- a/js/varien/menu.js
+++ b/js/varien/menu.js
@@ -1,8 +1,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/js/varien/menu.js
+++ b/js/varien/menu.js
@@ -3,8 +3,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    Varien
  * @package     js

--- a/js/varien/menu.js
+++ b/js/varien/menu.js
@@ -5,9 +5,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Varien
  * @package     js

--- a/js/varien/payment.js
+++ b/js/varien/payment.js
@@ -1,8 +1,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/js/varien/payment.js
+++ b/js/varien/payment.js
@@ -3,8 +3,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    Varien
  * @package     js

--- a/js/varien/payment.js
+++ b/js/varien/payment.js
@@ -5,9 +5,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Varien
  * @package     js

--- a/js/varien/product.js
+++ b/js/varien/product.js
@@ -1,8 +1,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/js/varien/product.js
+++ b/js/varien/product.js
@@ -3,8 +3,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    Varien
  * @package     js

--- a/js/varien/product.js
+++ b/js/varien/product.js
@@ -5,9 +5,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Varien
  * @package     js

--- a/js/varien/product_options.js
+++ b/js/varien/product_options.js
@@ -1,8 +1,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/js/varien/product_options.js
+++ b/js/varien/product_options.js
@@ -3,8 +3,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    Varien
  * @package     js

--- a/js/varien/product_options.js
+++ b/js/varien/product_options.js
@@ -5,9 +5,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Varien
  * @package     js

--- a/js/varien/telephone.js
+++ b/js/varien/telephone.js
@@ -1,8 +1,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/js/varien/telephone.js
+++ b/js/varien/telephone.js
@@ -3,8 +3,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    Varien
  * @package     js

--- a/js/varien/telephone.js
+++ b/js/varien/telephone.js
@@ -5,9 +5,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Varien
  * @package     js

--- a/js/varien/weee.js
+++ b/js/varien/weee.js
@@ -1,8 +1,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/js/varien/weee.js
+++ b/js/varien/weee.js
@@ -3,8 +3,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    Varien
  * @package     js

--- a/js/varien/weee.js
+++ b/js/varien/weee.js
@@ -5,9 +5,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Varien
  * @package     js

--- a/lib/Mage/Archive.php
+++ b/lib/Mage/Archive.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Mage/Archive.php
+++ b/lib/Mage/Archive.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Archive

--- a/lib/Mage/Archive.php
+++ b/lib/Mage/Archive.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Archive

--- a/lib/Mage/Archive/Abstract.php
+++ b/lib/Mage/Archive/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Mage/Archive/Abstract.php
+++ b/lib/Mage/Archive/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Archive

--- a/lib/Mage/Archive/Abstract.php
+++ b/lib/Mage/Archive/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Archive

--- a/lib/Mage/Archive/Bz.php
+++ b/lib/Mage/Archive/Bz.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Mage/Archive/Bz.php
+++ b/lib/Mage/Archive/Bz.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Archive

--- a/lib/Mage/Archive/Bz.php
+++ b/lib/Mage/Archive/Bz.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Archive

--- a/lib/Mage/Archive/Gz.php
+++ b/lib/Mage/Archive/Gz.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Mage/Archive/Gz.php
+++ b/lib/Mage/Archive/Gz.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Archive

--- a/lib/Mage/Archive/Gz.php
+++ b/lib/Mage/Archive/Gz.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Archive

--- a/lib/Mage/Archive/Helper/File.php
+++ b/lib/Mage/Archive/Helper/File.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Mage/Archive/Helper/File.php
+++ b/lib/Mage/Archive/Helper/File.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Archive

--- a/lib/Mage/Archive/Helper/File.php
+++ b/lib/Mage/Archive/Helper/File.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Archive

--- a/lib/Mage/Archive/Helper/File/Bz.php
+++ b/lib/Mage/Archive/Helper/File/Bz.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Mage/Archive/Helper/File/Bz.php
+++ b/lib/Mage/Archive/Helper/File/Bz.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Archive

--- a/lib/Mage/Archive/Helper/File/Bz.php
+++ b/lib/Mage/Archive/Helper/File/Bz.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Archive

--- a/lib/Mage/Archive/Helper/File/Gz.php
+++ b/lib/Mage/Archive/Helper/File/Gz.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Mage/Archive/Helper/File/Gz.php
+++ b/lib/Mage/Archive/Helper/File/Gz.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Archive

--- a/lib/Mage/Archive/Helper/File/Gz.php
+++ b/lib/Mage/Archive/Helper/File/Gz.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Archive

--- a/lib/Mage/Archive/Interface.php
+++ b/lib/Mage/Archive/Interface.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Mage/Archive/Interface.php
+++ b/lib/Mage/Archive/Interface.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Archive

--- a/lib/Mage/Archive/Interface.php
+++ b/lib/Mage/Archive/Interface.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Archive

--- a/lib/Mage/Archive/Tar.php
+++ b/lib/Mage/Archive/Tar.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Mage/Archive/Tar.php
+++ b/lib/Mage/Archive/Tar.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Archive

--- a/lib/Mage/Archive/Tar.php
+++ b/lib/Mage/Archive/Tar.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Archive

--- a/lib/Mage/Cache/Backend/File.php
+++ b/lib/Mage/Cache/Backend/File.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Mage/Cache/Backend/File.php
+++ b/lib/Mage/Cache/Backend/File.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Cache

--- a/lib/Mage/Cache/Backend/File.php
+++ b/lib/Mage/Cache/Backend/File.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Cache

--- a/lib/Mage/Cache/Backend/Redis.php
+++ b/lib/Mage/Cache/Backend/Redis.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Mage/Cache/Backend/Redis.php
+++ b/lib/Mage/Cache/Backend/Redis.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Cache

--- a/lib/Mage/Cache/Backend/Redis.php
+++ b/lib/Mage/Cache/Backend/Redis.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Cache

--- a/lib/Mage/DB/Exception.php
+++ b/lib/Mage/DB/Exception.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_DB

--- a/lib/Mage/DB/Exception.php
+++ b/lib/Mage/DB/Exception.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Mage/DB/Exception.php
+++ b/lib/Mage/DB/Exception.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_DB

--- a/lib/Mage/DB/Mysqli.php
+++ b/lib/Mage/DB/Mysqli.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_DB

--- a/lib/Mage/DB/Mysqli.php
+++ b/lib/Mage/DB/Mysqli.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Mage/DB/Mysqli.php
+++ b/lib/Mage/DB/Mysqli.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_DB

--- a/lib/Mage/Exception.php
+++ b/lib/Mage/Exception.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Mage/Exception.php
+++ b/lib/Mage/Exception.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Exception

--- a/lib/Mage/Exception.php
+++ b/lib/Mage/Exception.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Exception

--- a/lib/Mage/HTTP/Client.php
+++ b/lib/Mage/HTTP/Client.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Mage/HTTP/Client.php
+++ b/lib/Mage/HTTP/Client.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_HTTP

--- a/lib/Mage/HTTP/Client.php
+++ b/lib/Mage/HTTP/Client.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_HTTP

--- a/lib/Mage/HTTP/Client/Curl.php
+++ b/lib/Mage/HTTP/Client/Curl.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Mage/HTTP/Client/Curl.php
+++ b/lib/Mage/HTTP/Client/Curl.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_HTTP

--- a/lib/Mage/HTTP/Client/Curl.php
+++ b/lib/Mage/HTTP/Client/Curl.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_HTTP

--- a/lib/Mage/HTTP/Client/Socket.php
+++ b/lib/Mage/HTTP/Client/Socket.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Mage/HTTP/Client/Socket.php
+++ b/lib/Mage/HTTP/Client/Socket.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_HTTP

--- a/lib/Mage/HTTP/Client/Socket.php
+++ b/lib/Mage/HTTP/Client/Socket.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_HTTP

--- a/lib/Mage/HTTP/IClient.php
+++ b/lib/Mage/HTTP/IClient.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Mage/HTTP/IClient.php
+++ b/lib/Mage/HTTP/IClient.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_HTTP

--- a/lib/Mage/HTTP/IClient.php
+++ b/lib/Mage/HTTP/IClient.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_HTTP

--- a/lib/Mage/System/Args.php
+++ b/lib/Mage/System/Args.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_System

--- a/lib/Mage/System/Args.php
+++ b/lib/Mage/System/Args.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Mage/System/Args.php
+++ b/lib/Mage/System/Args.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_System

--- a/lib/Mage/System/Dirs.php
+++ b/lib/Mage/System/Dirs.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_System

--- a/lib/Mage/System/Dirs.php
+++ b/lib/Mage/System/Dirs.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Mage/System/Dirs.php
+++ b/lib/Mage/System/Dirs.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_System

--- a/lib/Mage/System/Ftp.php
+++ b/lib/Mage/System/Ftp.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_System

--- a/lib/Mage/System/Ftp.php
+++ b/lib/Mage/System/Ftp.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Mage/System/Ftp.php
+++ b/lib/Mage/System/Ftp.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_System

--- a/lib/Mage/Xml/Generator.php
+++ b/lib/Mage/Xml/Generator.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Xml

--- a/lib/Mage/Xml/Generator.php
+++ b/lib/Mage/Xml/Generator.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Xml

--- a/lib/Mage/Xml/Generator.php
+++ b/lib/Mage/Xml/Generator.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Mage/Xml/Parser.php
+++ b/lib/Mage/Xml/Parser.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Mage
  * @package    Mage_Xml

--- a/lib/Mage/Xml/Parser.php
+++ b/lib/Mage/Xml/Parser.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Mage
  * @package    Mage_Xml

--- a/lib/Mage/Xml/Parser.php
+++ b/lib/Mage/Xml/Parser.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Magento/Crypt.php
+++ b/lib/Magento/Crypt.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Magento/Crypt.php
+++ b/lib/Magento/Crypt.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Magento
  * @package    Magento_Crypt

--- a/lib/Magento/Crypt.php
+++ b/lib/Magento/Crypt.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Magento
  * @package    Magento_Crypt

--- a/lib/Magento/Db/Adapter/Pdo/Mysql.php
+++ b/lib/Magento/Db/Adapter/Pdo/Mysql.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Magento/Db/Adapter/Pdo/Mysql.php
+++ b/lib/Magento/Db/Adapter/Pdo/Mysql.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Magento
  * @package    Magento_Db

--- a/lib/Magento/Db/Adapter/Pdo/Mysql.php
+++ b/lib/Magento/Db/Adapter/Pdo/Mysql.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Magento
  * @package    Magento_Db

--- a/lib/Magento/Db/Object.php
+++ b/lib/Magento/Db/Object.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Magento/Db/Object.php
+++ b/lib/Magento/Db/Object.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Magento
  * @package    Magento_Db

--- a/lib/Magento/Db/Object.php
+++ b/lib/Magento/Db/Object.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Magento
  * @package    Magento_Db

--- a/lib/Magento/Db/Object/Interface.php
+++ b/lib/Magento/Db/Object/Interface.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Magento/Db/Object/Interface.php
+++ b/lib/Magento/Db/Object/Interface.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Magento
  * @package    Magento_Db

--- a/lib/Magento/Db/Object/Interface.php
+++ b/lib/Magento/Db/Object/Interface.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Magento
  * @package    Magento_Db

--- a/lib/Magento/Db/Object/Table.php
+++ b/lib/Magento/Db/Object/Table.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Magento/Db/Object/Table.php
+++ b/lib/Magento/Db/Object/Table.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Magento
  * @package    Magento_Db

--- a/lib/Magento/Db/Object/Table.php
+++ b/lib/Magento/Db/Object/Table.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Magento
  * @package    Magento_Db

--- a/lib/Magento/Db/Object/Trigger.php
+++ b/lib/Magento/Db/Object/Trigger.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Magento/Db/Object/Trigger.php
+++ b/lib/Magento/Db/Object/Trigger.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Magento
  * @package    Magento_Db

--- a/lib/Magento/Db/Object/Trigger.php
+++ b/lib/Magento/Db/Object/Trigger.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Magento
  * @package    Magento_Db

--- a/lib/Magento/Db/Object/View.php
+++ b/lib/Magento/Db/Object/View.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Magento/Db/Object/View.php
+++ b/lib/Magento/Db/Object/View.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Magento
  * @package    Magento_Db

--- a/lib/Magento/Db/Object/View.php
+++ b/lib/Magento/Db/Object/View.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Magento
  * @package    Magento_Db

--- a/lib/Magento/Db/Sql/Select.php
+++ b/lib/Magento/Db/Sql/Select.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Magento/Db/Sql/Select.php
+++ b/lib/Magento/Db/Sql/Select.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Magento
  * @package    Magento_Db

--- a/lib/Magento/Db/Sql/Select.php
+++ b/lib/Magento/Db/Sql/Select.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Magento
  * @package    Magento_Db

--- a/lib/Magento/Db/Sql/Trigger.php
+++ b/lib/Magento/Db/Sql/Trigger.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Magento/Db/Sql/Trigger.php
+++ b/lib/Magento/Db/Sql/Trigger.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Magento
  * @package    Magento_Db

--- a/lib/Magento/Db/Sql/Trigger.php
+++ b/lib/Magento/Db/Sql/Trigger.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Magento
  * @package    Magento_Db

--- a/lib/Magento/Exception.php
+++ b/lib/Magento/Exception.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Magento
  * @package    Magento_Exception

--- a/lib/Magento/Exception.php
+++ b/lib/Magento/Exception.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Magento/Exception.php
+++ b/lib/Magento/Exception.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Magento
  * @package    Magento_Exception

--- a/lib/Magento/Profiler.php
+++ b/lib/Magento/Profiler.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Magento/Profiler.php
+++ b/lib/Magento/Profiler.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Magento
  * @package    Magento_Profiler

--- a/lib/Magento/Profiler.php
+++ b/lib/Magento/Profiler.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Magento
  * @package    Magento_Profiler

--- a/lib/Magento/Profiler/Output/Csvfile.php
+++ b/lib/Magento/Profiler/Output/Csvfile.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Magento/Profiler/Output/Csvfile.php
+++ b/lib/Magento/Profiler/Output/Csvfile.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Magento
  * @package    Magento_Profiler

--- a/lib/Magento/Profiler/Output/Csvfile.php
+++ b/lib/Magento/Profiler/Output/Csvfile.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Magento
  * @package    Magento_Profiler

--- a/lib/Magento/Profiler/Output/Firebug.php
+++ b/lib/Magento/Profiler/Output/Firebug.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Magento/Profiler/Output/Firebug.php
+++ b/lib/Magento/Profiler/Output/Firebug.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Magento
  * @package    Magento_Profiler

--- a/lib/Magento/Profiler/Output/Firebug.php
+++ b/lib/Magento/Profiler/Output/Firebug.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Magento
  * @package    Magento_Profiler

--- a/lib/Magento/Profiler/Output/Html.php
+++ b/lib/Magento/Profiler/Output/Html.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Magento/Profiler/Output/Html.php
+++ b/lib/Magento/Profiler/Output/Html.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Magento
  * @package    Magento_Profiler

--- a/lib/Magento/Profiler/Output/Html.php
+++ b/lib/Magento/Profiler/Output/Html.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Magento
  * @package    Magento_Profiler

--- a/lib/Magento/Profiler/OutputAbstract.php
+++ b/lib/Magento/Profiler/OutputAbstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Magento/Profiler/OutputAbstract.php
+++ b/lib/Magento/Profiler/OutputAbstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Magento
  * @package    Magento_Profiler

--- a/lib/Magento/Profiler/OutputAbstract.php
+++ b/lib/Magento/Profiler/OutputAbstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Magento
  * @package    Magento_Profiler

--- a/lib/Unserialize/Parser.php
+++ b/lib/Unserialize/Parser.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Unserialize
  * @package     Unserialize_Parser

--- a/lib/Unserialize/Parser.php
+++ b/lib/Unserialize/Parser.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Unserialize/Parser.php
+++ b/lib/Unserialize/Parser.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Unserialize
  * @package     Unserialize_Parser

--- a/lib/Unserialize/Reader/Arr.php
+++ b/lib/Unserialize/Reader/Arr.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Unserialize/Reader/Arr.php
+++ b/lib/Unserialize/Reader/Arr.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Unserialize
  * @package     Unserialize_Reader

--- a/lib/Unserialize/Reader/Arr.php
+++ b/lib/Unserialize/Reader/Arr.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Unserialize
  * @package     Unserialize_Reader

--- a/lib/Unserialize/Reader/ArrKey.php
+++ b/lib/Unserialize/Reader/ArrKey.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Unserialize/Reader/ArrKey.php
+++ b/lib/Unserialize/Reader/ArrKey.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Unserialize
  * @package     Unserialize_Reader

--- a/lib/Unserialize/Reader/ArrKey.php
+++ b/lib/Unserialize/Reader/ArrKey.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Unserialize
  * @package     Unserialize_Reader

--- a/lib/Unserialize/Reader/ArrValue.php
+++ b/lib/Unserialize/Reader/ArrValue.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Unserialize/Reader/ArrValue.php
+++ b/lib/Unserialize/Reader/ArrValue.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Unserialize
  * @package     Unserialize_Reader

--- a/lib/Unserialize/Reader/ArrValue.php
+++ b/lib/Unserialize/Reader/ArrValue.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Unserialize
  * @package     Unserialize_Reader

--- a/lib/Unserialize/Reader/Bool.php
+++ b/lib/Unserialize/Reader/Bool.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Unserialize/Reader/Bool.php
+++ b/lib/Unserialize/Reader/Bool.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Unserialize
  * @package     Unserialize_Reader

--- a/lib/Unserialize/Reader/Bool.php
+++ b/lib/Unserialize/Reader/Bool.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Unserialize
  * @package     Unserialize_Reader

--- a/lib/Unserialize/Reader/Dbl.php
+++ b/lib/Unserialize/Reader/Dbl.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Unserialize/Reader/Dbl.php
+++ b/lib/Unserialize/Reader/Dbl.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Unserialize
  * @package     Unserialize_Reader

--- a/lib/Unserialize/Reader/Dbl.php
+++ b/lib/Unserialize/Reader/Dbl.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Unserialize
  * @package     Unserialize_Reader

--- a/lib/Unserialize/Reader/Int.php
+++ b/lib/Unserialize/Reader/Int.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Unserialize/Reader/Int.php
+++ b/lib/Unserialize/Reader/Int.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Unserialize
  * @package     Unserialize_Reader

--- a/lib/Unserialize/Reader/Int.php
+++ b/lib/Unserialize/Reader/Int.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Unserialize
  * @package     Unserialize_Reader

--- a/lib/Unserialize/Reader/Null.php
+++ b/lib/Unserialize/Reader/Null.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Unserialize/Reader/Null.php
+++ b/lib/Unserialize/Reader/Null.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Unserialize
  * @package     Unserialize_Reader

--- a/lib/Unserialize/Reader/Null.php
+++ b/lib/Unserialize/Reader/Null.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Unserialize
  * @package     Unserialize_Reader

--- a/lib/Unserialize/Reader/Str.php
+++ b/lib/Unserialize/Reader/Str.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Unserialize/Reader/Str.php
+++ b/lib/Unserialize/Reader/Str.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Unserialize
  * @package     Unserialize_Reader

--- a/lib/Unserialize/Reader/Str.php
+++ b/lib/Unserialize/Reader/Str.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Unserialize
  * @package     Unserialize_Reader

--- a/lib/Varien/Autoload.php
+++ b/lib/Varien/Autoload.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Autoload

--- a/lib/Varien/Autoload.php
+++ b/lib/Varien/Autoload.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Autoload.php
+++ b/lib/Varien/Autoload.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Autoload

--- a/lib/Varien/Cache/Backend/Database.php
+++ b/lib/Varien/Cache/Backend/Database.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Cache/Backend/Database.php
+++ b/lib/Varien/Cache/Backend/Database.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Cache

--- a/lib/Varien/Cache/Backend/Database.php
+++ b/lib/Varien/Cache/Backend/Database.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Cache

--- a/lib/Varien/Cache/Backend/Memcached.php
+++ b/lib/Varien/Cache/Backend/Memcached.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Cache/Backend/Memcached.php
+++ b/lib/Varien/Cache/Backend/Memcached.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Cache

--- a/lib/Varien/Cache/Backend/Memcached.php
+++ b/lib/Varien/Cache/Backend/Memcached.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Cache

--- a/lib/Varien/Cache/Core.php
+++ b/lib/Varien/Cache/Core.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Cache/Core.php
+++ b/lib/Varien/Cache/Core.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Cache

--- a/lib/Varien/Cache/Core.php
+++ b/lib/Varien/Cache/Core.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Cache

--- a/lib/Varien/Convert.php
+++ b/lib/Varien/Convert.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Convert

--- a/lib/Varien/Convert.php
+++ b/lib/Varien/Convert.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Convert.php
+++ b/lib/Varien/Convert.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Convert

--- a/lib/Varien/Convert/Action.php
+++ b/lib/Varien/Convert/Action.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Convert

--- a/lib/Varien/Convert/Action.php
+++ b/lib/Varien/Convert/Action.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Convert/Action.php
+++ b/lib/Varien/Convert/Action.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Convert

--- a/lib/Varien/Convert/Action/Abstract.php
+++ b/lib/Varien/Convert/Action/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Convert

--- a/lib/Varien/Convert/Action/Abstract.php
+++ b/lib/Varien/Convert/Action/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Convert/Action/Abstract.php
+++ b/lib/Varien/Convert/Action/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Convert

--- a/lib/Varien/Convert/Action/Interface.php
+++ b/lib/Varien/Convert/Action/Interface.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Convert

--- a/lib/Varien/Convert/Action/Interface.php
+++ b/lib/Varien/Convert/Action/Interface.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Convert/Action/Interface.php
+++ b/lib/Varien/Convert/Action/Interface.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Convert

--- a/lib/Varien/Convert/Adapter/Abstract.php
+++ b/lib/Varien/Convert/Adapter/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Convert

--- a/lib/Varien/Convert/Adapter/Abstract.php
+++ b/lib/Varien/Convert/Adapter/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Convert/Adapter/Abstract.php
+++ b/lib/Varien/Convert/Adapter/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Convert

--- a/lib/Varien/Convert/Adapter/Db/Table.php
+++ b/lib/Varien/Convert/Adapter/Db/Table.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Convert

--- a/lib/Varien/Convert/Adapter/Db/Table.php
+++ b/lib/Varien/Convert/Adapter/Db/Table.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Convert/Adapter/Db/Table.php
+++ b/lib/Varien/Convert/Adapter/Db/Table.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Convert

--- a/lib/Varien/Convert/Adapter/Http.php
+++ b/lib/Varien/Convert/Adapter/Http.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Convert

--- a/lib/Varien/Convert/Adapter/Http.php
+++ b/lib/Varien/Convert/Adapter/Http.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Convert/Adapter/Http.php
+++ b/lib/Varien/Convert/Adapter/Http.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Convert

--- a/lib/Varien/Convert/Adapter/Http/Curl.php
+++ b/lib/Varien/Convert/Adapter/Http/Curl.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Convert

--- a/lib/Varien/Convert/Adapter/Http/Curl.php
+++ b/lib/Varien/Convert/Adapter/Http/Curl.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Convert/Adapter/Http/Curl.php
+++ b/lib/Varien/Convert/Adapter/Http/Curl.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Convert

--- a/lib/Varien/Convert/Adapter/Interface.php
+++ b/lib/Varien/Convert/Adapter/Interface.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Convert

--- a/lib/Varien/Convert/Adapter/Interface.php
+++ b/lib/Varien/Convert/Adapter/Interface.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Convert/Adapter/Interface.php
+++ b/lib/Varien/Convert/Adapter/Interface.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Convert

--- a/lib/Varien/Convert/Adapter/Io.php
+++ b/lib/Varien/Convert/Adapter/Io.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Convert

--- a/lib/Varien/Convert/Adapter/Io.php
+++ b/lib/Varien/Convert/Adapter/Io.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Convert/Adapter/Io.php
+++ b/lib/Varien/Convert/Adapter/Io.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Convert

--- a/lib/Varien/Convert/Adapter/Soap.php
+++ b/lib/Varien/Convert/Adapter/Soap.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Convert

--- a/lib/Varien/Convert/Adapter/Soap.php
+++ b/lib/Varien/Convert/Adapter/Soap.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Convert/Adapter/Soap.php
+++ b/lib/Varien/Convert/Adapter/Soap.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Convert

--- a/lib/Varien/Convert/Adapter/Std.php
+++ b/lib/Varien/Convert/Adapter/Std.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Convert

--- a/lib/Varien/Convert/Adapter/Std.php
+++ b/lib/Varien/Convert/Adapter/Std.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Convert/Adapter/Std.php
+++ b/lib/Varien/Convert/Adapter/Std.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Convert

--- a/lib/Varien/Convert/Adapter/Zend/Cache.php
+++ b/lib/Varien/Convert/Adapter/Zend/Cache.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Convert

--- a/lib/Varien/Convert/Adapter/Zend/Cache.php
+++ b/lib/Varien/Convert/Adapter/Zend/Cache.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Convert/Adapter/Zend/Cache.php
+++ b/lib/Varien/Convert/Adapter/Zend/Cache.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Convert

--- a/lib/Varien/Convert/Adapter/Zend/Db.php
+++ b/lib/Varien/Convert/Adapter/Zend/Db.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Convert

--- a/lib/Varien/Convert/Adapter/Zend/Db.php
+++ b/lib/Varien/Convert/Adapter/Zend/Db.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Convert/Adapter/Zend/Db.php
+++ b/lib/Varien/Convert/Adapter/Zend/Db.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Convert

--- a/lib/Varien/Convert/Container/Abstract.php
+++ b/lib/Varien/Convert/Container/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Convert

--- a/lib/Varien/Convert/Container/Abstract.php
+++ b/lib/Varien/Convert/Container/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Convert/Container/Abstract.php
+++ b/lib/Varien/Convert/Container/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Convert

--- a/lib/Varien/Convert/Container/Collection.php
+++ b/lib/Varien/Convert/Container/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Convert

--- a/lib/Varien/Convert/Container/Collection.php
+++ b/lib/Varien/Convert/Container/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Convert/Container/Collection.php
+++ b/lib/Varien/Convert/Container/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Convert

--- a/lib/Varien/Convert/Container/Generic.php
+++ b/lib/Varien/Convert/Container/Generic.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Convert

--- a/lib/Varien/Convert/Container/Generic.php
+++ b/lib/Varien/Convert/Container/Generic.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Convert/Container/Generic.php
+++ b/lib/Varien/Convert/Container/Generic.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Convert

--- a/lib/Varien/Convert/Container/Interface.php
+++ b/lib/Varien/Convert/Container/Interface.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Convert

--- a/lib/Varien/Convert/Container/Interface.php
+++ b/lib/Varien/Convert/Container/Interface.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Convert/Container/Interface.php
+++ b/lib/Varien/Convert/Container/Interface.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Convert

--- a/lib/Varien/Convert/Exception.php
+++ b/lib/Varien/Convert/Exception.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Convert

--- a/lib/Varien/Convert/Exception.php
+++ b/lib/Varien/Convert/Exception.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Convert/Exception.php
+++ b/lib/Varien/Convert/Exception.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Convert

--- a/lib/Varien/Convert/Mapper/Abstract.php
+++ b/lib/Varien/Convert/Mapper/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Convert

--- a/lib/Varien/Convert/Mapper/Abstract.php
+++ b/lib/Varien/Convert/Mapper/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Convert/Mapper/Abstract.php
+++ b/lib/Varien/Convert/Mapper/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Convert

--- a/lib/Varien/Convert/Mapper/Column.php
+++ b/lib/Varien/Convert/Mapper/Column.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Convert

--- a/lib/Varien/Convert/Mapper/Column.php
+++ b/lib/Varien/Convert/Mapper/Column.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Convert/Mapper/Column.php
+++ b/lib/Varien/Convert/Mapper/Column.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Convert

--- a/lib/Varien/Convert/Mapper/Interface.php
+++ b/lib/Varien/Convert/Mapper/Interface.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Convert

--- a/lib/Varien/Convert/Mapper/Interface.php
+++ b/lib/Varien/Convert/Mapper/Interface.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Convert/Mapper/Interface.php
+++ b/lib/Varien/Convert/Mapper/Interface.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Convert

--- a/lib/Varien/Convert/Parser/Abstract.php
+++ b/lib/Varien/Convert/Parser/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Convert

--- a/lib/Varien/Convert/Parser/Abstract.php
+++ b/lib/Varien/Convert/Parser/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Convert/Parser/Abstract.php
+++ b/lib/Varien/Convert/Parser/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Convert

--- a/lib/Varien/Convert/Parser/Csv.php
+++ b/lib/Varien/Convert/Parser/Csv.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Convert

--- a/lib/Varien/Convert/Parser/Csv.php
+++ b/lib/Varien/Convert/Parser/Csv.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Convert/Parser/Csv.php
+++ b/lib/Varien/Convert/Parser/Csv.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Convert

--- a/lib/Varien/Convert/Parser/Interface.php
+++ b/lib/Varien/Convert/Parser/Interface.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Convert

--- a/lib/Varien/Convert/Parser/Interface.php
+++ b/lib/Varien/Convert/Parser/Interface.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Convert/Parser/Interface.php
+++ b/lib/Varien/Convert/Parser/Interface.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Convert

--- a/lib/Varien/Convert/Parser/Serialize.php
+++ b/lib/Varien/Convert/Parser/Serialize.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Convert

--- a/lib/Varien/Convert/Parser/Serialize.php
+++ b/lib/Varien/Convert/Parser/Serialize.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Convert/Parser/Serialize.php
+++ b/lib/Varien/Convert/Parser/Serialize.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Convert

--- a/lib/Varien/Convert/Parser/Xml/Excel.php
+++ b/lib/Varien/Convert/Parser/Xml/Excel.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Convert

--- a/lib/Varien/Convert/Parser/Xml/Excel.php
+++ b/lib/Varien/Convert/Parser/Xml/Excel.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Convert/Parser/Xml/Excel.php
+++ b/lib/Varien/Convert/Parser/Xml/Excel.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Convert

--- a/lib/Varien/Convert/Profile.php
+++ b/lib/Varien/Convert/Profile.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Convert

--- a/lib/Varien/Convert/Profile.php
+++ b/lib/Varien/Convert/Profile.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Convert/Profile.php
+++ b/lib/Varien/Convert/Profile.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Convert

--- a/lib/Varien/Convert/Profile/Abstract.php
+++ b/lib/Varien/Convert/Profile/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Convert

--- a/lib/Varien/Convert/Profile/Abstract.php
+++ b/lib/Varien/Convert/Profile/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Convert/Profile/Abstract.php
+++ b/lib/Varien/Convert/Profile/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Convert

--- a/lib/Varien/Convert/Profile/Collection.php
+++ b/lib/Varien/Convert/Profile/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Convert

--- a/lib/Varien/Convert/Profile/Collection.php
+++ b/lib/Varien/Convert/Profile/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Convert/Profile/Collection.php
+++ b/lib/Varien/Convert/Profile/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Convert

--- a/lib/Varien/Convert/Validator/Abstract.php
+++ b/lib/Varien/Convert/Validator/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Convert

--- a/lib/Varien/Convert/Validator/Abstract.php
+++ b/lib/Varien/Convert/Validator/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Convert/Validator/Abstract.php
+++ b/lib/Varien/Convert/Validator/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Convert

--- a/lib/Varien/Convert/Validator/Column.php
+++ b/lib/Varien/Convert/Validator/Column.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Convert

--- a/lib/Varien/Convert/Validator/Column.php
+++ b/lib/Varien/Convert/Validator/Column.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Convert/Validator/Column.php
+++ b/lib/Varien/Convert/Validator/Column.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Convert

--- a/lib/Varien/Convert/Validator/Dryrun.php
+++ b/lib/Varien/Convert/Validator/Dryrun.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Convert

--- a/lib/Varien/Convert/Validator/Dryrun.php
+++ b/lib/Varien/Convert/Validator/Dryrun.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Convert/Validator/Dryrun.php
+++ b/lib/Varien/Convert/Validator/Dryrun.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Convert

--- a/lib/Varien/Convert/Validator/Interface.php
+++ b/lib/Varien/Convert/Validator/Interface.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Convert

--- a/lib/Varien/Convert/Validator/Interface.php
+++ b/lib/Varien/Convert/Validator/Interface.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Convert/Validator/Interface.php
+++ b/lib/Varien/Convert/Validator/Interface.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Convert

--- a/lib/Varien/Crypt.php
+++ b/lib/Varien/Crypt.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Crypt

--- a/lib/Varien/Crypt.php
+++ b/lib/Varien/Crypt.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Crypt.php
+++ b/lib/Varien/Crypt.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Crypt

--- a/lib/Varien/Crypt/Abstract.php
+++ b/lib/Varien/Crypt/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Crypt

--- a/lib/Varien/Crypt/Abstract.php
+++ b/lib/Varien/Crypt/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Crypt/Abstract.php
+++ b/lib/Varien/Crypt/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Crypt

--- a/lib/Varien/Crypt/Mcrypt.php
+++ b/lib/Varien/Crypt/Mcrypt.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Crypt

--- a/lib/Varien/Crypt/Mcrypt.php
+++ b/lib/Varien/Crypt/Mcrypt.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Crypt/Mcrypt.php
+++ b/lib/Varien/Crypt/Mcrypt.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Crypt

--- a/lib/Varien/Data/Collection.php
+++ b/lib/Varien/Data/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Data

--- a/lib/Varien/Data/Collection.php
+++ b/lib/Varien/Data/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Data/Collection.php
+++ b/lib/Varien/Data/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Data

--- a/lib/Varien/Data/Collection/Db.php
+++ b/lib/Varien/Data/Collection/Db.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Data

--- a/lib/Varien/Data/Collection/Db.php
+++ b/lib/Varien/Data/Collection/Db.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Data/Collection/Db.php
+++ b/lib/Varien/Data/Collection/Db.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Data

--- a/lib/Varien/Data/Collection/Filesystem.php
+++ b/lib/Varien/Data/Collection/Filesystem.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Data

--- a/lib/Varien/Data/Collection/Filesystem.php
+++ b/lib/Varien/Data/Collection/Filesystem.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Data/Collection/Filesystem.php
+++ b/lib/Varien/Data/Collection/Filesystem.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Data

--- a/lib/Varien/Data/Form.php
+++ b/lib/Varien/Data/Form.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Data

--- a/lib/Varien/Data/Form.php
+++ b/lib/Varien/Data/Form.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Data/Form.php
+++ b/lib/Varien/Data/Form.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Data

--- a/lib/Varien/Data/Form/Abstract.php
+++ b/lib/Varien/Data/Form/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Data

--- a/lib/Varien/Data/Form/Abstract.php
+++ b/lib/Varien/Data/Form/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Data/Form/Abstract.php
+++ b/lib/Varien/Data/Form/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Data

--- a/lib/Varien/Data/Form/Element/Abstract.php
+++ b/lib/Varien/Data/Form/Element/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Data

--- a/lib/Varien/Data/Form/Element/Abstract.php
+++ b/lib/Varien/Data/Form/Element/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Data/Form/Element/Abstract.php
+++ b/lib/Varien/Data/Form/Element/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Data

--- a/lib/Varien/Data/Form/Element/Button.php
+++ b/lib/Varien/Data/Form/Element/Button.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Data

--- a/lib/Varien/Data/Form/Element/Button.php
+++ b/lib/Varien/Data/Form/Element/Button.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Data/Form/Element/Button.php
+++ b/lib/Varien/Data/Form/Element/Button.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Data

--- a/lib/Varien/Data/Form/Element/Checkbox.php
+++ b/lib/Varien/Data/Form/Element/Checkbox.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Data

--- a/lib/Varien/Data/Form/Element/Checkbox.php
+++ b/lib/Varien/Data/Form/Element/Checkbox.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Data/Form/Element/Checkbox.php
+++ b/lib/Varien/Data/Form/Element/Checkbox.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Data

--- a/lib/Varien/Data/Form/Element/Checkboxes.php
+++ b/lib/Varien/Data/Form/Element/Checkboxes.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Data

--- a/lib/Varien/Data/Form/Element/Checkboxes.php
+++ b/lib/Varien/Data/Form/Element/Checkboxes.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Data/Form/Element/Checkboxes.php
+++ b/lib/Varien/Data/Form/Element/Checkboxes.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Data

--- a/lib/Varien/Data/Form/Element/Collection.php
+++ b/lib/Varien/Data/Form/Element/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Data

--- a/lib/Varien/Data/Form/Element/Collection.php
+++ b/lib/Varien/Data/Form/Element/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Data/Form/Element/Collection.php
+++ b/lib/Varien/Data/Form/Element/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Data

--- a/lib/Varien/Data/Form/Element/Color.php
+++ b/lib/Varien/Data/Form/Element/Color.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Data

--- a/lib/Varien/Data/Form/Element/Color.php
+++ b/lib/Varien/Data/Form/Element/Color.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Data/Form/Element/Color.php
+++ b/lib/Varien/Data/Form/Element/Color.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Data

--- a/lib/Varien/Data/Form/Element/Column.php
+++ b/lib/Varien/Data/Form/Element/Column.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Data

--- a/lib/Varien/Data/Form/Element/Column.php
+++ b/lib/Varien/Data/Form/Element/Column.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Data/Form/Element/Column.php
+++ b/lib/Varien/Data/Form/Element/Column.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Data

--- a/lib/Varien/Data/Form/Element/Date.php
+++ b/lib/Varien/Data/Form/Element/Date.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Data

--- a/lib/Varien/Data/Form/Element/Date.php
+++ b/lib/Varien/Data/Form/Element/Date.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Data/Form/Element/Date.php
+++ b/lib/Varien/Data/Form/Element/Date.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Data

--- a/lib/Varien/Data/Form/Element/Datetime.php
+++ b/lib/Varien/Data/Form/Element/Datetime.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Data

--- a/lib/Varien/Data/Form/Element/Datetime.php
+++ b/lib/Varien/Data/Form/Element/Datetime.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Data/Form/Element/Datetime.php
+++ b/lib/Varien/Data/Form/Element/Datetime.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Data

--- a/lib/Varien/Data/Form/Element/Editor.php
+++ b/lib/Varien/Data/Form/Element/Editor.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Data

--- a/lib/Varien/Data/Form/Element/Editor.php
+++ b/lib/Varien/Data/Form/Element/Editor.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Data/Form/Element/Editor.php
+++ b/lib/Varien/Data/Form/Element/Editor.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Data

--- a/lib/Varien/Data/Form/Element/Fieldset.php
+++ b/lib/Varien/Data/Form/Element/Fieldset.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Data

--- a/lib/Varien/Data/Form/Element/Fieldset.php
+++ b/lib/Varien/Data/Form/Element/Fieldset.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Data/Form/Element/Fieldset.php
+++ b/lib/Varien/Data/Form/Element/Fieldset.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Data

--- a/lib/Varien/Data/Form/Element/File.php
+++ b/lib/Varien/Data/Form/Element/File.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Data

--- a/lib/Varien/Data/Form/Element/File.php
+++ b/lib/Varien/Data/Form/Element/File.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Data/Form/Element/File.php
+++ b/lib/Varien/Data/Form/Element/File.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Data

--- a/lib/Varien/Data/Form/Element/Gallery.php
+++ b/lib/Varien/Data/Form/Element/Gallery.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Data

--- a/lib/Varien/Data/Form/Element/Gallery.php
+++ b/lib/Varien/Data/Form/Element/Gallery.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Data/Form/Element/Gallery.php
+++ b/lib/Varien/Data/Form/Element/Gallery.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Data

--- a/lib/Varien/Data/Form/Element/Hidden.php
+++ b/lib/Varien/Data/Form/Element/Hidden.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Data

--- a/lib/Varien/Data/Form/Element/Hidden.php
+++ b/lib/Varien/Data/Form/Element/Hidden.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Data/Form/Element/Hidden.php
+++ b/lib/Varien/Data/Form/Element/Hidden.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Data

--- a/lib/Varien/Data/Form/Element/Image.php
+++ b/lib/Varien/Data/Form/Element/Image.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Data

--- a/lib/Varien/Data/Form/Element/Image.php
+++ b/lib/Varien/Data/Form/Element/Image.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Data/Form/Element/Image.php
+++ b/lib/Varien/Data/Form/Element/Image.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Data

--- a/lib/Varien/Data/Form/Element/Imagefile.php
+++ b/lib/Varien/Data/Form/Element/Imagefile.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Data

--- a/lib/Varien/Data/Form/Element/Imagefile.php
+++ b/lib/Varien/Data/Form/Element/Imagefile.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Data/Form/Element/Imagefile.php
+++ b/lib/Varien/Data/Form/Element/Imagefile.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Data

--- a/lib/Varien/Data/Form/Element/Label.php
+++ b/lib/Varien/Data/Form/Element/Label.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Data

--- a/lib/Varien/Data/Form/Element/Label.php
+++ b/lib/Varien/Data/Form/Element/Label.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Data/Form/Element/Label.php
+++ b/lib/Varien/Data/Form/Element/Label.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Data

--- a/lib/Varien/Data/Form/Element/Link.php
+++ b/lib/Varien/Data/Form/Element/Link.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Data

--- a/lib/Varien/Data/Form/Element/Link.php
+++ b/lib/Varien/Data/Form/Element/Link.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Data/Form/Element/Link.php
+++ b/lib/Varien/Data/Form/Element/Link.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Data

--- a/lib/Varien/Data/Form/Element/Multiline.php
+++ b/lib/Varien/Data/Form/Element/Multiline.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Data

--- a/lib/Varien/Data/Form/Element/Multiline.php
+++ b/lib/Varien/Data/Form/Element/Multiline.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Data/Form/Element/Multiline.php
+++ b/lib/Varien/Data/Form/Element/Multiline.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Data

--- a/lib/Varien/Data/Form/Element/Multiselect.php
+++ b/lib/Varien/Data/Form/Element/Multiselect.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Data

--- a/lib/Varien/Data/Form/Element/Multiselect.php
+++ b/lib/Varien/Data/Form/Element/Multiselect.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Data/Form/Element/Multiselect.php
+++ b/lib/Varien/Data/Form/Element/Multiselect.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Data

--- a/lib/Varien/Data/Form/Element/Note.php
+++ b/lib/Varien/Data/Form/Element/Note.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Data

--- a/lib/Varien/Data/Form/Element/Note.php
+++ b/lib/Varien/Data/Form/Element/Note.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Data/Form/Element/Note.php
+++ b/lib/Varien/Data/Form/Element/Note.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Data

--- a/lib/Varien/Data/Form/Element/Obscure.php
+++ b/lib/Varien/Data/Form/Element/Obscure.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Data

--- a/lib/Varien/Data/Form/Element/Obscure.php
+++ b/lib/Varien/Data/Form/Element/Obscure.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Data/Form/Element/Obscure.php
+++ b/lib/Varien/Data/Form/Element/Obscure.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Data

--- a/lib/Varien/Data/Form/Element/Password.php
+++ b/lib/Varien/Data/Form/Element/Password.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Data

--- a/lib/Varien/Data/Form/Element/Password.php
+++ b/lib/Varien/Data/Form/Element/Password.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Data/Form/Element/Password.php
+++ b/lib/Varien/Data/Form/Element/Password.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Data

--- a/lib/Varien/Data/Form/Element/Radio.php
+++ b/lib/Varien/Data/Form/Element/Radio.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Data

--- a/lib/Varien/Data/Form/Element/Radio.php
+++ b/lib/Varien/Data/Form/Element/Radio.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Data/Form/Element/Radio.php
+++ b/lib/Varien/Data/Form/Element/Radio.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Data

--- a/lib/Varien/Data/Form/Element/Radios.php
+++ b/lib/Varien/Data/Form/Element/Radios.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Data

--- a/lib/Varien/Data/Form/Element/Radios.php
+++ b/lib/Varien/Data/Form/Element/Radios.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Data/Form/Element/Radios.php
+++ b/lib/Varien/Data/Form/Element/Radios.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Data

--- a/lib/Varien/Data/Form/Element/Renderer/Interface.php
+++ b/lib/Varien/Data/Form/Element/Renderer/Interface.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Data

--- a/lib/Varien/Data/Form/Element/Renderer/Interface.php
+++ b/lib/Varien/Data/Form/Element/Renderer/Interface.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Data/Form/Element/Renderer/Interface.php
+++ b/lib/Varien/Data/Form/Element/Renderer/Interface.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Data

--- a/lib/Varien/Data/Form/Element/Reset.php
+++ b/lib/Varien/Data/Form/Element/Reset.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Data

--- a/lib/Varien/Data/Form/Element/Reset.php
+++ b/lib/Varien/Data/Form/Element/Reset.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Data/Form/Element/Reset.php
+++ b/lib/Varien/Data/Form/Element/Reset.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Data

--- a/lib/Varien/Data/Form/Element/Select.php
+++ b/lib/Varien/Data/Form/Element/Select.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Data

--- a/lib/Varien/Data/Form/Element/Select.php
+++ b/lib/Varien/Data/Form/Element/Select.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Data/Form/Element/Select.php
+++ b/lib/Varien/Data/Form/Element/Select.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Data

--- a/lib/Varien/Data/Form/Element/Submit.php
+++ b/lib/Varien/Data/Form/Element/Submit.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Data

--- a/lib/Varien/Data/Form/Element/Submit.php
+++ b/lib/Varien/Data/Form/Element/Submit.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Data/Form/Element/Submit.php
+++ b/lib/Varien/Data/Form/Element/Submit.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Data

--- a/lib/Varien/Data/Form/Element/Text.php
+++ b/lib/Varien/Data/Form/Element/Text.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Data

--- a/lib/Varien/Data/Form/Element/Text.php
+++ b/lib/Varien/Data/Form/Element/Text.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Data/Form/Element/Text.php
+++ b/lib/Varien/Data/Form/Element/Text.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Data

--- a/lib/Varien/Data/Form/Element/Textarea.php
+++ b/lib/Varien/Data/Form/Element/Textarea.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Data

--- a/lib/Varien/Data/Form/Element/Textarea.php
+++ b/lib/Varien/Data/Form/Element/Textarea.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Data/Form/Element/Textarea.php
+++ b/lib/Varien/Data/Form/Element/Textarea.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Data

--- a/lib/Varien/Data/Form/Element/Time.php
+++ b/lib/Varien/Data/Form/Element/Time.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Data

--- a/lib/Varien/Data/Form/Element/Time.php
+++ b/lib/Varien/Data/Form/Element/Time.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Data/Form/Element/Time.php
+++ b/lib/Varien/Data/Form/Element/Time.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Data

--- a/lib/Varien/Data/Form/Filter/Date.php
+++ b/lib/Varien/Data/Form/Filter/Date.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Data

--- a/lib/Varien/Data/Form/Filter/Date.php
+++ b/lib/Varien/Data/Form/Filter/Date.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Data/Form/Filter/Date.php
+++ b/lib/Varien/Data/Form/Filter/Date.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Data

--- a/lib/Varien/Data/Form/Filter/Datetime.php
+++ b/lib/Varien/Data/Form/Filter/Datetime.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Data

--- a/lib/Varien/Data/Form/Filter/Datetime.php
+++ b/lib/Varien/Data/Form/Filter/Datetime.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Data/Form/Filter/Datetime.php
+++ b/lib/Varien/Data/Form/Filter/Datetime.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Data

--- a/lib/Varien/Data/Form/Filter/Escapehtml.php
+++ b/lib/Varien/Data/Form/Filter/Escapehtml.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Data

--- a/lib/Varien/Data/Form/Filter/Escapehtml.php
+++ b/lib/Varien/Data/Form/Filter/Escapehtml.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Data/Form/Filter/Escapehtml.php
+++ b/lib/Varien/Data/Form/Filter/Escapehtml.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Data

--- a/lib/Varien/Data/Form/Filter/Interface.php
+++ b/lib/Varien/Data/Form/Filter/Interface.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Data

--- a/lib/Varien/Data/Form/Filter/Interface.php
+++ b/lib/Varien/Data/Form/Filter/Interface.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Data/Form/Filter/Interface.php
+++ b/lib/Varien/Data/Form/Filter/Interface.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Data

--- a/lib/Varien/Data/Form/Filter/Striptags.php
+++ b/lib/Varien/Data/Form/Filter/Striptags.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Data

--- a/lib/Varien/Data/Form/Filter/Striptags.php
+++ b/lib/Varien/Data/Form/Filter/Striptags.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Data/Form/Filter/Striptags.php
+++ b/lib/Varien/Data/Form/Filter/Striptags.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Data

--- a/lib/Varien/Data/Tree.php
+++ b/lib/Varien/Data/Tree.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Data

--- a/lib/Varien/Data/Tree.php
+++ b/lib/Varien/Data/Tree.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Data/Tree.php
+++ b/lib/Varien/Data/Tree.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Data

--- a/lib/Varien/Data/Tree/Db.php
+++ b/lib/Varien/Data/Tree/Db.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Data

--- a/lib/Varien/Data/Tree/Db.php
+++ b/lib/Varien/Data/Tree/Db.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Data/Tree/Db.php
+++ b/lib/Varien/Data/Tree/Db.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Data

--- a/lib/Varien/Data/Tree/Dbp.php
+++ b/lib/Varien/Data/Tree/Dbp.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Data

--- a/lib/Varien/Data/Tree/Dbp.php
+++ b/lib/Varien/Data/Tree/Dbp.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Data/Tree/Dbp.php
+++ b/lib/Varien/Data/Tree/Dbp.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Data

--- a/lib/Varien/Data/Tree/Node.php
+++ b/lib/Varien/Data/Tree/Node.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Data

--- a/lib/Varien/Data/Tree/Node.php
+++ b/lib/Varien/Data/Tree/Node.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Data/Tree/Node.php
+++ b/lib/Varien/Data/Tree/Node.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Data

--- a/lib/Varien/Data/Tree/Node/Collection.php
+++ b/lib/Varien/Data/Tree/Node/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Data

--- a/lib/Varien/Data/Tree/Node/Collection.php
+++ b/lib/Varien/Data/Tree/Node/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Data/Tree/Node/Collection.php
+++ b/lib/Varien/Data/Tree/Node/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Data

--- a/lib/Varien/Date.php
+++ b/lib/Varien/Date.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Date.php
+++ b/lib/Varien/Date.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Date

--- a/lib/Varien/Date.php
+++ b/lib/Varien/Date.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Date

--- a/lib/Varien/Db/Adapter/Interface.php
+++ b/lib/Varien/Db/Adapter/Interface.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Db/Adapter/Interface.php
+++ b/lib/Varien/Db/Adapter/Interface.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Db

--- a/lib/Varien/Db/Adapter/Interface.php
+++ b/lib/Varien/Db/Adapter/Interface.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Db

--- a/lib/Varien/Db/Adapter/Mysqli.php
+++ b/lib/Varien/Db/Adapter/Mysqli.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Db/Adapter/Mysqli.php
+++ b/lib/Varien/Db/Adapter/Mysqli.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Db

--- a/lib/Varien/Db/Adapter/Mysqli.php
+++ b/lib/Varien/Db/Adapter/Mysqli.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Db

--- a/lib/Varien/Db/Adapter/Pdo/Mysql.php
+++ b/lib/Varien/Db/Adapter/Pdo/Mysql.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Db/Adapter/Pdo/Mysql.php
+++ b/lib/Varien/Db/Adapter/Pdo/Mysql.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Db

--- a/lib/Varien/Db/Adapter/Pdo/Mysql.php
+++ b/lib/Varien/Db/Adapter/Pdo/Mysql.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Db

--- a/lib/Varien/Db/Ddl/Table.php
+++ b/lib/Varien/Db/Ddl/Table.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Db/Ddl/Table.php
+++ b/lib/Varien/Db/Ddl/Table.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Db

--- a/lib/Varien/Db/Ddl/Table.php
+++ b/lib/Varien/Db/Ddl/Table.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Db

--- a/lib/Varien/Db/Exception.php
+++ b/lib/Varien/Db/Exception.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Db/Exception.php
+++ b/lib/Varien/Db/Exception.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Db

--- a/lib/Varien/Db/Exception.php
+++ b/lib/Varien/Db/Exception.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Db

--- a/lib/Varien/Db/Helper.php
+++ b/lib/Varien/Db/Helper.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Db/Helper.php
+++ b/lib/Varien/Db/Helper.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Db

--- a/lib/Varien/Db/Helper.php
+++ b/lib/Varien/Db/Helper.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Db

--- a/lib/Varien/Db/Select.php
+++ b/lib/Varien/Db/Select.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Db/Select.php
+++ b/lib/Varien/Db/Select.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Db

--- a/lib/Varien/Db/Select.php
+++ b/lib/Varien/Db/Select.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Db

--- a/lib/Varien/Db/Statement/Parameter.php
+++ b/lib/Varien/Db/Statement/Parameter.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Db/Statement/Parameter.php
+++ b/lib/Varien/Db/Statement/Parameter.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Db

--- a/lib/Varien/Db/Statement/Parameter.php
+++ b/lib/Varien/Db/Statement/Parameter.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Db

--- a/lib/Varien/Db/Statement/Pdo/Mysql.php
+++ b/lib/Varien/Db/Statement/Pdo/Mysql.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Db/Statement/Pdo/Mysql.php
+++ b/lib/Varien/Db/Statement/Pdo/Mysql.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Db

--- a/lib/Varien/Db/Statement/Pdo/Mysql.php
+++ b/lib/Varien/Db/Statement/Pdo/Mysql.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Db

--- a/lib/Varien/Db/Tree.php
+++ b/lib/Varien/Db/Tree.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Db/Tree.php
+++ b/lib/Varien/Db/Tree.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Db

--- a/lib/Varien/Db/Tree.php
+++ b/lib/Varien/Db/Tree.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Db

--- a/lib/Varien/Db/Tree/Exception.php
+++ b/lib/Varien/Db/Tree/Exception.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Db/Tree/Exception.php
+++ b/lib/Varien/Db/Tree/Exception.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Db

--- a/lib/Varien/Db/Tree/Exception.php
+++ b/lib/Varien/Db/Tree/Exception.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Db

--- a/lib/Varien/Db/Tree/Node.php
+++ b/lib/Varien/Db/Tree/Node.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Db/Tree/Node.php
+++ b/lib/Varien/Db/Tree/Node.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Db

--- a/lib/Varien/Db/Tree/Node.php
+++ b/lib/Varien/Db/Tree/Node.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Db

--- a/lib/Varien/Db/Tree/Node/Exception.php
+++ b/lib/Varien/Db/Tree/Node/Exception.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Db/Tree/Node/Exception.php
+++ b/lib/Varien/Db/Tree/Node/Exception.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Db

--- a/lib/Varien/Db/Tree/Node/Exception.php
+++ b/lib/Varien/Db/Tree/Node/Exception.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Db

--- a/lib/Varien/Db/Tree/NodeSet.php
+++ b/lib/Varien/Db/Tree/NodeSet.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Db/Tree/NodeSet.php
+++ b/lib/Varien/Db/Tree/NodeSet.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Db

--- a/lib/Varien/Db/Tree/NodeSet.php
+++ b/lib/Varien/Db/Tree/NodeSet.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Db

--- a/lib/Varien/Db/Tree/NodeSet/Exception.php
+++ b/lib/Varien/Db/Tree/NodeSet/Exception.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Db/Tree/NodeSet/Exception.php
+++ b/lib/Varien/Db/Tree/NodeSet/Exception.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Db

--- a/lib/Varien/Db/Tree/NodeSet/Exception.php
+++ b/lib/Varien/Db/Tree/NodeSet/Exception.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Db

--- a/lib/Varien/Debug.php
+++ b/lib/Varien/Debug.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Debug.php
+++ b/lib/Varien/Debug.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Debug

--- a/lib/Varien/Debug.php
+++ b/lib/Varien/Debug.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Debug

--- a/lib/Varien/Directory/Collection.php
+++ b/lib/Varien/Directory/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Directory/Collection.php
+++ b/lib/Varien/Directory/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Directory

--- a/lib/Varien/Directory/Collection.php
+++ b/lib/Varien/Directory/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Directory

--- a/lib/Varien/Directory/Factory.php
+++ b/lib/Varien/Directory/Factory.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Directory/Factory.php
+++ b/lib/Varien/Directory/Factory.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Directory

--- a/lib/Varien/Directory/Factory.php
+++ b/lib/Varien/Directory/Factory.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Directory

--- a/lib/Varien/Directory/IFactory.php
+++ b/lib/Varien/Directory/IFactory.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Directory/IFactory.php
+++ b/lib/Varien/Directory/IFactory.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Directory

--- a/lib/Varien/Directory/IFactory.php
+++ b/lib/Varien/Directory/IFactory.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Directory

--- a/lib/Varien/Event.php
+++ b/lib/Varien/Event.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Event.php
+++ b/lib/Varien/Event.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Event

--- a/lib/Varien/Event.php
+++ b/lib/Varien/Event.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Event

--- a/lib/Varien/Event/Collection.php
+++ b/lib/Varien/Event/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Event/Collection.php
+++ b/lib/Varien/Event/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Event

--- a/lib/Varien/Event/Collection.php
+++ b/lib/Varien/Event/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Event

--- a/lib/Varien/Event/Observer.php
+++ b/lib/Varien/Event/Observer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Event/Observer.php
+++ b/lib/Varien/Event/Observer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Event

--- a/lib/Varien/Event/Observer.php
+++ b/lib/Varien/Event/Observer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Event

--- a/lib/Varien/Event/Observer/Collection.php
+++ b/lib/Varien/Event/Observer/Collection.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Event/Observer/Collection.php
+++ b/lib/Varien/Event/Observer/Collection.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Event

--- a/lib/Varien/Event/Observer/Collection.php
+++ b/lib/Varien/Event/Observer/Collection.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Event

--- a/lib/Varien/Event/Observer/Cron.php
+++ b/lib/Varien/Event/Observer/Cron.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Event/Observer/Cron.php
+++ b/lib/Varien/Event/Observer/Cron.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Event

--- a/lib/Varien/Event/Observer/Cron.php
+++ b/lib/Varien/Event/Observer/Cron.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Event

--- a/lib/Varien/Event/Observer/Regex.php
+++ b/lib/Varien/Event/Observer/Regex.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Event/Observer/Regex.php
+++ b/lib/Varien/Event/Observer/Regex.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Event

--- a/lib/Varien/Event/Observer/Regex.php
+++ b/lib/Varien/Event/Observer/Regex.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Event

--- a/lib/Varien/Exception.php
+++ b/lib/Varien/Exception.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Exception

--- a/lib/Varien/Exception.php
+++ b/lib/Varien/Exception.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Exception.php
+++ b/lib/Varien/Exception.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Exception

--- a/lib/Varien/File/Csv.php
+++ b/lib/Varien/File/Csv.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_File

--- a/lib/Varien/File/Csv.php
+++ b/lib/Varien/File/Csv.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/File/Csv.php
+++ b/lib/Varien/File/Csv.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_File

--- a/lib/Varien/File/CsvMulty.php
+++ b/lib/Varien/File/CsvMulty.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_File

--- a/lib/Varien/File/CsvMulty.php
+++ b/lib/Varien/File/CsvMulty.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/File/CsvMulty.php
+++ b/lib/Varien/File/CsvMulty.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_File

--- a/lib/Varien/File/Object.php
+++ b/lib/Varien/File/Object.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_File

--- a/lib/Varien/File/Object.php
+++ b/lib/Varien/File/Object.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/File/Object.php
+++ b/lib/Varien/File/Object.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_File

--- a/lib/Varien/File/Transfer/Adapter/Http.php
+++ b/lib/Varien/File/Transfer/Adapter/Http.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_File

--- a/lib/Varien/File/Transfer/Adapter/Http.php
+++ b/lib/Varien/File/Transfer/Adapter/Http.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/File/Transfer/Adapter/Http.php
+++ b/lib/Varien/File/Transfer/Adapter/Http.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_File

--- a/lib/Varien/File/Uploader.php
+++ b/lib/Varien/File/Uploader.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_File

--- a/lib/Varien/File/Uploader.php
+++ b/lib/Varien/File/Uploader.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/File/Uploader.php
+++ b/lib/Varien/File/Uploader.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_File

--- a/lib/Varien/File/Uploader/Image.php
+++ b/lib/Varien/File/Uploader/Image.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_File

--- a/lib/Varien/File/Uploader/Image.php
+++ b/lib/Varien/File/Uploader/Image.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/File/Uploader/Image.php
+++ b/lib/Varien/File/Uploader/Image.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_File

--- a/lib/Varien/Filter/Array.php
+++ b/lib/Varien/Filter/Array.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Filter/Array.php
+++ b/lib/Varien/Filter/Array.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Filter

--- a/lib/Varien/Filter/Array.php
+++ b/lib/Varien/Filter/Array.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Filter

--- a/lib/Varien/Filter/Array/Grid.php
+++ b/lib/Varien/Filter/Array/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Filter/Array/Grid.php
+++ b/lib/Varien/Filter/Array/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Filter

--- a/lib/Varien/Filter/Array/Grid.php
+++ b/lib/Varien/Filter/Array/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Filter

--- a/lib/Varien/Filter/Email.php
+++ b/lib/Varien/Filter/Email.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Filter/Email.php
+++ b/lib/Varien/Filter/Email.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Filter

--- a/lib/Varien/Filter/Email.php
+++ b/lib/Varien/Filter/Email.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Filter

--- a/lib/Varien/Filter/FormElementName.php
+++ b/lib/Varien/Filter/FormElementName.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Filter/FormElementName.php
+++ b/lib/Varien/Filter/FormElementName.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Filter

--- a/lib/Varien/Filter/FormElementName.php
+++ b/lib/Varien/Filter/FormElementName.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Filter

--- a/lib/Varien/Filter/Object.php
+++ b/lib/Varien/Filter/Object.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Filter/Object.php
+++ b/lib/Varien/Filter/Object.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Filter

--- a/lib/Varien/Filter/Object.php
+++ b/lib/Varien/Filter/Object.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Filter

--- a/lib/Varien/Filter/Object/Grid.php
+++ b/lib/Varien/Filter/Object/Grid.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Filter/Object/Grid.php
+++ b/lib/Varien/Filter/Object/Grid.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Filter

--- a/lib/Varien/Filter/Object/Grid.php
+++ b/lib/Varien/Filter/Object/Grid.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Filter

--- a/lib/Varien/Filter/Sprintf.php
+++ b/lib/Varien/Filter/Sprintf.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Filter/Sprintf.php
+++ b/lib/Varien/Filter/Sprintf.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Filter

--- a/lib/Varien/Filter/Sprintf.php
+++ b/lib/Varien/Filter/Sprintf.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Filter

--- a/lib/Varien/Filter/Template.php
+++ b/lib/Varien/Filter/Template.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Filter/Template.php
+++ b/lib/Varien/Filter/Template.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Filter

--- a/lib/Varien/Filter/Template.php
+++ b/lib/Varien/Filter/Template.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Filter

--- a/lib/Varien/Filter/Template/Simple.php
+++ b/lib/Varien/Filter/Template/Simple.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Filter/Template/Simple.php
+++ b/lib/Varien/Filter/Template/Simple.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Filter

--- a/lib/Varien/Filter/Template/Simple.php
+++ b/lib/Varien/Filter/Template/Simple.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Filter

--- a/lib/Varien/Filter/Template/Tokenizer/Abstract.php
+++ b/lib/Varien/Filter/Template/Tokenizer/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Filter/Template/Tokenizer/Abstract.php
+++ b/lib/Varien/Filter/Template/Tokenizer/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Filter

--- a/lib/Varien/Filter/Template/Tokenizer/Abstract.php
+++ b/lib/Varien/Filter/Template/Tokenizer/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Filter

--- a/lib/Varien/Filter/Template/Tokenizer/Parameter.php
+++ b/lib/Varien/Filter/Template/Tokenizer/Parameter.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Filter/Template/Tokenizer/Parameter.php
+++ b/lib/Varien/Filter/Template/Tokenizer/Parameter.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Filter

--- a/lib/Varien/Filter/Template/Tokenizer/Parameter.php
+++ b/lib/Varien/Filter/Template/Tokenizer/Parameter.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Filter

--- a/lib/Varien/Filter/Template/Tokenizer/Variable.php
+++ b/lib/Varien/Filter/Template/Tokenizer/Variable.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Filter/Template/Tokenizer/Variable.php
+++ b/lib/Varien/Filter/Template/Tokenizer/Variable.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Filter

--- a/lib/Varien/Filter/Template/Tokenizer/Variable.php
+++ b/lib/Varien/Filter/Template/Tokenizer/Variable.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Filter

--- a/lib/Varien/Http/Adapter/Curl.php
+++ b/lib/Varien/Http/Adapter/Curl.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Http/Adapter/Curl.php
+++ b/lib/Varien/Http/Adapter/Curl.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Http

--- a/lib/Varien/Http/Adapter/Curl.php
+++ b/lib/Varien/Http/Adapter/Curl.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Http

--- a/lib/Varien/Http/Client.php
+++ b/lib/Varien/Http/Client.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Http/Client.php
+++ b/lib/Varien/Http/Client.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Http

--- a/lib/Varien/Http/Client.php
+++ b/lib/Varien/Http/Client.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Http

--- a/lib/Varien/Image.php
+++ b/lib/Varien/Image.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Image.php
+++ b/lib/Varien/Image.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Image

--- a/lib/Varien/Image.php
+++ b/lib/Varien/Image.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Image

--- a/lib/Varien/Image/Adapter.php
+++ b/lib/Varien/Image/Adapter.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Image/Adapter.php
+++ b/lib/Varien/Image/Adapter.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Image

--- a/lib/Varien/Image/Adapter.php
+++ b/lib/Varien/Image/Adapter.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Image

--- a/lib/Varien/Image/Adapter/Abstract.php
+++ b/lib/Varien/Image/Adapter/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Image/Adapter/Abstract.php
+++ b/lib/Varien/Image/Adapter/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Image

--- a/lib/Varien/Image/Adapter/Abstract.php
+++ b/lib/Varien/Image/Adapter/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Image

--- a/lib/Varien/Image/Adapter/Gd2.php
+++ b/lib/Varien/Image/Adapter/Gd2.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Image/Adapter/Gd2.php
+++ b/lib/Varien/Image/Adapter/Gd2.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Image

--- a/lib/Varien/Image/Adapter/Gd2.php
+++ b/lib/Varien/Image/Adapter/Gd2.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Image

--- a/lib/Varien/Io/Abstract.php
+++ b/lib/Varien/Io/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Io/Abstract.php
+++ b/lib/Varien/Io/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Io

--- a/lib/Varien/Io/Abstract.php
+++ b/lib/Varien/Io/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Io

--- a/lib/Varien/Io/Exception.php
+++ b/lib/Varien/Io/Exception.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Io/Exception.php
+++ b/lib/Varien/Io/Exception.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Io

--- a/lib/Varien/Io/Exception.php
+++ b/lib/Varien/Io/Exception.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Io

--- a/lib/Varien/Io/File.php
+++ b/lib/Varien/Io/File.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Io/File.php
+++ b/lib/Varien/Io/File.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Io

--- a/lib/Varien/Io/File.php
+++ b/lib/Varien/Io/File.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Io

--- a/lib/Varien/Io/Ftp.php
+++ b/lib/Varien/Io/Ftp.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Io/Ftp.php
+++ b/lib/Varien/Io/Ftp.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Io

--- a/lib/Varien/Io/Ftp.php
+++ b/lib/Varien/Io/Ftp.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Io

--- a/lib/Varien/Io/Interface.php
+++ b/lib/Varien/Io/Interface.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Io/Interface.php
+++ b/lib/Varien/Io/Interface.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Io

--- a/lib/Varien/Io/Interface.php
+++ b/lib/Varien/Io/Interface.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Io

--- a/lib/Varien/Io/Sftp.php
+++ b/lib/Varien/Io/Sftp.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Io/Sftp.php
+++ b/lib/Varien/Io/Sftp.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Io

--- a/lib/Varien/Io/Sftp.php
+++ b/lib/Varien/Io/Sftp.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Io

--- a/lib/Varien/Object.php
+++ b/lib/Varien/Object.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Object.php
+++ b/lib/Varien/Object.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Object

--- a/lib/Varien/Object.php
+++ b/lib/Varien/Object.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Object

--- a/lib/Varien/Object/Cache.php
+++ b/lib/Varien/Object/Cache.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Object/Cache.php
+++ b/lib/Varien/Object/Cache.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Object

--- a/lib/Varien/Object/Cache.php
+++ b/lib/Varien/Object/Cache.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Object

--- a/lib/Varien/Object/Mapper.php
+++ b/lib/Varien/Object/Mapper.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Object/Mapper.php
+++ b/lib/Varien/Object/Mapper.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Object

--- a/lib/Varien/Object/Mapper.php
+++ b/lib/Varien/Object/Mapper.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Object

--- a/lib/Varien/Profiler.php
+++ b/lib/Varien/Profiler.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Profiler.php
+++ b/lib/Varien/Profiler.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Profiler

--- a/lib/Varien/Profiler.php
+++ b/lib/Varien/Profiler.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Profiler

--- a/lib/Varien/Simplexml/Config.php
+++ b/lib/Varien/Simplexml/Config.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Simplexml/Config.php
+++ b/lib/Varien/Simplexml/Config.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Simplexml

--- a/lib/Varien/Simplexml/Config.php
+++ b/lib/Varien/Simplexml/Config.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Simplexml

--- a/lib/Varien/Simplexml/Config/Cache/Abstract.php
+++ b/lib/Varien/Simplexml/Config/Cache/Abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Simplexml/Config/Cache/Abstract.php
+++ b/lib/Varien/Simplexml/Config/Cache/Abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Simplexml

--- a/lib/Varien/Simplexml/Config/Cache/Abstract.php
+++ b/lib/Varien/Simplexml/Config/Cache/Abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Simplexml

--- a/lib/Varien/Simplexml/Config/Cache/File.php
+++ b/lib/Varien/Simplexml/Config/Cache/File.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Simplexml/Config/Cache/File.php
+++ b/lib/Varien/Simplexml/Config/Cache/File.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Simplexml

--- a/lib/Varien/Simplexml/Config/Cache/File.php
+++ b/lib/Varien/Simplexml/Config/Cache/File.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Simplexml

--- a/lib/Varien/Simplexml/Element.php
+++ b/lib/Varien/Simplexml/Element.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/lib/Varien/Simplexml/Element.php
+++ b/lib/Varien/Simplexml/Element.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category   Varien
  * @package    Varien_Simplexml

--- a/lib/Varien/Simplexml/Element.php
+++ b/lib/Varien/Simplexml/Element.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category   Varien
  * @package    Varien_Simplexml

--- a/shell/abstract.php
+++ b/shell/abstract.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/shell/abstract.php
+++ b/shell/abstract.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Mage
  * @package     Mage_Shell

--- a/shell/abstract.php
+++ b/shell/abstract.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Mage
  * @package     Mage_Shell

--- a/shell/indexer.php
+++ b/shell/indexer.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/shell/indexer.php
+++ b/shell/indexer.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Mage
  * @package     Mage_Shell

--- a/shell/indexer.php
+++ b/shell/indexer.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Mage
  * @package     Mage_Shell

--- a/shell/log.php
+++ b/shell/log.php
@@ -2,8 +2,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:

--- a/shell/log.php
+++ b/shell/log.php
@@ -4,8 +4,7 @@
  *
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/osl-3.0.php
+ * It is also available at https://opensource.org/license/osl-3-0-php
  *
  * @category    Mage
  * @package     Mage_Shell

--- a/shell/log.php
+++ b/shell/log.php
@@ -6,9 +6,6 @@
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/osl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    Mage
  * @package     Mage_Shell

--- a/skin/adminhtml/default/default/below_ie7.css
+++ b/skin/adminhtml/default/default/below_ie7.css
@@ -3,8 +3,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/skin/adminhtml/default/default/below_ie7.css
+++ b/skin/adminhtml/default/default/below_ie7.css
@@ -1,8 +1,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/skin/adminhtml/default/default/below_ie7.css
+++ b/skin/adminhtml/default/default/below_ie7.css
@@ -5,9 +5,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/skin/adminhtml/default/default/boxes.css
+++ b/skin/adminhtml/default/default/boxes.css
@@ -3,8 +3,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/skin/adminhtml/default/default/boxes.css
+++ b/skin/adminhtml/default/default/boxes.css
@@ -1,8 +1,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/skin/adminhtml/default/default/boxes.css
+++ b/skin/adminhtml/default/default/boxes.css
@@ -5,9 +5,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/skin/adminhtml/default/default/custom.css
+++ b/skin/adminhtml/default/default/custom.css
@@ -3,8 +3,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/skin/adminhtml/default/default/custom.css
+++ b/skin/adminhtml/default/default/custom.css
@@ -1,8 +1,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/skin/adminhtml/default/default/custom.css
+++ b/skin/adminhtml/default/default/custom.css
@@ -5,9 +5,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/skin/adminhtml/default/default/ie7.css
+++ b/skin/adminhtml/default/default/ie7.css
@@ -3,8 +3,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/skin/adminhtml/default/default/ie7.css
+++ b/skin/adminhtml/default/default/ie7.css
@@ -1,8 +1,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/skin/adminhtml/default/default/ie7.css
+++ b/skin/adminhtml/default/default/ie7.css
@@ -5,9 +5,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/skin/adminhtml/default/default/iestyles.css
+++ b/skin/adminhtml/default/default/iestyles.css
@@ -3,8 +3,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/skin/adminhtml/default/default/iestyles.css
+++ b/skin/adminhtml/default/default/iestyles.css
@@ -1,8 +1,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/skin/adminhtml/default/default/iestyles.css
+++ b/skin/adminhtml/default/default/iestyles.css
@@ -5,9 +5,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/skin/adminhtml/default/default/lib/prototype/windows/themes/magento.css
+++ b/skin/adminhtml/default/default/lib/prototype/windows/themes/magento.css
@@ -3,8 +3,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/skin/adminhtml/default/default/lib/prototype/windows/themes/magento.css
+++ b/skin/adminhtml/default/default/lib/prototype/windows/themes/magento.css
@@ -1,8 +1,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/skin/adminhtml/default/default/lib/prototype/windows/themes/magento.css
+++ b/skin/adminhtml/default/default/lib/prototype/windows/themes/magento.css
@@ -5,9 +5,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/skin/adminhtml/default/default/menu.css
+++ b/skin/adminhtml/default/default/menu.css
@@ -3,8 +3,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/skin/adminhtml/default/default/menu.css
+++ b/skin/adminhtml/default/default/menu.css
@@ -1,8 +1,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/skin/adminhtml/default/default/menu.css
+++ b/skin/adminhtml/default/default/menu.css
@@ -5,9 +5,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/skin/adminhtml/default/default/oauth-simple.css
+++ b/skin/adminhtml/default/default/oauth-simple.css
@@ -3,8 +3,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/skin/adminhtml/default/default/oauth-simple.css
+++ b/skin/adminhtml/default/default/oauth-simple.css
@@ -1,8 +1,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/skin/adminhtml/default/default/oauth-simple.css
+++ b/skin/adminhtml/default/default/oauth-simple.css
@@ -5,9 +5,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/skin/adminhtml/default/default/print.css
+++ b/skin/adminhtml/default/default/print.css
@@ -3,8 +3,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/skin/adminhtml/default/default/print.css
+++ b/skin/adminhtml/default/default/print.css
@@ -1,8 +1,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/skin/adminhtml/default/default/print.css
+++ b/skin/adminhtml/default/default/print.css
@@ -5,9 +5,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/skin/adminhtml/default/default/reset.css
+++ b/skin/adminhtml/default/default/reset.css
@@ -3,8 +3,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/skin/adminhtml/default/default/reset.css
+++ b/skin/adminhtml/default/default/reset.css
@@ -1,8 +1,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/skin/adminhtml/default/default/reset.css
+++ b/skin/adminhtml/default/default/reset.css
@@ -5,9 +5,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/skin/frontend/base/default/css/email-inline.css
+++ b/skin/frontend/base/default/css/email-inline.css
@@ -5,9 +5,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/skin/frontend/base/default/css/email-inline.css
+++ b/skin/frontend/base/default/css/email-inline.css
@@ -3,8 +3,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/skin/frontend/base/default/css/email-inline.css
+++ b/skin/frontend/base/default/css/email-inline.css
@@ -1,8 +1,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/skin/frontend/base/default/css/email-non-inline.css
+++ b/skin/frontend/base/default/css/email-non-inline.css
@@ -5,9 +5,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/skin/frontend/base/default/css/email-non-inline.css
+++ b/skin/frontend/base/default/css/email-non-inline.css
@@ -3,8 +3,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/skin/frontend/base/default/css/email-non-inline.css
+++ b/skin/frontend/base/default/css/email-non-inline.css
@@ -1,8 +1,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/skin/frontend/base/default/css/widgets.css
+++ b/skin/frontend/base/default/css/widgets.css
@@ -5,9 +5,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/skin/frontend/base/default/css/widgets.css
+++ b/skin/frontend/base/default/css/widgets.css
@@ -3,8 +3,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/skin/frontend/base/default/css/widgets.css
+++ b/skin/frontend/base/default/css/widgets.css
@@ -1,8 +1,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/skin/frontend/base/default/js/bundle.js
+++ b/skin/frontend/base/default/js/bundle.js
@@ -5,9 +5,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/skin/frontend/base/default/js/bundle.js
+++ b/skin/frontend/base/default/js/bundle.js
@@ -3,8 +3,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/skin/frontend/base/default/js/bundle.js
+++ b/skin/frontend/base/default/js/bundle.js
@@ -1,8 +1,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/skin/frontend/base/default/js/checkout/review.js
+++ b/skin/frontend/base/default/js/checkout/review.js
@@ -5,9 +5,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/skin/frontend/base/default/js/checkout/review.js
+++ b/skin/frontend/base/default/js/checkout/review.js
@@ -3,8 +3,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/skin/frontend/base/default/js/checkout/review.js
+++ b/skin/frontend/base/default/js/checkout/review.js
@@ -1,8 +1,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/skin/frontend/base/default/js/giftmessage.js
+++ b/skin/frontend/base/default/js/giftmessage.js
@@ -5,9 +5,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/skin/frontend/base/default/js/giftmessage.js
+++ b/skin/frontend/base/default/js/giftmessage.js
@@ -3,8 +3,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/skin/frontend/base/default/js/giftmessage.js
+++ b/skin/frontend/base/default/js/giftmessage.js
@@ -1,8 +1,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/skin/frontend/base/default/js/ie6.js
+++ b/skin/frontend/base/default/js/ie6.js
@@ -5,9 +5,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/skin/frontend/base/default/js/ie6.js
+++ b/skin/frontend/base/default/js/ie6.js
@@ -3,8 +3,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/skin/frontend/base/default/js/ie6.js
+++ b/skin/frontend/base/default/js/ie6.js
@@ -1,8 +1,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/skin/frontend/base/default/js/msrp.js
+++ b/skin/frontend/base/default/js/msrp.js
@@ -5,9 +5,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/skin/frontend/base/default/js/msrp.js
+++ b/skin/frontend/base/default/js/msrp.js
@@ -3,8 +3,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/skin/frontend/base/default/js/msrp.js
+++ b/skin/frontend/base/default/js/msrp.js
@@ -1,8 +1,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/skin/frontend/base/default/js/opcheckout.js
+++ b/skin/frontend/base/default/js/opcheckout.js
@@ -5,9 +5,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/skin/frontend/base/default/js/opcheckout.js
+++ b/skin/frontend/base/default/js/opcheckout.js
@@ -3,8 +3,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/skin/frontend/base/default/js/opcheckout.js
+++ b/skin/frontend/base/default/js/opcheckout.js
@@ -1,8 +1,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/skin/frontend/base/default/lib/prototype/windows/themes/magento.css
+++ b/skin/frontend/base/default/lib/prototype/windows/themes/magento.css
@@ -5,9 +5,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     base_default

--- a/skin/frontend/base/default/lib/prototype/windows/themes/magento.css
+++ b/skin/frontend/base/default/lib/prototype/windows/themes/magento.css
@@ -3,8 +3,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     base_default

--- a/skin/frontend/base/default/lib/prototype/windows/themes/magento.css
+++ b/skin/frontend/base/default/lib/prototype/windows/themes/magento.css
@@ -1,8 +1,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/skin/frontend/rwd/default/css/madisonisland-ie8.css
+++ b/skin/frontend/rwd/default/css/madisonisland-ie8.css
@@ -5,9 +5,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/skin/frontend/rwd/default/css/madisonisland-ie8.css
+++ b/skin/frontend/rwd/default/css/madisonisland-ie8.css
@@ -3,8 +3,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/skin/frontend/rwd/default/css/madisonisland-ie8.css
+++ b/skin/frontend/rwd/default/css/madisonisland-ie8.css
@@ -1,8 +1,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/skin/frontend/rwd/default/css/madisonisland.css
+++ b/skin/frontend/rwd/default/css/madisonisland.css
@@ -5,9 +5,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/skin/frontend/rwd/default/css/madisonisland.css
+++ b/skin/frontend/rwd/default/css/madisonisland.css
@@ -3,8 +3,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/skin/frontend/rwd/default/css/madisonisland.css
+++ b/skin/frontend/rwd/default/css/madisonisland.css
@@ -1,8 +1,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/skin/frontend/rwd/default/css/scaffold-forms.css
+++ b/skin/frontend/rwd/default/css/scaffold-forms.css
@@ -5,9 +5,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/skin/frontend/rwd/default/css/scaffold-forms.css
+++ b/skin/frontend/rwd/default/css/scaffold-forms.css
@@ -3,8 +3,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/skin/frontend/rwd/default/css/scaffold-forms.css
+++ b/skin/frontend/rwd/default/css/scaffold-forms.css
@@ -1,8 +1,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/skin/frontend/rwd/default/css/styles-ie8.css
+++ b/skin/frontend/rwd/default/css/styles-ie8.css
@@ -5,9 +5,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/skin/frontend/rwd/default/css/styles-ie8.css
+++ b/skin/frontend/rwd/default/css/styles-ie8.css
@@ -3,8 +3,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/skin/frontend/rwd/default/css/styles-ie8.css
+++ b/skin/frontend/rwd/default/css/styles-ie8.css
@@ -1,8 +1,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/skin/frontend/rwd/default/css/styles.css
+++ b/skin/frontend/rwd/default/css/styles.css
@@ -5,9 +5,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/skin/frontend/rwd/default/css/styles.css
+++ b/skin/frontend/rwd/default/css/styles.css
@@ -3,8 +3,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/skin/frontend/rwd/default/css/styles.css
+++ b/skin/frontend/rwd/default/css/styles.css
@@ -1,8 +1,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/skin/frontend/rwd/default/js/app.js
+++ b/skin/frontend/rwd/default/js/app.js
@@ -5,9 +5,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/skin/frontend/rwd/default/js/app.js
+++ b/skin/frontend/rwd/default/js/app.js
@@ -3,8 +3,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/skin/frontend/rwd/default/js/app.js
+++ b/skin/frontend/rwd/default/js/app.js
@@ -1,8 +1,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/skin/frontend/rwd/default/js/configurableswatches/configurable-swatch-prices.js
+++ b/skin/frontend/rwd/default/js/configurableswatches/configurable-swatch-prices.js
@@ -5,9 +5,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/skin/frontend/rwd/default/js/configurableswatches/configurable-swatch-prices.js
+++ b/skin/frontend/rwd/default/js/configurableswatches/configurable-swatch-prices.js
@@ -3,8 +3,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/skin/frontend/rwd/default/js/configurableswatches/configurable-swatch-prices.js
+++ b/skin/frontend/rwd/default/js/configurableswatches/configurable-swatch-prices.js
@@ -1,8 +1,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/skin/frontend/rwd/default/js/configurableswatches/product-media.js
+++ b/skin/frontend/rwd/default/js/configurableswatches/product-media.js
@@ -5,9 +5,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/skin/frontend/rwd/default/js/configurableswatches/product-media.js
+++ b/skin/frontend/rwd/default/js/configurableswatches/product-media.js
@@ -3,8 +3,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/skin/frontend/rwd/default/js/configurableswatches/product-media.js
+++ b/skin/frontend/rwd/default/js/configurableswatches/product-media.js
@@ -1,8 +1,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/skin/frontend/rwd/default/js/configurableswatches/swatches-list.js
+++ b/skin/frontend/rwd/default/js/configurableswatches/swatches-list.js
@@ -5,9 +5,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/skin/frontend/rwd/default/js/configurableswatches/swatches-list.js
+++ b/skin/frontend/rwd/default/js/configurableswatches/swatches-list.js
@@ -3,8 +3,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/skin/frontend/rwd/default/js/configurableswatches/swatches-list.js
+++ b/skin/frontend/rwd/default/js/configurableswatches/swatches-list.js
@@ -1,8 +1,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/skin/frontend/rwd/default/js/configurableswatches/swatches-product.js
+++ b/skin/frontend/rwd/default/js/configurableswatches/swatches-product.js
@@ -5,9 +5,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/skin/frontend/rwd/default/js/configurableswatches/swatches-product.js
+++ b/skin/frontend/rwd/default/js/configurableswatches/swatches-product.js
@@ -3,8 +3,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/skin/frontend/rwd/default/js/configurableswatches/swatches-product.js
+++ b/skin/frontend/rwd/default/js/configurableswatches/swatches-product.js
@@ -1,8 +1,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/skin/frontend/rwd/default/js/minicart.js
+++ b/skin/frontend/rwd/default/js/minicart.js
@@ -5,9 +5,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/skin/frontend/rwd/default/js/minicart.js
+++ b/skin/frontend/rwd/default/js/minicart.js
@@ -3,8 +3,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/skin/frontend/rwd/default/js/minicart.js
+++ b/skin/frontend/rwd/default/js/minicart.js
@@ -1,8 +1,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/skin/frontend/rwd/default/js/msrp_rwd.js
+++ b/skin/frontend/rwd/default/js/msrp_rwd.js
@@ -5,9 +5,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/skin/frontend/rwd/default/js/msrp_rwd.js
+++ b/skin/frontend/rwd/default/js/msrp_rwd.js
@@ -3,8 +3,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/skin/frontend/rwd/default/js/msrp_rwd.js
+++ b/skin/frontend/rwd/default/js/msrp_rwd.js
@@ -1,8 +1,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/skin/frontend/rwd/default/js/opcheckout_rwd.js
+++ b/skin/frontend/rwd/default/js/opcheckout_rwd.js
@@ -5,9 +5,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/skin/frontend/rwd/default/js/opcheckout_rwd.js
+++ b/skin/frontend/rwd/default/js/opcheckout_rwd.js
@@ -3,8 +3,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/skin/frontend/rwd/default/js/opcheckout_rwd.js
+++ b/skin/frontend/rwd/default/js/opcheckout_rwd.js
@@ -1,8 +1,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/skin/frontend/rwd/default/js/slideshow.js
+++ b/skin/frontend/rwd/default/js/slideshow.js
@@ -5,9 +5,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     rwd_default

--- a/skin/frontend/rwd/default/js/slideshow.js
+++ b/skin/frontend/rwd/default/js/slideshow.js
@@ -3,8 +3,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     rwd_default

--- a/skin/frontend/rwd/default/js/slideshow.js
+++ b/skin/frontend/rwd/default/js/slideshow.js
@@ -1,8 +1,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/skin/frontend/rwd/default/scss/_core.scss
+++ b/skin/frontend/rwd/default/scss/_core.scss
@@ -3,8 +3,7 @@
 //
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
-// It is also available through the world-wide-web at this URL:
-// https://opensource.org/licenses/afl-3.0.php
+// It is also available at https://opensource.org/license/afl-3-0-php
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/_core.scss
+++ b/skin/frontend/rwd/default/scss/_core.scss
@@ -5,9 +5,6 @@
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:
 // https://opensource.org/licenses/afl-3.0.php
-// If you did not receive a copy of the license and are unable to
-// obtain it through the world-wide-web, please send an email
-// to license@magento.com so we can send you a copy immediately.
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/_core.scss
+++ b/skin/frontend/rwd/default/scss/_core.scss
@@ -1,8 +1,6 @@
 //
 // OpenMage
 //
-// NOTICE OF LICENSE
-//
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:

--- a/skin/frontend/rwd/default/scss/_framework.scss
+++ b/skin/frontend/rwd/default/scss/_framework.scss
@@ -3,8 +3,7 @@
 //
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
-// It is also available through the world-wide-web at this URL:
-// https://opensource.org/licenses/afl-3.0.php
+// It is also available at https://opensource.org/license/afl-3-0-php
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/_framework.scss
+++ b/skin/frontend/rwd/default/scss/_framework.scss
@@ -5,9 +5,6 @@
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:
 // https://opensource.org/licenses/afl-3.0.php
-// If you did not receive a copy of the license and are unable to
-// obtain it through the world-wide-web, please send an email
-// to license@magento.com so we can send you a copy immediately.
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/_framework.scss
+++ b/skin/frontend/rwd/default/scss/_framework.scss
@@ -1,8 +1,6 @@
 //
 // OpenMage
 //
-// NOTICE OF LICENSE
-//
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:

--- a/skin/frontend/rwd/default/scss/_var.scss
+++ b/skin/frontend/rwd/default/scss/_var.scss
@@ -3,8 +3,7 @@
 //
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
-// It is also available through the world-wide-web at this URL:
-// https://opensource.org/licenses/afl-3.0.php
+// It is also available at https://opensource.org/license/afl-3-0-php
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/_var.scss
+++ b/skin/frontend/rwd/default/scss/_var.scss
@@ -5,9 +5,6 @@
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:
 // https://opensource.org/licenses/afl-3.0.php
-// If you did not receive a copy of the license and are unable to
-// obtain it through the world-wide-web, please send an email
-// to license@magento.com so we can send you a copy immediately.
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/_var.scss
+++ b/skin/frontend/rwd/default/scss/_var.scss
@@ -1,8 +1,6 @@
 //
 // OpenMage
 //
-// NOTICE OF LICENSE
-//
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:

--- a/skin/frontend/rwd/default/scss/content/_category.scss
+++ b/skin/frontend/rwd/default/scss/content/_category.scss
@@ -3,8 +3,7 @@
 //
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
-// It is also available through the world-wide-web at this URL:
-// https://opensource.org/licenses/afl-3.0.php
+// It is also available at https://opensource.org/license/afl-3-0-php
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/content/_category.scss
+++ b/skin/frontend/rwd/default/scss/content/_category.scss
@@ -5,9 +5,6 @@
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:
 // https://opensource.org/licenses/afl-3.0.php
-// If you did not receive a copy of the license and are unable to
-// obtain it through the world-wide-web, please send an email
-// to license@magento.com so we can send you a copy immediately.
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/content/_category.scss
+++ b/skin/frontend/rwd/default/scss/content/_category.scss
@@ -1,8 +1,6 @@
 //
 // OpenMage
 //
-// NOTICE OF LICENSE
-//
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:

--- a/skin/frontend/rwd/default/scss/content/_home.scss
+++ b/skin/frontend/rwd/default/scss/content/_home.scss
@@ -3,8 +3,7 @@
 //
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
-// It is also available through the world-wide-web at this URL:
-// https://opensource.org/licenses/afl-3.0.php
+// It is also available at https://opensource.org/license/afl-3-0-php
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/content/_home.scss
+++ b/skin/frontend/rwd/default/scss/content/_home.scss
@@ -5,9 +5,6 @@
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:
 // https://opensource.org/licenses/afl-3.0.php
-// If you did not receive a copy of the license and are unable to
-// obtain it through the world-wide-web, please send an email
-// to license@magento.com so we can send you a copy immediately.
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/content/_home.scss
+++ b/skin/frontend/rwd/default/scss/content/_home.scss
@@ -1,8 +1,6 @@
 //
 // OpenMage
 //
-// NOTICE OF LICENSE
-//
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:

--- a/skin/frontend/rwd/default/scss/core/_common.scss
+++ b/skin/frontend/rwd/default/scss/core/_common.scss
@@ -3,8 +3,7 @@
 //
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
-// It is also available through the world-wide-web at this URL:
-// https://opensource.org/licenses/afl-3.0.php
+// It is also available at https://opensource.org/license/afl-3-0-php
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/core/_common.scss
+++ b/skin/frontend/rwd/default/scss/core/_common.scss
@@ -5,9 +5,6 @@
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:
 // https://opensource.org/licenses/afl-3.0.php
-// If you did not receive a copy of the license and are unable to
-// obtain it through the world-wide-web, please send an email
-// to license@magento.com so we can send you a copy immediately.
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/core/_common.scss
+++ b/skin/frontend/rwd/default/scss/core/_common.scss
@@ -1,8 +1,6 @@
 //
 // OpenMage
 //
-// NOTICE OF LICENSE
-//
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:

--- a/skin/frontend/rwd/default/scss/core/_form.scss
+++ b/skin/frontend/rwd/default/scss/core/_form.scss
@@ -3,8 +3,7 @@
 //
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
-// It is also available through the world-wide-web at this URL:
-// https://opensource.org/licenses/afl-3.0.php
+// It is also available at https://opensource.org/license/afl-3-0-php
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/core/_form.scss
+++ b/skin/frontend/rwd/default/scss/core/_form.scss
@@ -5,9 +5,6 @@
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:
 // https://opensource.org/licenses/afl-3.0.php
-// If you did not receive a copy of the license and are unable to
-// obtain it through the world-wide-web, please send an email
-// to license@magento.com so we can send you a copy immediately.
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/core/_form.scss
+++ b/skin/frontend/rwd/default/scss/core/_form.scss
@@ -1,8 +1,6 @@
 //
 // OpenMage
 //
-// NOTICE OF LICENSE
-//
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:

--- a/skin/frontend/rwd/default/scss/core/_reset.scss
+++ b/skin/frontend/rwd/default/scss/core/_reset.scss
@@ -3,8 +3,7 @@
 //
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
-// It is also available through the world-wide-web at this URL:
-// https://opensource.org/licenses/afl-3.0.php
+// It is also available at https://opensource.org/license/afl-3-0-php
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/core/_reset.scss
+++ b/skin/frontend/rwd/default/scss/core/_reset.scss
@@ -5,9 +5,6 @@
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:
 // https://opensource.org/licenses/afl-3.0.php
-// If you did not receive a copy of the license and are unable to
-// obtain it through the world-wide-web, please send an email
-// to license@magento.com so we can send you a copy immediately.
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/core/_reset.scss
+++ b/skin/frontend/rwd/default/scss/core/_reset.scss
@@ -1,8 +1,6 @@
 //
 // OpenMage
 //
-// NOTICE OF LICENSE
-//
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:

--- a/skin/frontend/rwd/default/scss/core/_table.scss
+++ b/skin/frontend/rwd/default/scss/core/_table.scss
@@ -3,8 +3,7 @@
 //
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
-// It is also available through the world-wide-web at this URL:
-// https://opensource.org/licenses/afl-3.0.php
+// It is also available at https://opensource.org/license/afl-3-0-php
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/core/_table.scss
+++ b/skin/frontend/rwd/default/scss/core/_table.scss
@@ -5,9 +5,6 @@
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:
 // https://opensource.org/licenses/afl-3.0.php
-// If you did not receive a copy of the license and are unable to
-// obtain it through the world-wide-web, please send an email
-// to license@magento.com so we can send you a copy immediately.
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/core/_table.scss
+++ b/skin/frontend/rwd/default/scss/core/_table.scss
@@ -1,8 +1,6 @@
 //
 // OpenMage
 //
-// NOTICE OF LICENSE
-//
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:

--- a/skin/frontend/rwd/default/scss/email-inline.scss
+++ b/skin/frontend/rwd/default/scss/email-inline.scss
@@ -3,8 +3,7 @@
 //
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
-// It is also available through the world-wide-web at this URL:
-// https://opensource.org/licenses/afl-3.0.php
+// It is also available at https://opensource.org/license/afl-3-0-php
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/email-inline.scss
+++ b/skin/frontend/rwd/default/scss/email-inline.scss
@@ -5,9 +5,6 @@
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:
 // https://opensource.org/licenses/afl-3.0.php
-// If you did not receive a copy of the license and are unable to
-// obtain it through the world-wide-web, please send an email
-// to license@magento.com so we can send you a copy immediately.
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/email-inline.scss
+++ b/skin/frontend/rwd/default/scss/email-inline.scss
@@ -1,8 +1,6 @@
 //
 // OpenMage
 //
-// NOTICE OF LICENSE
-//
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:

--- a/skin/frontend/rwd/default/scss/email-non-inline.scss
+++ b/skin/frontend/rwd/default/scss/email-non-inline.scss
@@ -3,8 +3,7 @@
 //
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
-// It is also available through the world-wide-web at this URL:
-// https://opensource.org/licenses/afl-3.0.php
+// It is also available at https://opensource.org/license/afl-3-0-php
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/email-non-inline.scss
+++ b/skin/frontend/rwd/default/scss/email-non-inline.scss
@@ -5,9 +5,6 @@
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:
 // https://opensource.org/licenses/afl-3.0.php
-// If you did not receive a copy of the license and are unable to
-// obtain it through the world-wide-web, please send an email
-// to license@magento.com so we can send you a copy immediately.
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/email-non-inline.scss
+++ b/skin/frontend/rwd/default/scss/email-non-inline.scss
@@ -1,8 +1,6 @@
 //
 // OpenMage
 //
-// NOTICE OF LICENSE
-//
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:

--- a/skin/frontend/rwd/default/scss/function/_black.scss
+++ b/skin/frontend/rwd/default/scss/function/_black.scss
@@ -3,8 +3,7 @@
 //
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
-// It is also available through the world-wide-web at this URL:
-// https://opensource.org/licenses/afl-3.0.php
+// It is also available at https://opensource.org/license/afl-3-0-php
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/function/_black.scss
+++ b/skin/frontend/rwd/default/scss/function/_black.scss
@@ -5,9 +5,6 @@
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:
 // https://opensource.org/licenses/afl-3.0.php
-// If you did not receive a copy of the license and are unable to
-// obtain it through the world-wide-web, please send an email
-// to license@magento.com so we can send you a copy immediately.
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/function/_black.scss
+++ b/skin/frontend/rwd/default/scss/function/_black.scss
@@ -1,8 +1,6 @@
 //
 // OpenMage
 //
-// NOTICE OF LICENSE
-//
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:

--- a/skin/frontend/rwd/default/scss/function/_white.scss
+++ b/skin/frontend/rwd/default/scss/function/_white.scss
@@ -3,8 +3,7 @@
 //
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
-// It is also available through the world-wide-web at this URL:
-// https://opensource.org/licenses/afl-3.0.php
+// It is also available at https://opensource.org/license/afl-3-0-php
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/function/_white.scss
+++ b/skin/frontend/rwd/default/scss/function/_white.scss
@@ -5,9 +5,6 @@
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:
 // https://opensource.org/licenses/afl-3.0.php
-// If you did not receive a copy of the license and are unable to
-// obtain it through the world-wide-web, please send an email
-// to license@magento.com so we can send you a copy immediately.
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/function/_white.scss
+++ b/skin/frontend/rwd/default/scss/function/_white.scss
@@ -1,8 +1,6 @@
 //
 // OpenMage
 //
-// NOTICE OF LICENSE
-//
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:

--- a/skin/frontend/rwd/default/scss/layout/_footer.scss
+++ b/skin/frontend/rwd/default/scss/layout/_footer.scss
@@ -3,8 +3,7 @@
 //
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
-// It is also available through the world-wide-web at this URL:
-// https://opensource.org/licenses/afl-3.0.php
+// It is also available at https://opensource.org/license/afl-3-0-php
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/layout/_footer.scss
+++ b/skin/frontend/rwd/default/scss/layout/_footer.scss
@@ -5,9 +5,6 @@
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:
 // https://opensource.org/licenses/afl-3.0.php
-// If you did not receive a copy of the license and are unable to
-// obtain it through the world-wide-web, please send an email
-// to license@magento.com so we can send you a copy immediately.
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/layout/_footer.scss
+++ b/skin/frontend/rwd/default/scss/layout/_footer.scss
@@ -1,8 +1,6 @@
 //
 // OpenMage
 //
-// NOTICE OF LICENSE
-//
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:

--- a/skin/frontend/rwd/default/scss/layout/_global.scss
+++ b/skin/frontend/rwd/default/scss/layout/_global.scss
@@ -3,8 +3,7 @@
 //
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
-// It is also available through the world-wide-web at this URL:
-// https://opensource.org/licenses/afl-3.0.php
+// It is also available at https://opensource.org/license/afl-3-0-php
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/layout/_global.scss
+++ b/skin/frontend/rwd/default/scss/layout/_global.scss
@@ -5,9 +5,6 @@
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:
 // https://opensource.org/licenses/afl-3.0.php
-// If you did not receive a copy of the license and are unable to
-// obtain it through the world-wide-web, please send an email
-// to license@magento.com so we can send you a copy immediately.
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/layout/_global.scss
+++ b/skin/frontend/rwd/default/scss/layout/_global.scss
@@ -1,8 +1,6 @@
 //
 // OpenMage
 //
-// NOTICE OF LICENSE
-//
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:

--- a/skin/frontend/rwd/default/scss/layout/_header-account.scss
+++ b/skin/frontend/rwd/default/scss/layout/_header-account.scss
@@ -3,8 +3,7 @@
 //
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
-// It is also available through the world-wide-web at this URL:
-// https://opensource.org/licenses/afl-3.0.php
+// It is also available at https://opensource.org/license/afl-3-0-php
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/layout/_header-account.scss
+++ b/skin/frontend/rwd/default/scss/layout/_header-account.scss
@@ -5,9 +5,6 @@
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:
 // https://opensource.org/licenses/afl-3.0.php
-// If you did not receive a copy of the license and are unable to
-// obtain it through the world-wide-web, please send an email
-// to license@magento.com so we can send you a copy immediately.
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/layout/_header-account.scss
+++ b/skin/frontend/rwd/default/scss/layout/_header-account.scss
@@ -1,8 +1,6 @@
 //
 // OpenMage
 //
-// NOTICE OF LICENSE
-//
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:

--- a/skin/frontend/rwd/default/scss/layout/_header-cart.scss
+++ b/skin/frontend/rwd/default/scss/layout/_header-cart.scss
@@ -3,8 +3,7 @@
 //
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
-// It is also available through the world-wide-web at this URL:
-// https://opensource.org/licenses/afl-3.0.php
+// It is also available at https://opensource.org/license/afl-3-0-php
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/layout/_header-cart.scss
+++ b/skin/frontend/rwd/default/scss/layout/_header-cart.scss
@@ -5,9 +5,6 @@
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:
 // https://opensource.org/licenses/afl-3.0.php
-// If you did not receive a copy of the license and are unable to
-// obtain it through the world-wide-web, please send an email
-// to license@magento.com so we can send you a copy immediately.
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/layout/_header-cart.scss
+++ b/skin/frontend/rwd/default/scss/layout/_header-cart.scss
@@ -1,8 +1,6 @@
 //
 // OpenMage
 //
-// NOTICE OF LICENSE
-//
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:

--- a/skin/frontend/rwd/default/scss/layout/_header-nav.scss
+++ b/skin/frontend/rwd/default/scss/layout/_header-nav.scss
@@ -3,8 +3,7 @@
 //
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
-// It is also available through the world-wide-web at this URL:
-// https://opensource.org/licenses/afl-3.0.php
+// It is also available at https://opensource.org/license/afl-3-0-php
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/layout/_header-nav.scss
+++ b/skin/frontend/rwd/default/scss/layout/_header-nav.scss
@@ -5,9 +5,6 @@
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:
 // https://opensource.org/licenses/afl-3.0.php
-// If you did not receive a copy of the license and are unable to
-// obtain it through the world-wide-web, please send an email
-// to license@magento.com so we can send you a copy immediately.
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/layout/_header-nav.scss
+++ b/skin/frontend/rwd/default/scss/layout/_header-nav.scss
@@ -1,8 +1,6 @@
 //
 // OpenMage
 //
-// NOTICE OF LICENSE
-//
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:

--- a/skin/frontend/rwd/default/scss/layout/_header-search.scss
+++ b/skin/frontend/rwd/default/scss/layout/_header-search.scss
@@ -3,8 +3,7 @@
 //
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
-// It is also available through the world-wide-web at this URL:
-// https://opensource.org/licenses/afl-3.0.php
+// It is also available at https://opensource.org/license/afl-3-0-php
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/layout/_header-search.scss
+++ b/skin/frontend/rwd/default/scss/layout/_header-search.scss
@@ -5,9 +5,6 @@
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:
 // https://opensource.org/licenses/afl-3.0.php
-// If you did not receive a copy of the license and are unable to
-// obtain it through the world-wide-web, please send an email
-// to license@magento.com so we can send you a copy immediately.
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/layout/_header-search.scss
+++ b/skin/frontend/rwd/default/scss/layout/_header-search.scss
@@ -1,8 +1,6 @@
 //
 // OpenMage
 //
-// NOTICE OF LICENSE
-//
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:

--- a/skin/frontend/rwd/default/scss/layout/_header.scss
+++ b/skin/frontend/rwd/default/scss/layout/_header.scss
@@ -3,8 +3,7 @@
 //
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
-// It is also available through the world-wide-web at this URL:
-// https://opensource.org/licenses/afl-3.0.php
+// It is also available at https://opensource.org/license/afl-3-0-php
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/layout/_header.scss
+++ b/skin/frontend/rwd/default/scss/layout/_header.scss
@@ -5,9 +5,6 @@
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:
 // https://opensource.org/licenses/afl-3.0.php
-// If you did not receive a copy of the license and are unable to
-// obtain it through the world-wide-web, please send an email
-// to license@magento.com so we can send you a copy immediately.
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/layout/_header.scss
+++ b/skin/frontend/rwd/default/scss/layout/_header.scss
@@ -1,8 +1,6 @@
 //
 // OpenMage
 //
-// NOTICE OF LICENSE
-//
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:

--- a/skin/frontend/rwd/default/scss/madisonisland-ie8.scss
+++ b/skin/frontend/rwd/default/scss/madisonisland-ie8.scss
@@ -3,8 +3,7 @@
 //
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
-// It is also available through the world-wide-web at this URL:
-// https://opensource.org/licenses/afl-3.0.php
+// It is also available at https://opensource.org/license/afl-3-0-php
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/madisonisland-ie8.scss
+++ b/skin/frontend/rwd/default/scss/madisonisland-ie8.scss
@@ -5,9 +5,6 @@
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:
 // https://opensource.org/licenses/afl-3.0.php
-// If you did not receive a copy of the license and are unable to
-// obtain it through the world-wide-web, please send an email
-// to license@magento.com so we can send you a copy immediately.
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/madisonisland-ie8.scss
+++ b/skin/frontend/rwd/default/scss/madisonisland-ie8.scss
@@ -1,8 +1,6 @@
 //
 // OpenMage
 //
-// NOTICE OF LICENSE
-//
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:

--- a/skin/frontend/rwd/default/scss/madisonisland.scss
+++ b/skin/frontend/rwd/default/scss/madisonisland.scss
@@ -3,8 +3,7 @@
 //
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
-// It is also available through the world-wide-web at this URL:
-// https://opensource.org/licenses/afl-3.0.php
+// It is also available at https://opensource.org/license/afl-3-0-php
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/madisonisland.scss
+++ b/skin/frontend/rwd/default/scss/madisonisland.scss
@@ -5,9 +5,6 @@
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:
 // https://opensource.org/licenses/afl-3.0.php
-// If you did not receive a copy of the license and are unable to
-// obtain it through the world-wide-web, please send an email
-// to license@magento.com so we can send you a copy immediately.
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/madisonisland.scss
+++ b/skin/frontend/rwd/default/scss/madisonisland.scss
@@ -1,8 +1,6 @@
 //
 // OpenMage
 //
-// NOTICE OF LICENSE
-//
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:

--- a/skin/frontend/rwd/default/scss/mixin/_breakpoint.scss
+++ b/skin/frontend/rwd/default/scss/mixin/_breakpoint.scss
@@ -3,8 +3,7 @@
 //
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
-// It is also available through the world-wide-web at this URL:
-// https://opensource.org/licenses/afl-3.0.php
+// It is also available at https://opensource.org/license/afl-3-0-php
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/mixin/_breakpoint.scss
+++ b/skin/frontend/rwd/default/scss/mixin/_breakpoint.scss
@@ -5,9 +5,6 @@
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:
 // https://opensource.org/licenses/afl-3.0.php
-// If you did not receive a copy of the license and are unable to
-// obtain it through the world-wide-web, please send an email
-// to license@magento.com so we can send you a copy immediately.
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/mixin/_breakpoint.scss
+++ b/skin/frontend/rwd/default/scss/mixin/_breakpoint.scss
@@ -1,8 +1,6 @@
 //
 // OpenMage
 //
-// NOTICE OF LICENSE
-//
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:

--- a/skin/frontend/rwd/default/scss/mixin/_clearfix.scss
+++ b/skin/frontend/rwd/default/scss/mixin/_clearfix.scss
@@ -3,8 +3,7 @@
 //
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
-// It is also available through the world-wide-web at this URL:
-// https://opensource.org/licenses/afl-3.0.php
+// It is also available at https://opensource.org/license/afl-3-0-php
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/mixin/_clearfix.scss
+++ b/skin/frontend/rwd/default/scss/mixin/_clearfix.scss
@@ -5,9 +5,6 @@
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:
 // https://opensource.org/licenses/afl-3.0.php
-// If you did not receive a copy of the license and are unable to
-// obtain it through the world-wide-web, please send an email
-// to license@magento.com so we can send you a copy immediately.
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/mixin/_clearfix.scss
+++ b/skin/frontend/rwd/default/scss/mixin/_clearfix.scss
@@ -1,8 +1,6 @@
 //
 // OpenMage
 //
-// NOTICE OF LICENSE
-//
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:

--- a/skin/frontend/rwd/default/scss/mixin/_if-resolution.scss
+++ b/skin/frontend/rwd/default/scss/mixin/_if-resolution.scss
@@ -3,8 +3,7 @@
 //
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
-// It is also available through the world-wide-web at this URL:
-// https://opensource.org/licenses/afl-3.0.php
+// It is also available at https://opensource.org/license/afl-3-0-php
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/mixin/_if-resolution.scss
+++ b/skin/frontend/rwd/default/scss/mixin/_if-resolution.scss
@@ -5,9 +5,6 @@
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:
 // https://opensource.org/licenses/afl-3.0.php
-// If you did not receive a copy of the license and are unable to
-// obtain it through the world-wide-web, please send an email
-// to license@magento.com so we can send you a copy immediately.
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/mixin/_if-resolution.scss
+++ b/skin/frontend/rwd/default/scss/mixin/_if-resolution.scss
@@ -1,8 +1,6 @@
 //
 // OpenMage
 //
-// NOTICE OF LICENSE
-//
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:

--- a/skin/frontend/rwd/default/scss/mixin/_image-replacement.scss
+++ b/skin/frontend/rwd/default/scss/mixin/_image-replacement.scss
@@ -3,8 +3,7 @@
 //
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
-// It is also available through the world-wide-web at this URL:
-// https://opensource.org/licenses/afl-3.0.php
+// It is also available at https://opensource.org/license/afl-3-0-php
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/mixin/_image-replacement.scss
+++ b/skin/frontend/rwd/default/scss/mixin/_image-replacement.scss
@@ -5,9 +5,6 @@
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:
 // https://opensource.org/licenses/afl-3.0.php
-// If you did not receive a copy of the license and are unable to
-// obtain it through the world-wide-web, please send an email
-// to license@magento.com so we can send you a copy immediately.
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/mixin/_image-replacement.scss
+++ b/skin/frontend/rwd/default/scss/mixin/_image-replacement.scss
@@ -1,8 +1,6 @@
 //
 // OpenMage
 //
-// NOTICE OF LICENSE
-//
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:

--- a/skin/frontend/rwd/default/scss/mixin/_loading-overlay.scss
+++ b/skin/frontend/rwd/default/scss/mixin/_loading-overlay.scss
@@ -3,8 +3,7 @@
 //
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
-// It is also available through the world-wide-web at this URL:
-// https://opensource.org/licenses/afl-3.0.php
+// It is also available at https://opensource.org/license/afl-3-0-php
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/mixin/_loading-overlay.scss
+++ b/skin/frontend/rwd/default/scss/mixin/_loading-overlay.scss
@@ -5,9 +5,6 @@
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:
 // https://opensource.org/licenses/afl-3.0.php
-// If you did not receive a copy of the license and are unable to
-// obtain it through the world-wide-web, please send an email
-// to license@magento.com so we can send you a copy immediately.
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/mixin/_loading-overlay.scss
+++ b/skin/frontend/rwd/default/scss/mixin/_loading-overlay.scss
@@ -1,8 +1,6 @@
 //
 // OpenMage
 //
-// NOTICE OF LICENSE
-//
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:

--- a/skin/frontend/rwd/default/scss/mixin/_menu.scss
+++ b/skin/frontend/rwd/default/scss/mixin/_menu.scss
@@ -3,8 +3,7 @@
 //
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
-// It is also available through the world-wide-web at this URL:
-// https://opensource.org/licenses/afl-3.0.php
+// It is also available at https://opensource.org/license/afl-3-0-php
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/mixin/_menu.scss
+++ b/skin/frontend/rwd/default/scss/mixin/_menu.scss
@@ -5,9 +5,6 @@
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:
 // https://opensource.org/licenses/afl-3.0.php
-// If you did not receive a copy of the license and are unable to
-// obtain it through the world-wide-web, please send an email
-// to license@magento.com so we can send you a copy immediately.
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/mixin/_menu.scss
+++ b/skin/frontend/rwd/default/scss/mixin/_menu.scss
@@ -1,8 +1,6 @@
 //
 // OpenMage
 //
-// NOTICE OF LICENSE
-//
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:

--- a/skin/frontend/rwd/default/scss/mixin/_not-selectable.scss
+++ b/skin/frontend/rwd/default/scss/mixin/_not-selectable.scss
@@ -3,8 +3,7 @@
 //
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
-// It is also available through the world-wide-web at this URL:
-// https://opensource.org/licenses/afl-3.0.php
+// It is also available at https://opensource.org/license/afl-3-0-php
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/mixin/_not-selectable.scss
+++ b/skin/frontend/rwd/default/scss/mixin/_not-selectable.scss
@@ -5,9 +5,6 @@
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:
 // https://opensource.org/licenses/afl-3.0.php
-// If you did not receive a copy of the license and are unable to
-// obtain it through the world-wide-web, please send an email
-// to license@magento.com so we can send you a copy immediately.
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/mixin/_not-selectable.scss
+++ b/skin/frontend/rwd/default/scss/mixin/_not-selectable.scss
@@ -1,8 +1,6 @@
 //
 // OpenMage
 //
-// NOTICE OF LICENSE
-//
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:

--- a/skin/frontend/rwd/default/scss/mixin/_toggle-content.scss
+++ b/skin/frontend/rwd/default/scss/mixin/_toggle-content.scss
@@ -3,8 +3,7 @@
 //
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
-// It is also available through the world-wide-web at this URL:
-// https://opensource.org/licenses/afl-3.0.php
+// It is also available at https://opensource.org/license/afl-3-0-php
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/mixin/_toggle-content.scss
+++ b/skin/frontend/rwd/default/scss/mixin/_toggle-content.scss
@@ -5,9 +5,6 @@
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:
 // https://opensource.org/licenses/afl-3.0.php
-// If you did not receive a copy of the license and are unable to
-// obtain it through the world-wide-web, please send an email
-// to license@magento.com so we can send you a copy immediately.
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/mixin/_toggle-content.scss
+++ b/skin/frontend/rwd/default/scss/mixin/_toggle-content.scss
@@ -1,8 +1,6 @@
 //
 // OpenMage
 //
-// NOTICE OF LICENSE
-//
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:

--- a/skin/frontend/rwd/default/scss/mixin/_triangle.scss
+++ b/skin/frontend/rwd/default/scss/mixin/_triangle.scss
@@ -3,8 +3,7 @@
 //
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
-// It is also available through the world-wide-web at this URL:
-// https://opensource.org/licenses/afl-3.0.php
+// It is also available at https://opensource.org/license/afl-3-0-php
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/mixin/_triangle.scss
+++ b/skin/frontend/rwd/default/scss/mixin/_triangle.scss
@@ -5,9 +5,6 @@
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:
 // https://opensource.org/licenses/afl-3.0.php
-// If you did not receive a copy of the license and are unable to
-// obtain it through the world-wide-web, please send an email
-// to license@magento.com so we can send you a copy immediately.
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/mixin/_triangle.scss
+++ b/skin/frontend/rwd/default/scss/mixin/_triangle.scss
@@ -1,8 +1,6 @@
 //
 // OpenMage
 //
-// NOTICE OF LICENSE
-//
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:

--- a/skin/frontend/rwd/default/scss/mixin/_typography.scss
+++ b/skin/frontend/rwd/default/scss/mixin/_typography.scss
@@ -3,8 +3,7 @@
 //
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
-// It is also available through the world-wide-web at this URL:
-// https://opensource.org/licenses/afl-3.0.php
+// It is also available at https://opensource.org/license/afl-3-0-php
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/mixin/_typography.scss
+++ b/skin/frontend/rwd/default/scss/mixin/_typography.scss
@@ -5,9 +5,6 @@
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:
 // https://opensource.org/licenses/afl-3.0.php
-// If you did not receive a copy of the license and are unable to
-// obtain it through the world-wide-web, please send an email
-// to license@magento.com so we can send you a copy immediately.
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/mixin/_typography.scss
+++ b/skin/frontend/rwd/default/scss/mixin/_typography.scss
@@ -1,8 +1,6 @@
 //
 // OpenMage
 //
-// NOTICE OF LICENSE
-//
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:

--- a/skin/frontend/rwd/default/scss/module/_account-orders.scss
+++ b/skin/frontend/rwd/default/scss/module/_account-orders.scss
@@ -3,8 +3,7 @@
 //
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
-// It is also available through the world-wide-web at this URL:
-// https://opensource.org/licenses/afl-3.0.php
+// It is also available at https://opensource.org/license/afl-3-0-php
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/module/_account-orders.scss
+++ b/skin/frontend/rwd/default/scss/module/_account-orders.scss
@@ -5,9 +5,6 @@
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:
 // https://opensource.org/licenses/afl-3.0.php
-// If you did not receive a copy of the license and are unable to
-// obtain it through the world-wide-web, please send an email
-// to license@magento.com so we can send you a copy immediately.
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/module/_account-orders.scss
+++ b/skin/frontend/rwd/default/scss/module/_account-orders.scss
@@ -1,8 +1,6 @@
 //
 // OpenMage
 //
-// NOTICE OF LICENSE
-//
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:

--- a/skin/frontend/rwd/default/scss/module/_account-reviews.scss
+++ b/skin/frontend/rwd/default/scss/module/_account-reviews.scss
@@ -3,8 +3,7 @@
 //
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
-// It is also available through the world-wide-web at this URL:
-// https://opensource.org/licenses/afl-3.0.php
+// It is also available at https://opensource.org/license/afl-3-0-php
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/module/_account-reviews.scss
+++ b/skin/frontend/rwd/default/scss/module/_account-reviews.scss
@@ -5,9 +5,6 @@
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:
 // https://opensource.org/licenses/afl-3.0.php
-// If you did not receive a copy of the license and are unable to
-// obtain it through the world-wide-web, please send an email
-// to license@magento.com so we can send you a copy immediately.
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/module/_account-reviews.scss
+++ b/skin/frontend/rwd/default/scss/module/_account-reviews.scss
@@ -1,8 +1,6 @@
 //
 // OpenMage
 //
-// NOTICE OF LICENSE
-//
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:

--- a/skin/frontend/rwd/default/scss/module/_billing-agreements.scss
+++ b/skin/frontend/rwd/default/scss/module/_billing-agreements.scss
@@ -3,8 +3,7 @@
 //
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
-// It is also available through the world-wide-web at this URL:
-// https://opensource.org/licenses/afl-3.0.php
+// It is also available at https://opensource.org/license/afl-3-0-php
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/module/_billing-agreements.scss
+++ b/skin/frontend/rwd/default/scss/module/_billing-agreements.scss
@@ -5,9 +5,6 @@
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:
 // https://opensource.org/licenses/afl-3.0.php
-// If you did not receive a copy of the license and are unable to
-// obtain it through the world-wide-web, please send an email
-// to license@magento.com so we can send you a copy immediately.
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/module/_billing-agreements.scss
+++ b/skin/frontend/rwd/default/scss/module/_billing-agreements.scss
@@ -1,8 +1,6 @@
 //
 // OpenMage
 //
-// NOTICE OF LICENSE
-//
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:

--- a/skin/frontend/rwd/default/scss/module/_captcha.scss
+++ b/skin/frontend/rwd/default/scss/module/_captcha.scss
@@ -3,8 +3,7 @@
 //
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
-// It is also available through the world-wide-web at this URL:
-// https://opensource.org/licenses/afl-3.0.php
+// It is also available at https://opensource.org/license/afl-3-0-php
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/module/_captcha.scss
+++ b/skin/frontend/rwd/default/scss/module/_captcha.scss
@@ -5,9 +5,6 @@
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:
 // https://opensource.org/licenses/afl-3.0.php
-// If you did not receive a copy of the license and are unable to
-// obtain it through the world-wide-web, please send an email
-// to license@magento.com so we can send you a copy immediately.
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/module/_captcha.scss
+++ b/skin/frontend/rwd/default/scss/module/_captcha.scss
@@ -1,8 +1,6 @@
 //
 // OpenMage
 //
-// NOTICE OF LICENSE
-//
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:

--- a/skin/frontend/rwd/default/scss/module/_catalog-compare.scss
+++ b/skin/frontend/rwd/default/scss/module/_catalog-compare.scss
@@ -3,8 +3,7 @@
 //
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
-// It is also available through the world-wide-web at this URL:
-// https://opensource.org/licenses/afl-3.0.php
+// It is also available at https://opensource.org/license/afl-3-0-php
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/module/_catalog-compare.scss
+++ b/skin/frontend/rwd/default/scss/module/_catalog-compare.scss
@@ -5,9 +5,6 @@
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:
 // https://opensource.org/licenses/afl-3.0.php
-// If you did not receive a copy of the license and are unable to
-// obtain it through the world-wide-web, please send an email
-// to license@magento.com so we can send you a copy immediately.
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/module/_catalog-compare.scss
+++ b/skin/frontend/rwd/default/scss/module/_catalog-compare.scss
@@ -1,8 +1,6 @@
 //
 // OpenMage
 //
-// NOTICE OF LICENSE
-//
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:

--- a/skin/frontend/rwd/default/scss/module/_catalog-msrp.scss
+++ b/skin/frontend/rwd/default/scss/module/_catalog-msrp.scss
@@ -3,8 +3,7 @@
 //
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
-// It is also available through the world-wide-web at this URL:
-// https://opensource.org/licenses/afl-3.0.php
+// It is also available at https://opensource.org/license/afl-3-0-php
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/module/_catalog-msrp.scss
+++ b/skin/frontend/rwd/default/scss/module/_catalog-msrp.scss
@@ -5,9 +5,6 @@
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:
 // https://opensource.org/licenses/afl-3.0.php
-// If you did not receive a copy of the license and are unable to
-// obtain it through the world-wide-web, please send an email
-// to license@magento.com so we can send you a copy immediately.
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/module/_catalog-msrp.scss
+++ b/skin/frontend/rwd/default/scss/module/_catalog-msrp.scss
@@ -1,8 +1,6 @@
 //
 // OpenMage
 //
-// NOTICE OF LICENSE
-//
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:

--- a/skin/frontend/rwd/default/scss/module/_catalog-product.scss
+++ b/skin/frontend/rwd/default/scss/module/_catalog-product.scss
@@ -3,8 +3,7 @@
 //
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
-// It is also available through the world-wide-web at this URL:
-// https://opensource.org/licenses/afl-3.0.php
+// It is also available at https://opensource.org/license/afl-3-0-php
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/module/_catalog-product.scss
+++ b/skin/frontend/rwd/default/scss/module/_catalog-product.scss
@@ -5,9 +5,6 @@
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:
 // https://opensource.org/licenses/afl-3.0.php
-// If you did not receive a copy of the license and are unable to
-// obtain it through the world-wide-web, please send an email
-// to license@magento.com so we can send you a copy immediately.
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/module/_catalog-product.scss
+++ b/skin/frontend/rwd/default/scss/module/_catalog-product.scss
@@ -1,8 +1,6 @@
 //
 // OpenMage
 //
-// NOTICE OF LICENSE
-//
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:

--- a/skin/frontend/rwd/default/scss/module/_checkout-cart-minicart.scss
+++ b/skin/frontend/rwd/default/scss/module/_checkout-cart-minicart.scss
@@ -3,8 +3,7 @@
 //
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
-// It is also available through the world-wide-web at this URL:
-// https://opensource.org/licenses/afl-3.0.php
+// It is also available at https://opensource.org/license/afl-3-0-php
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/module/_checkout-cart-minicart.scss
+++ b/skin/frontend/rwd/default/scss/module/_checkout-cart-minicart.scss
@@ -5,9 +5,6 @@
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:
 // https://opensource.org/licenses/afl-3.0.php
-// If you did not receive a copy of the license and are unable to
-// obtain it through the world-wide-web, please send an email
-// to license@magento.com so we can send you a copy immediately.
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/module/_checkout-cart-minicart.scss
+++ b/skin/frontend/rwd/default/scss/module/_checkout-cart-minicart.scss
@@ -1,8 +1,6 @@
 //
 // OpenMage
 //
-// NOTICE OF LICENSE
-//
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:

--- a/skin/frontend/rwd/default/scss/module/_checkout-cart.scss
+++ b/skin/frontend/rwd/default/scss/module/_checkout-cart.scss
@@ -3,8 +3,7 @@
 //
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
-// It is also available through the world-wide-web at this URL:
-// https://opensource.org/licenses/afl-3.0.php
+// It is also available at https://opensource.org/license/afl-3-0-php
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/module/_checkout-cart.scss
+++ b/skin/frontend/rwd/default/scss/module/_checkout-cart.scss
@@ -5,9 +5,6 @@
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:
 // https://opensource.org/licenses/afl-3.0.php
-// If you did not receive a copy of the license and are unable to
-// obtain it through the world-wide-web, please send an email
-// to license@magento.com so we can send you a copy immediately.
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/module/_checkout-cart.scss
+++ b/skin/frontend/rwd/default/scss/module/_checkout-cart.scss
@@ -1,8 +1,6 @@
 //
 // OpenMage
 //
-// NOTICE OF LICENSE
-//
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:

--- a/skin/frontend/rwd/default/scss/module/_checkout-multi-address.scss
+++ b/skin/frontend/rwd/default/scss/module/_checkout-multi-address.scss
@@ -3,8 +3,7 @@
 //
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
-// It is also available through the world-wide-web at this URL:
-// https://opensource.org/licenses/afl-3.0.php
+// It is also available at https://opensource.org/license/afl-3-0-php
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/module/_checkout-multi-address.scss
+++ b/skin/frontend/rwd/default/scss/module/_checkout-multi-address.scss
@@ -5,9 +5,6 @@
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:
 // https://opensource.org/licenses/afl-3.0.php
-// If you did not receive a copy of the license and are unable to
-// obtain it through the world-wide-web, please send an email
-// to license@magento.com so we can send you a copy immediately.
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/module/_checkout-multi-address.scss
+++ b/skin/frontend/rwd/default/scss/module/_checkout-multi-address.scss
@@ -1,8 +1,6 @@
 //
 // OpenMage
 //
-// NOTICE OF LICENSE
-//
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:

--- a/skin/frontend/rwd/default/scss/module/_checkout-onepage.scss
+++ b/skin/frontend/rwd/default/scss/module/_checkout-onepage.scss
@@ -3,8 +3,7 @@
 //
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
-// It is also available through the world-wide-web at this URL:
-// https://opensource.org/licenses/afl-3.0.php
+// It is also available at https://opensource.org/license/afl-3-0-php
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/module/_checkout-onepage.scss
+++ b/skin/frontend/rwd/default/scss/module/_checkout-onepage.scss
@@ -5,9 +5,6 @@
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:
 // https://opensource.org/licenses/afl-3.0.php
-// If you did not receive a copy of the license and are unable to
-// obtain it through the world-wide-web, please send an email
-// to license@magento.com so we can send you a copy immediately.
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/module/_checkout-onepage.scss
+++ b/skin/frontend/rwd/default/scss/module/_checkout-onepage.scss
@@ -1,8 +1,6 @@
 //
 // OpenMage
 //
-// NOTICE OF LICENSE
-//
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:

--- a/skin/frontend/rwd/default/scss/module/_checkout-success.scss
+++ b/skin/frontend/rwd/default/scss/module/_checkout-success.scss
@@ -3,8 +3,7 @@
 //
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
-// It is also available through the world-wide-web at this URL:
-// https://opensource.org/licenses/afl-3.0.php
+// It is also available at https://opensource.org/license/afl-3-0-php
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/module/_checkout-success.scss
+++ b/skin/frontend/rwd/default/scss/module/_checkout-success.scss
@@ -5,9 +5,6 @@
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:
 // https://opensource.org/licenses/afl-3.0.php
-// If you did not receive a copy of the license and are unable to
-// obtain it through the world-wide-web, please send an email
-// to license@magento.com so we can send you a copy immediately.
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/module/_checkout-success.scss
+++ b/skin/frontend/rwd/default/scss/module/_checkout-success.scss
@@ -1,8 +1,6 @@
 //
 // OpenMage
 //
-// NOTICE OF LICENSE
-//
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:

--- a/skin/frontend/rwd/default/scss/module/_cms.scss
+++ b/skin/frontend/rwd/default/scss/module/_cms.scss
@@ -3,8 +3,7 @@
 //
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
-// It is also available through the world-wide-web at this URL:
-// https://opensource.org/licenses/afl-3.0.php
+// It is also available at https://opensource.org/license/afl-3-0-php
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/module/_cms.scss
+++ b/skin/frontend/rwd/default/scss/module/_cms.scss
@@ -5,9 +5,6 @@
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:
 // https://opensource.org/licenses/afl-3.0.php
-// If you did not receive a copy of the license and are unable to
-// obtain it through the world-wide-web, please send an email
-// to license@magento.com so we can send you a copy immediately.
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/module/_cms.scss
+++ b/skin/frontend/rwd/default/scss/module/_cms.scss
@@ -1,8 +1,6 @@
 //
 // OpenMage
 //
-// NOTICE OF LICENSE
-//
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:

--- a/skin/frontend/rwd/default/scss/module/_configurableswatches.scss
+++ b/skin/frontend/rwd/default/scss/module/_configurableswatches.scss
@@ -3,8 +3,7 @@
 //
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
-// It is also available through the world-wide-web at this URL:
-// https://opensource.org/licenses/afl-3.0.php
+// It is also available at https://opensource.org/license/afl-3-0-php
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/module/_configurableswatches.scss
+++ b/skin/frontend/rwd/default/scss/module/_configurableswatches.scss
@@ -5,9 +5,6 @@
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:
 // https://opensource.org/licenses/afl-3.0.php
-// If you did not receive a copy of the license and are unable to
-// obtain it through the world-wide-web, please send an email
-// to license@magento.com so we can send you a copy immediately.
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/module/_configurableswatches.scss
+++ b/skin/frontend/rwd/default/scss/module/_configurableswatches.scss
@@ -1,8 +1,6 @@
 //
 // OpenMage
 //
-// NOTICE OF LICENSE
-//
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:

--- a/skin/frontend/rwd/default/scss/module/_contacts.scss
+++ b/skin/frontend/rwd/default/scss/module/_contacts.scss
@@ -3,8 +3,7 @@
 //
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
-// It is also available through the world-wide-web at this URL:
-// https://opensource.org/licenses/afl-3.0.php
+// It is also available at https://opensource.org/license/afl-3-0-php
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/module/_contacts.scss
+++ b/skin/frontend/rwd/default/scss/module/_contacts.scss
@@ -5,9 +5,6 @@
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:
 // https://opensource.org/licenses/afl-3.0.php
-// If you did not receive a copy of the license and are unable to
-// obtain it through the world-wide-web, please send an email
-// to license@magento.com so we can send you a copy immediately.
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/module/_contacts.scss
+++ b/skin/frontend/rwd/default/scss/module/_contacts.scss
@@ -1,8 +1,6 @@
 //
 // OpenMage
 //
-// NOTICE OF LICENSE
-//
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:

--- a/skin/frontend/rwd/default/scss/module/_cookies.scss
+++ b/skin/frontend/rwd/default/scss/module/_cookies.scss
@@ -3,8 +3,7 @@
 //
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
-// It is also available through the world-wide-web at this URL:
-// https://opensource.org/licenses/afl-3.0.php
+// It is also available at https://opensource.org/license/afl-3-0-php
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/module/_cookies.scss
+++ b/skin/frontend/rwd/default/scss/module/_cookies.scss
@@ -5,9 +5,6 @@
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:
 // https://opensource.org/licenses/afl-3.0.php
-// If you did not receive a copy of the license and are unable to
-// obtain it through the world-wide-web, please send an email
-// to license@magento.com so we can send you a copy immediately.
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/module/_cookies.scss
+++ b/skin/frontend/rwd/default/scss/module/_cookies.scss
@@ -1,8 +1,6 @@
 //
 // OpenMage
 //
-// NOTICE OF LICENSE
-//
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:

--- a/skin/frontend/rwd/default/scss/module/_customer.scss
+++ b/skin/frontend/rwd/default/scss/module/_customer.scss
@@ -3,8 +3,7 @@
 //
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
-// It is also available through the world-wide-web at this URL:
-// https://opensource.org/licenses/afl-3.0.php
+// It is also available at https://opensource.org/license/afl-3-0-php
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/module/_customer.scss
+++ b/skin/frontend/rwd/default/scss/module/_customer.scss
@@ -5,9 +5,6 @@
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:
 // https://opensource.org/licenses/afl-3.0.php
-// If you did not receive a copy of the license and are unable to
-// obtain it through the world-wide-web, please send an email
-// to license@magento.com so we can send you a copy immediately.
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/module/_customer.scss
+++ b/skin/frontend/rwd/default/scss/module/_customer.scss
@@ -1,8 +1,6 @@
 //
 // OpenMage
 //
-// NOTICE OF LICENSE
-//
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:

--- a/skin/frontend/rwd/default/scss/module/_paypal.scss
+++ b/skin/frontend/rwd/default/scss/module/_paypal.scss
@@ -3,8 +3,7 @@
 //
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
-// It is also available through the world-wide-web at this URL:
-// https://opensource.org/licenses/afl-3.0.php
+// It is also available at https://opensource.org/license/afl-3-0-php
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/module/_paypal.scss
+++ b/skin/frontend/rwd/default/scss/module/_paypal.scss
@@ -5,9 +5,6 @@
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:
 // https://opensource.org/licenses/afl-3.0.php
-// If you did not receive a copy of the license and are unable to
-// obtain it through the world-wide-web, please send an email
-// to license@magento.com so we can send you a copy immediately.
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/module/_paypal.scss
+++ b/skin/frontend/rwd/default/scss/module/_paypal.scss
@@ -1,8 +1,6 @@
 //
 // OpenMage
 //
-// NOTICE OF LICENSE
-//
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:

--- a/skin/frontend/rwd/default/scss/module/_popular-terms.scss
+++ b/skin/frontend/rwd/default/scss/module/_popular-terms.scss
@@ -3,8 +3,7 @@
 //
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
-// It is also available through the world-wide-web at this URL:
-// https://opensource.org/licenses/afl-3.0.php
+// It is also available at https://opensource.org/license/afl-3-0-php
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/module/_popular-terms.scss
+++ b/skin/frontend/rwd/default/scss/module/_popular-terms.scss
@@ -5,9 +5,6 @@
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:
 // https://opensource.org/licenses/afl-3.0.php
-// If you did not receive a copy of the license and are unable to
-// obtain it through the world-wide-web, please send an email
-// to license@magento.com so we can send you a copy immediately.
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/module/_popular-terms.scss
+++ b/skin/frontend/rwd/default/scss/module/_popular-terms.scss
@@ -1,8 +1,6 @@
 //
 // OpenMage
 //
-// NOTICE OF LICENSE
-//
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:

--- a/skin/frontend/rwd/default/scss/module/_pricing_conditions.scss
+++ b/skin/frontend/rwd/default/scss/module/_pricing_conditions.scss
@@ -3,8 +3,7 @@
 //
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
-// It is also available through the world-wide-web at this URL:
-// https://opensource.org/licenses/afl-3.0.php
+// It is also available at https://opensource.org/license/afl-3-0-php
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/module/_pricing_conditions.scss
+++ b/skin/frontend/rwd/default/scss/module/_pricing_conditions.scss
@@ -5,9 +5,6 @@
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:
 // https://opensource.org/licenses/afl-3.0.php
-// If you did not receive a copy of the license and are unable to
-// obtain it through the world-wide-web, please send an email
-// to license@magento.com so we can send you a copy immediately.
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/module/_pricing_conditions.scss
+++ b/skin/frontend/rwd/default/scss/module/_pricing_conditions.scss
@@ -1,8 +1,6 @@
 //
 // OpenMage
 //
-// NOTICE OF LICENSE
-//
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:

--- a/skin/frontend/rwd/default/scss/module/_product-list.scss
+++ b/skin/frontend/rwd/default/scss/module/_product-list.scss
@@ -3,8 +3,7 @@
 //
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
-// It is also available through the world-wide-web at this URL:
-// https://opensource.org/licenses/afl-3.0.php
+// It is also available at https://opensource.org/license/afl-3-0-php
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/module/_product-list.scss
+++ b/skin/frontend/rwd/default/scss/module/_product-list.scss
@@ -5,9 +5,6 @@
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:
 // https://opensource.org/licenses/afl-3.0.php
-// If you did not receive a copy of the license and are unable to
-// obtain it through the world-wide-web, please send an email
-// to license@magento.com so we can send you a copy immediately.
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/module/_product-list.scss
+++ b/skin/frontend/rwd/default/scss/module/_product-list.scss
@@ -1,8 +1,6 @@
 //
 // OpenMage
 //
-// NOTICE OF LICENSE
-//
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:

--- a/skin/frontend/rwd/default/scss/module/_recurring-profiles.scss
+++ b/skin/frontend/rwd/default/scss/module/_recurring-profiles.scss
@@ -3,8 +3,7 @@
 //
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
-// It is also available through the world-wide-web at this URL:
-// https://opensource.org/licenses/afl-3.0.php
+// It is also available at https://opensource.org/license/afl-3-0-php
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/module/_recurring-profiles.scss
+++ b/skin/frontend/rwd/default/scss/module/_recurring-profiles.scss
@@ -5,9 +5,6 @@
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:
 // https://opensource.org/licenses/afl-3.0.php
-// If you did not receive a copy of the license and are unable to
-// obtain it through the world-wide-web, please send an email
-// to license@magento.com so we can send you a copy immediately.
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/module/_recurring-profiles.scss
+++ b/skin/frontend/rwd/default/scss/module/_recurring-profiles.scss
@@ -1,8 +1,6 @@
 //
 // OpenMage
 //
-// NOTICE OF LICENSE
-//
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:

--- a/skin/frontend/rwd/default/scss/module/_review.scss
+++ b/skin/frontend/rwd/default/scss/module/_review.scss
@@ -3,8 +3,7 @@
 //
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
-// It is also available through the world-wide-web at this URL:
-// https://opensource.org/licenses/afl-3.0.php
+// It is also available at https://opensource.org/license/afl-3-0-php
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/module/_review.scss
+++ b/skin/frontend/rwd/default/scss/module/_review.scss
@@ -5,9 +5,6 @@
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:
 // https://opensource.org/licenses/afl-3.0.php
-// If you did not receive a copy of the license and are unable to
-// obtain it through the world-wide-web, please send an email
-// to license@magento.com so we can send you a copy immediately.
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/module/_review.scss
+++ b/skin/frontend/rwd/default/scss/module/_review.scss
@@ -1,8 +1,6 @@
 //
 // OpenMage
 //
-// NOTICE OF LICENSE
-//
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:

--- a/skin/frontend/rwd/default/scss/module/_search.scss
+++ b/skin/frontend/rwd/default/scss/module/_search.scss
@@ -3,8 +3,7 @@
 //
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
-// It is also available through the world-wide-web at this URL:
-// https://opensource.org/licenses/afl-3.0.php
+// It is also available at https://opensource.org/license/afl-3-0-php
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/module/_search.scss
+++ b/skin/frontend/rwd/default/scss/module/_search.scss
@@ -5,9 +5,6 @@
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:
 // https://opensource.org/licenses/afl-3.0.php
-// If you did not receive a copy of the license and are unable to
-// obtain it through the world-wide-web, please send an email
-// to license@magento.com so we can send you a copy immediately.
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/module/_search.scss
+++ b/skin/frontend/rwd/default/scss/module/_search.scss
@@ -1,8 +1,6 @@
 //
 // OpenMage
 //
-// NOTICE OF LICENSE
-//
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:

--- a/skin/frontend/rwd/default/scss/module/_slideshow.scss
+++ b/skin/frontend/rwd/default/scss/module/_slideshow.scss
@@ -3,8 +3,7 @@
 //
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
-// It is also available through the world-wide-web at this URL:
-// https://opensource.org/licenses/afl-3.0.php
+// It is also available at https://opensource.org/license/afl-3-0-php
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/module/_slideshow.scss
+++ b/skin/frontend/rwd/default/scss/module/_slideshow.scss
@@ -5,9 +5,6 @@
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:
 // https://opensource.org/licenses/afl-3.0.php
-// If you did not receive a copy of the license and are unable to
-// obtain it through the world-wide-web, please send an email
-// to license@magento.com so we can send you a copy immediately.
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/module/_slideshow.scss
+++ b/skin/frontend/rwd/default/scss/module/_slideshow.scss
@@ -1,8 +1,6 @@
 //
 // OpenMage
 //
-// NOTICE OF LICENSE
-//
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:

--- a/skin/frontend/rwd/default/scss/module/_tags.scss
+++ b/skin/frontend/rwd/default/scss/module/_tags.scss
@@ -3,8 +3,7 @@
 //
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
-// It is also available through the world-wide-web at this URL:
-// https://opensource.org/licenses/afl-3.0.php
+// It is also available at https://opensource.org/license/afl-3-0-php
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/module/_tags.scss
+++ b/skin/frontend/rwd/default/scss/module/_tags.scss
@@ -5,9 +5,6 @@
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:
 // https://opensource.org/licenses/afl-3.0.php
-// If you did not receive a copy of the license and are unable to
-// obtain it through the world-wide-web, please send an email
-// to license@magento.com so we can send you a copy immediately.
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/module/_tags.scss
+++ b/skin/frontend/rwd/default/scss/module/_tags.scss
@@ -1,8 +1,6 @@
 //
 // OpenMage
 //
-// NOTICE OF LICENSE
-//
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:

--- a/skin/frontend/rwd/default/scss/module/_widget.scss
+++ b/skin/frontend/rwd/default/scss/module/_widget.scss
@@ -3,8 +3,7 @@
 //
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
-// It is also available through the world-wide-web at this URL:
-// https://opensource.org/licenses/afl-3.0.php
+// It is also available at https://opensource.org/license/afl-3-0-php
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/module/_widget.scss
+++ b/skin/frontend/rwd/default/scss/module/_widget.scss
@@ -5,9 +5,6 @@
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:
 // https://opensource.org/licenses/afl-3.0.php
-// If you did not receive a copy of the license and are unable to
-// obtain it through the world-wide-web, please send an email
-// to license@magento.com so we can send you a copy immediately.
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/module/_widget.scss
+++ b/skin/frontend/rwd/default/scss/module/_widget.scss
@@ -1,8 +1,6 @@
 //
 // OpenMage
 //
-// NOTICE OF LICENSE
-//
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:

--- a/skin/frontend/rwd/default/scss/module/_wishlist.scss
+++ b/skin/frontend/rwd/default/scss/module/_wishlist.scss
@@ -3,8 +3,7 @@
 //
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
-// It is also available through the world-wide-web at this URL:
-// https://opensource.org/licenses/afl-3.0.php
+// It is also available at https://opensource.org/license/afl-3-0-php
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/module/_wishlist.scss
+++ b/skin/frontend/rwd/default/scss/module/_wishlist.scss
@@ -5,9 +5,6 @@
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:
 // https://opensource.org/licenses/afl-3.0.php
-// If you did not receive a copy of the license and are unable to
-// obtain it through the world-wide-web, please send an email
-// to license@magento.com so we can send you a copy immediately.
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/module/_wishlist.scss
+++ b/skin/frontend/rwd/default/scss/module/_wishlist.scss
@@ -1,8 +1,6 @@
 //
 // OpenMage
 //
-// NOTICE OF LICENSE
-//
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:

--- a/skin/frontend/rwd/default/scss/override/_plugin.scss
+++ b/skin/frontend/rwd/default/scss/override/_plugin.scss
@@ -3,8 +3,7 @@
 //
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
-// It is also available through the world-wide-web at this URL:
-// https://opensource.org/licenses/afl-3.0.php
+// It is also available at https://opensource.org/license/afl-3-0-php
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/override/_plugin.scss
+++ b/skin/frontend/rwd/default/scss/override/_plugin.scss
@@ -5,9 +5,6 @@
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:
 // https://opensource.org/licenses/afl-3.0.php
-// If you did not receive a copy of the license and are unable to
-// obtain it through the world-wide-web, please send an email
-// to license@magento.com so we can send you a copy immediately.
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/override/_plugin.scss
+++ b/skin/frontend/rwd/default/scss/override/_plugin.scss
@@ -1,8 +1,6 @@
 //
 // OpenMage
 //
-// NOTICE OF LICENSE
-//
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:

--- a/skin/frontend/rwd/default/scss/scaffold-forms.scss
+++ b/skin/frontend/rwd/default/scss/scaffold-forms.scss
@@ -3,8 +3,7 @@
 //
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
-// It is also available through the world-wide-web at this URL:
-// https://opensource.org/licenses/afl-3.0.php
+// It is also available at https://opensource.org/license/afl-3-0-php
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/scaffold-forms.scss
+++ b/skin/frontend/rwd/default/scss/scaffold-forms.scss
@@ -5,9 +5,6 @@
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:
 // https://opensource.org/licenses/afl-3.0.php
-// If you did not receive a copy of the license and are unable to
-// obtain it through the world-wide-web, please send an email
-// to license@magento.com so we can send you a copy immediately.
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/scaffold-forms.scss
+++ b/skin/frontend/rwd/default/scss/scaffold-forms.scss
@@ -1,8 +1,6 @@
 //
 // OpenMage
 //
-// NOTICE OF LICENSE
-//
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:

--- a/skin/frontend/rwd/default/scss/styles-ie8.scss
+++ b/skin/frontend/rwd/default/scss/styles-ie8.scss
@@ -3,8 +3,7 @@
 //
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
-// It is also available through the world-wide-web at this URL:
-// https://opensource.org/licenses/afl-3.0.php
+// It is also available at https://opensource.org/license/afl-3-0-php
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/styles-ie8.scss
+++ b/skin/frontend/rwd/default/scss/styles-ie8.scss
@@ -5,9 +5,6 @@
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:
 // https://opensource.org/licenses/afl-3.0.php
-// If you did not receive a copy of the license and are unable to
-// obtain it through the world-wide-web, please send an email
-// to license@magento.com so we can send you a copy immediately.
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/styles-ie8.scss
+++ b/skin/frontend/rwd/default/scss/styles-ie8.scss
@@ -1,8 +1,6 @@
 //
 // OpenMage
 //
-// NOTICE OF LICENSE
-//
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:

--- a/skin/frontend/rwd/default/scss/styles.scss
+++ b/skin/frontend/rwd/default/scss/styles.scss
@@ -3,8 +3,7 @@
 //
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
-// It is also available through the world-wide-web at this URL:
-// https://opensource.org/licenses/afl-3.0.php
+// It is also available at https://opensource.org/license/afl-3-0-php
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/styles.scss
+++ b/skin/frontend/rwd/default/scss/styles.scss
@@ -5,9 +5,6 @@
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:
 // https://opensource.org/licenses/afl-3.0.php
-// If you did not receive a copy of the license and are unable to
-// obtain it through the world-wide-web, please send an email
-// to license@magento.com so we can send you a copy immediately.
 //
 // @category    design
 // @package     rwd_default

--- a/skin/frontend/rwd/default/scss/styles.scss
+++ b/skin/frontend/rwd/default/scss/styles.scss
@@ -1,8 +1,6 @@
 //
 // OpenMage
 //
-// NOTICE OF LICENSE
-//
 // This source file is subject to the Academic Free License (AFL 3.0)
 // that is bundled with this package in the file LICENSE_AFL.txt.
 // It is also available through the world-wide-web at this URL:

--- a/skin/install/default/default/css/boxes.css
+++ b/skin/install/default/default/css/boxes.css
@@ -3,8 +3,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/skin/install/default/default/css/boxes.css
+++ b/skin/install/default/default/css/boxes.css
@@ -1,8 +1,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/skin/install/default/default/css/boxes.css
+++ b/skin/install/default/default/css/boxes.css
@@ -5,9 +5,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/skin/install/default/default/css/clears.css
+++ b/skin/install/default/default/css/clears.css
@@ -3,8 +3,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/skin/install/default/default/css/clears.css
+++ b/skin/install/default/default/css/clears.css
@@ -1,8 +1,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/skin/install/default/default/css/clears.css
+++ b/skin/install/default/default/css/clears.css
@@ -5,9 +5,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/skin/install/default/default/css/ie7minus.css
+++ b/skin/install/default/default/css/ie7minus.css
@@ -3,8 +3,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/skin/install/default/default/css/ie7minus.css
+++ b/skin/install/default/default/css/ie7minus.css
@@ -1,8 +1,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/skin/install/default/default/css/ie7minus.css
+++ b/skin/install/default/default/css/ie7minus.css
@@ -5,9 +5,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/skin/install/default/default/css/iestyles.css
+++ b/skin/install/default/default/css/iestyles.css
@@ -3,8 +3,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/skin/install/default/default/css/iestyles.css
+++ b/skin/install/default/default/css/iestyles.css
@@ -1,8 +1,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/skin/install/default/default/css/iestyles.css
+++ b/skin/install/default/default/css/iestyles.css
@@ -5,9 +5,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default

--- a/skin/install/default/default/css/reset.css
+++ b/skin/install/default/default/css/reset.css
@@ -3,8 +3,7 @@
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
+ * It is also available at https://opensource.org/license/afl-3-0-php
  *
  * @category    design
  * @package     default_default

--- a/skin/install/default/default/css/reset.css
+++ b/skin/install/default/default/css/reset.css
@@ -1,8 +1,6 @@
 /**
  * OpenMage
  *
- * NOTICE OF LICENSE
- *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:

--- a/skin/install/default/default/css/reset.css
+++ b/skin/install/default/default/css/reset.css
@@ -5,9 +5,6 @@
  * that is bundled with this package in the file LICENSE_AFL.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@magento.com so we can send you a copy immediately.
  *
  * @category    design
  * @package     default_default


### PR DESCRIPTION
All files start with this code:

```
/**
 * OpenMage
 * 
 * NOTICE OF LICENSE
 *
 * This source file is subject to the Open Software License (OSL 3.0)
 * that is bundled with this package in the file LICENSE.txt.
 * It is also available through the world-wide-web at this URL:
 * https://opensource.org/licenses/osl-3.0.php
 * If you did not receive a copy of the license and are unable to
 * obtain it through the world-wide-web, please send an email
 * to license@magento.com so we can send you a copy immediately.
```

but I think that `* NOTICE OF LICENSE` is redundant and could be removed, sparing a lot of bytes.

I checked a few famous php projects on github and never found anything similar.

**EDIT:** after a comment from @kiatng I thought we could reduce that block even more (and spare some disk space) to
```
 * OpenMage
 *
 * This source file is subject to the Open Software License (OSL 3.0)
 * that is bundled with this package in the file LICENSE.txt.
 * It is also available at https://opensource.org/license/osl-3-0-php
```